### PR TITLE
[PERF] #5 Reduce statusline refresh cost and duplicate scans

### DIFF
--- a/docs/marmonitor-performance-plan.txt
+++ b/docs/marmonitor-performance-plan.txt
@@ -25,9 +25,9 @@ marmonitor 성능 개선 실행 계획
 재현 가능한 benchmark 기준
 - ad-hoc 로그만으로는 `40-file` 수치의 의미를 방어하기 어렵다.
 - 현재 권위 있는 benchmark entrypoint는 두 개다.
-  - [scripts/bench-codex-index.mjs](/Users/jaewankim/Desktop/jaewan-develop/marmonitor/scripts/bench-codex-index.mjs)
-  - [scripts/bench-statusline-live.mjs](/Users/jaewankim/Desktop/jaewan-develop/marmonitor/scripts/bench-statusline-live.mjs)
-- 방법론과 해석 기준은 [docs/performance-benchmarking.md](/Users/jaewankim/Desktop/jaewan-develop/marmonitor/docs/performance-benchmarking.md)에 정리한다.
+  - [`scripts/bench-codex-index.mjs`](../scripts/bench-codex-index.mjs)
+  - [`scripts/bench-statusline-live.mjs`](../scripts/bench-statusline-live.mjs)
+- 방법론과 해석 기준은 [`docs/performance-benchmarking.md`](./performance-benchmarking.md)에 정리한다.
 - 2026-03-31 예시 측정
   - synthetic `heavy / cold_empty_caches`: full avg `20.9ms`, light avg `4.6ms`
   - synthetic `compact / cold_empty_caches`: full avg `5.6ms`, light avg `3.4ms`

--- a/docs/marmonitor-performance-plan.txt
+++ b/docs/marmonitor-performance-plan.txt
@@ -144,3 +144,5 @@ marmonitor 성능 개선 실행 계획
 - 2026-03-31: shared cache뿐 아니라 snapshot/statusline cache 파일 쓰기도 temp file + rename으로 바꿔 경쟁 상황에서 partial write가 의미 오류가 아니라 cache miss 폴백으로만 이어지게 정리했다.
 - 2026-03-31: `tests/runtime-cache.test.mjs`에 process start-time shared cache hit / negative hit / identity partition 회귀 테스트를 추가했고, `tests/snapshot-cache.test.mjs`에 atomic cache write 테스트를 추가했다.
 - 2026-03-31: `npm run build`, `npm run lint`, `npm test` 재통과. 총 189개 테스트 통과.
+- 2026-03-31: 최신 head에서 실제 tmux 기준으로 다시 재실측했다. `statusline-only` shared runtime snapshot 제한 이후에도 cold `1.47s`, warm `0.05s`, forced snapshot miss `1.35s`, `1.16s`를 확인했다.
+- 2026-03-31: 같은 forced miss 구간에서 `pidusage`는 `933.5ms`, `769.1ms`, `ps-list`는 `166.6ms`, `194.3ms` 수준이었다. `lsof`, `ps_lstart`, tmux resolve/capture는 더 이상 상위 단계로 보이지 않았다.

--- a/docs/marmonitor-performance-plan.txt
+++ b/docs/marmonitor-performance-plan.txt
@@ -90,10 +90,12 @@ marmonitor 성능 개선 실행 계획
 - Codex / Gemini / dead Claude 세션 스캔은 `existsSync` 선확인 대신 실제 `readdir` / `readFile` 실패를 분기로 사용해 중복 syscall을 줄인다.
 - stdout heuristic는 cross-process shared cache를 사용해 같은 PID/cwd에 대한 tmux pane lookup과 capture를 새 CLI 실행 간 재사용한다.
 - process cwd 조회는 cross-process shared cache를 사용해 같은 PID에 대한 `lsof` 결과를 새 CLI 실행 간 재사용한다.
+- process start time 조회도 cross-process shared cache를 사용해 같은 PID에 대한 `ps -o lstart=` 결과를 새 CLI 실행 간 재사용한다.
 - Claude session resolution은 `sessionId + cwd + startedAt` 기준 cross-process shared cache를 사용해 session file path를 새 CLI 실행 간 재사용한다.
 - Claude phase detect는 `sessionFile + mtime + size` 기준 cross-process shared cache를 사용해 JSONL tail parse를 새 CLI 실행 간 재사용한다.
 - Codex phase detect도 `sessionFile + mtime + size` 기준 cross-process shared cache를 사용해 phase parse를 새 CLI 실행 간 재사용한다.
 - `ps-list`와 `pidusage`도 1초짜리 cross-process shared cache를 사용해 같은 PID 집합에 대한 process scan/metrics 조회를 새 CLI 실행 간 재사용한다.
+- shared cache 파일 쓰기는 temp file + rename으로 바꿔 partial write가 cache miss로만 폴백되도록 정리한다.
 - 완료 기준
   - Codex / Claude가 전체 스캔 비용의 대부분을 차지하지 않게 된다.
 
@@ -137,3 +139,7 @@ marmonitor 성능 개선 실행 계획
 - 2026-03-31: `tests/runtime-cache.test.mjs`에 process list shared cache, pidusage shared cache 회귀 테스트를 추가했다.
 - 2026-03-31: `npm run build`, `npm run lint`, `npm test` 재통과. 총 185개 테스트 통과.
 - 2026-03-31: 실제 tmux 기준 재실측에서 forced snapshot miss wall time은 `1.25s`, `1.50s`였고, 같은 구간의 `pidusage`는 `677ms`, `806ms`, `ps-list`는 `114ms`, `218ms` 수준이었다.
+- 2026-03-31: `getProcessStartTime`에도 cross-process shared cache를 추가해 같은 PID의 `ps -o lstart=` 재호출을 새 CLI 실행 간 줄였다.
+- 2026-03-31: shared cache 파일 쓰기를 temp file + rename으로 바꿔 경쟁 상황에서 partial write가 의미 오류가 아니라 cache miss 폴백으로만 이어지게 정리했다.
+- 2026-03-31: `tests/runtime-cache.test.mjs`에 process start-time shared cache hit / negative cache hit 회귀 테스트를 추가했다.
+- 2026-03-31: `npm run build`, `npm run lint`, `npm test` 재통과. 총 187개 테스트 통과.

--- a/docs/marmonitor-performance-plan.txt
+++ b/docs/marmonitor-performance-plan.txt
@@ -22,6 +22,19 @@ marmonitor 성능 개선 실행 계획
 - attention / jump / status 정확도는 유지해야 한다.
 - 개선이 "운 좋게 cache hit"가 아니라 "실제 계산량 감소"로 설명되어야 한다.
 
+재현 가능한 benchmark 기준
+- ad-hoc 로그만으로는 `40-file` 수치의 의미를 방어하기 어렵다.
+- 현재 권위 있는 benchmark entrypoint는 두 개다.
+  - [scripts/bench-codex-index.mjs](/Users/jaewankim/Desktop/jaewan-develop/marmonitor/scripts/bench-codex-index.mjs)
+  - [scripts/bench-statusline-live.mjs](/Users/jaewankim/Desktop/jaewan-develop/marmonitor/scripts/bench-statusline-live.mjs)
+- 방법론과 해석 기준은 [docs/performance-benchmarking.md](/Users/jaewankim/Desktop/jaewan-develop/marmonitor/docs/performance-benchmarking.md)에 정리한다.
+- 2026-03-31 예시 측정
+  - synthetic `heavy / cold_empty_caches`: full avg `20.9ms`, light avg `4.6ms`
+  - synthetic `compact / cold_empty_caches`: full avg `5.6ms`, light avg `3.4ms`
+  - live statusline: cold `1413.3ms`, warm `66.1ms`, forced-miss `550.1ms`, `118.4ms`
+  - 측정 host: `Apple M3 Max`, `14` logical CPU, `36GB RAM`
+  - live tmux 환경: `3` sessions, `7` panes, `37` agents
+
 진행 상태
 - [완료] 1. 계측 추가
 - [완료] 2. statusline 경로 분리
@@ -112,12 +125,12 @@ marmonitor 성능 개선 실행 계획
 - 2026-03-31: 현재 샌드박스에서는 `ps` spawn EPERM 때문에 실시간 `statusline` 실행 검증이 불안정하다.
 - 2026-03-31: `statusline` phase 판정을 유지한 채 light snapshot + snapshot lock으로 refresh를 직렬화했다.
 - 2026-03-31: snapshot lock이 실패할 때는 무한 대기 대신 안전하게 폴백하도록 정리했다.
-- 2026-03-31: Codex light 인덱스는 session_meta만 읽도록 바꾸고, synthetic 40-file benchmark에서 full 1147.4ms / light 126.6ms를 확인했다.
+- 2026-03-31: Codex light 인덱스는 session_meta만 읽도록 바꾸고, 초기 ad-hoc synthetic 40-file benchmark에서 full 1147.4ms / light 126.6ms를 확인했다. 이 수치는 이후 `scripts/bench-codex-index.mjs` 기반 재현 가능한 benchmark로 대체했다.
 - 2026-03-31: Codex light/full index cache를 분리하고, file cache도 light 결과가 full 결과를 덮지 않도록 정리했다.
 - 2026-03-31: `scanAgents`는 Codex 프로세스가 있을 때만 Codex 인덱스를 만들고, cwd가 단일 매칭이면 `ps` 시작 시각 조회를 건너뛰도록 바꿨다.
 - 2026-03-31: `debug-phase`의 Codex 경로도 light 인덱스를 사용하도록 조정했다.
 - 2026-03-31: `npm run build`, `npm run lint`, `npm test` 재통과. 총 166개 테스트 통과.
-- 2026-03-31: 임시 `HOME`/`CODEX_SESSIONS`로 격리한 synthetic 40-file benchmark에서 full avg 22.2ms / light avg 15.6ms를 확인했다. 이 측정은 default Codex 경로를 제외한 isolated run이다.
+- 2026-03-31: 임시 `HOME`/`CODEX_SESSIONS`로 격리한 synthetic 40-file benchmark에서 full avg 22.2ms / light avg 15.6ms를 확인했다. 이 값도 탐색용 ad-hoc 측정이며, 현재는 `scripts/bench-codex-index.mjs` 결과를 권위 있는 기준으로 사용한다.
 - 2026-03-31: `resolveTmuxJumpTarget`는 in-flight tmux runtime snapshot을 공유하도록 바꿨다. 같은 시점의 `tmux list-panes` / `ps -eo pid=,ppid=`는 한 번만 수행한다.
 - 2026-03-31: tmux snapshot single-flight는 `tests/tmux.test.mjs`에 회귀 테스트를 추가해 고정했다.
 - 2026-03-31: `scanAgents`와 `debug-phase`는 runtime path를 1회만 계산하고 Claude / Codex session helper에 재사용하도록 바꿨다.
@@ -146,3 +159,6 @@ marmonitor 성능 개선 실행 계획
 - 2026-03-31: `npm run build`, `npm run lint`, `npm test` 재통과. 총 189개 테스트 통과.
 - 2026-03-31: 최신 head에서 실제 tmux 기준으로 다시 재실측했다. `statusline-only` shared runtime snapshot 제한 이후에도 cold `1.47s`, warm `0.05s`, forced snapshot miss `1.35s`, `1.16s`를 확인했다.
 - 2026-03-31: 같은 forced miss 구간에서 `pidusage`는 `933.5ms`, `769.1ms`, `ps-list`는 `166.6ms`, `194.3ms` 수준이었다. `lsof`, `ps_lstart`, tmux resolve/capture는 더 이상 상위 단계로 보이지 않았다.
+- 2026-03-31: `scripts/bench-codex-index.mjs`와 `scripts/bench-statusline-live.mjs`를 추가해 benchmark를 코드로 재현 가능하게 만들었다.
+- 2026-03-31: benchmark 출력에는 current/baseline commit, CPU, RAM, tmux sessions/panes, agent count, TTL을 함께 남기도록 정리했다.
+- 2026-03-31: `statusline live` benchmark는 `status --json`이 `{ system, agents }` 형태를 반환해도 agent count를 정확히 읽도록 보정했다.

--- a/docs/marmonitor-performance-plan.txt
+++ b/docs/marmonitor-performance-plan.txt
@@ -90,12 +90,12 @@ marmonitor 성능 개선 실행 계획
 - Codex / Gemini / dead Claude 세션 스캔은 `existsSync` 선확인 대신 실제 `readdir` / `readFile` 실패를 분기로 사용해 중복 syscall을 줄인다.
 - stdout heuristic는 cross-process shared cache를 사용해 같은 PID/cwd에 대한 tmux pane lookup과 capture를 새 CLI 실행 간 재사용한다.
 - process cwd 조회는 cross-process shared cache를 사용해 같은 PID에 대한 `lsof` 결과를 새 CLI 실행 간 재사용한다.
-- process start time 조회도 cross-process shared cache를 사용해 같은 PID에 대한 `ps -o lstart=` 결과를 새 CLI 실행 간 재사용한다.
+- process start time 조회도 cross-process shared cache를 사용하되, shared key를 `pid + ppid + name + cmd`로 강화하고 shared TTL은 in-memory TTL보다 짧게 유지한다.
 - Claude session resolution은 `sessionId + cwd + startedAt` 기준 cross-process shared cache를 사용해 session file path를 새 CLI 실행 간 재사용한다.
 - Claude phase detect는 `sessionFile + mtime + size` 기준 cross-process shared cache를 사용해 JSONL tail parse를 새 CLI 실행 간 재사용한다.
 - Codex phase detect도 `sessionFile + mtime + size` 기준 cross-process shared cache를 사용해 phase parse를 새 CLI 실행 간 재사용한다.
-- `ps-list`와 `pidusage`도 1초짜리 cross-process shared cache를 사용해 같은 PID 집합에 대한 process scan/metrics 조회를 새 CLI 실행 간 재사용한다.
-- shared cache 파일 쓰기는 temp file + rename으로 바꿔 partial write가 cache miss로만 폴백되도록 정리한다.
+- `ps-list`와 `pidusage`의 1초짜리 cross-process shared cache는 `statusline` 경로에서만 사용해 freshness tradeoff 범위를 좁힌다.
+- shared cache뿐 아니라 snapshot/statusline cache 파일 쓰기도 temp file + rename으로 바꿔 partial write가 cache miss로만 폴백되도록 정리한다.
 - 완료 기준
   - Codex / Claude가 전체 스캔 비용의 대부분을 차지하지 않게 된다.
 
@@ -139,7 +139,8 @@ marmonitor 성능 개선 실행 계획
 - 2026-03-31: `tests/runtime-cache.test.mjs`에 process list shared cache, pidusage shared cache 회귀 테스트를 추가했다.
 - 2026-03-31: `npm run build`, `npm run lint`, `npm test` 재통과. 총 185개 테스트 통과.
 - 2026-03-31: 실제 tmux 기준 재실측에서 forced snapshot miss wall time은 `1.25s`, `1.50s`였고, 같은 구간의 `pidusage`는 `677ms`, `806ms`, `ps-list`는 `114ms`, `218ms` 수준이었다.
-- 2026-03-31: `getProcessStartTime`에도 cross-process shared cache를 추가해 같은 PID의 `ps -o lstart=` 재호출을 새 CLI 실행 간 줄였다.
-- 2026-03-31: shared cache 파일 쓰기를 temp file + rename으로 바꿔 경쟁 상황에서 partial write가 의미 오류가 아니라 cache miss 폴백으로만 이어지게 정리했다.
-- 2026-03-31: `tests/runtime-cache.test.mjs`에 process start-time shared cache hit / negative cache hit 회귀 테스트를 추가했다.
-- 2026-03-31: `npm run build`, `npm run lint`, `npm test` 재통과. 총 187개 테스트 통과.
+- 2026-03-31: `getProcessStartTime`에도 cross-process shared cache를 추가하되, shared key를 `pid + ppid + name + cmd`로 강화해 PID 재사용 리스크를 줄였다.
+- 2026-03-31: `ps-list` / `pidusage` 1초 shared snapshot은 `statusline` 경로에서만 사용하도록 좁혀 의미 범위를 줄였다.
+- 2026-03-31: shared cache뿐 아니라 snapshot/statusline cache 파일 쓰기도 temp file + rename으로 바꿔 경쟁 상황에서 partial write가 의미 오류가 아니라 cache miss 폴백으로만 이어지게 정리했다.
+- 2026-03-31: `tests/runtime-cache.test.mjs`에 process start-time shared cache hit / negative hit / identity partition 회귀 테스트를 추가했고, `tests/snapshot-cache.test.mjs`에 atomic cache write 테스트를 추가했다.
+- 2026-03-31: `npm run build`, `npm run lint`, `npm test` 재통과. 총 189개 테스트 통과.

--- a/docs/marmonitor-performance-plan.txt
+++ b/docs/marmonitor-performance-plan.txt
@@ -1,0 +1,139 @@
+marmonitor 성능 개선 실행 계획
+
+목표
+- tmux 상태바 갱신이 키보드 입력 지연을 유발하는지 확인하고, 가장 비싼 경로부터 줄인다.
+- "느리다"를 감각이 아니라 수치로 확인하고, 개선 전후를 비교할 수 있게 만든다.
+
+현재 기준선
+- tmux `status-interval`은 15초다.
+- `@marmonitor-interval`도 15초다.
+- 로컬 `marmonitor` 설정의 performance TTL은 10초다.
+- 즉, 상태바 갱신 주기보다 TTL이 짧아 cache miss가 자주 날 수 있다.
+- statusline cache miss 시 `scanAgents()` 경로로 내려가며, 이때 ps/pidusage/lsof/ps/tmux/codex indexing이 섞일 수 있다.
+
+핵심 가설
+- 렌더링보다 수집이 비싸다.
+- 특히 `--statusline` 경로가 cache miss 시 무거운 session enrichment로 들어가면 tmux 입력 체감 지연이 생길 수 있다.
+- multiple CLI invocations가 같은 시점에 겹치면 같은 스캔을 중복으로 수행할 수 있다.
+
+성공 기준
+- tmux statusline 갱신 중 타이핑 체감 지연이 줄어야 한다.
+- statusline 경로에서 어떤 단계가 시간을 쓰는지 수치로 확인할 수 있어야 한다.
+- attention / jump / status 정확도는 유지해야 한다.
+- 개선이 "운 좋게 cache hit"가 아니라 "실제 계산량 감소"로 설명되어야 한다.
+
+진행 상태
+- [완료] 1. 계측 추가
+- [완료] 2. statusline 경로 분리
+- [완료] 3. shared snapshot + single-flight
+- [진행 중] 4. Codex / Claude 세션 조회 축소
+- [대기] 5. tmux 실측 검증
+
+1. 계측 추가
+- `MARMONITOR_PERF=1`일 때만 stderr로 timing JSON을 출력한다.
+- 측정 대상
+  - `scanAgents`
+  - `indexCodexSessions`
+  - `parseClaudeSession`
+  - `parseClaudeTokens`
+  - `detectClaudePhase`
+  - `parseGeminiSession`
+  - `detectCliStdoutPhase`
+  - `getProcessCwd`
+  - `getProcessStartTime`
+  - `resolveTmuxJumpTarget`
+  - `captureTmuxPaneOutput`
+  - `renderStatusline`
+  - `readCachedStatusline`
+  - `readCachedSnapshot`
+- 출력 항목
+  - total_ms
+  - step별 ms
+  - cache hit / miss
+  - agent count
+  - 필요하면 format / enrichment mode
+- 완료 기준
+  - `statusline` 한 번 실행했을 때 상위 비용 구간을 숫자로 볼 수 있어야 한다.
+
+2. statusline 경로 분리
+- 목표는 statusline / attention / jump / dock / watch / status가 같은 비용을 갖지 않도록 만드는 것이다.
+- `full`은 `status`, `debug-phase`처럼 정보량이 필요한 명령에만 남긴다.
+- `light`는 statusline 계열에서 필요한 최소 필드만 만든다.
+- `statusline`은 `light` snapshot을 사용하고, light 경로에서는 Claude / Gemini 토큰 파싱을 끈다.
+- `statusline`의 phase 판정은 유지해야 하므로 stdout 힌트는 계속 적용한다.
+- Codex 매칭은 유지하되, `lsof`는 cwd-only 조회로 좁혀서 같은 결과를 더 싸게 구한다.
+- 제거 후보
+  - token parsing
+  - dead session collection
+  - 불필요한 full Codex indexing
+  - 중복 cwd / start-time 조회
+- 완료 기준
+  - statusline 경로가 full scan보다 확실히 가벼워진다.
+
+3. shared snapshot + single-flight
+- `/tmp/marmonitor` snapshot을 여러 CLI 프로세스가 공유한다.
+- refresh는 동시에 하나만 수행한다.
+- cache miss 시에는 lock을 통해 refresh를 직렬화하고, 다른 프로세스는 이미 갱신된 snapshot을 재사용한다.
+- 완료 기준
+  - 같은 시각에 여러 statusline 호출이 와도 동일한 스캔을 중복 수행하지 않는다.
+
+4. Codex / Claude 세션 조회 축소
+- Codex session index는 7일 전체 재스캔이 아니라 더 작은 단위로 갱신한다.
+- Claude session resolution은 project-dir 탐색과 JSONL 읽기를 최소화한다.
+- Codex light 경로는 session_meta 헤더만 읽고 token usage는 건너뛴다.
+- Codex index cache는 light/full을 분리해서 light 호출이 full 결과를 오염시키지 않게 한다.
+- `scanAgents`는 Codex 프로세스가 있을 때만 Codex 인덱스를 만든다.
+- Codex cwd 매칭은 후보가 여러 개일 때만 `ps` 시작 시각을 조회한다.
+- `debug-phase`의 Codex 경로도 light 인덱스를 사용한다.
+- `scanAgents`와 `debug-phase`는 runtime data path를 한 번만 계산해서 Claude / Codex helper로 전달한다.
+- Gemini project-dir 조회는 cwd별 안전 캐시를 사용하되, `.project_root`를 다시 읽어 stale cache를 무효화한다.
+- Codex / Gemini / dead Claude 세션 스캔은 `existsSync` 선확인 대신 실제 `readdir` / `readFile` 실패를 분기로 사용해 중복 syscall을 줄인다.
+- stdout heuristic는 cross-process shared cache를 사용해 같은 PID/cwd에 대한 tmux pane lookup과 capture를 새 CLI 실행 간 재사용한다.
+- process cwd 조회는 cross-process shared cache를 사용해 같은 PID에 대한 `lsof` 결과를 새 CLI 실행 간 재사용한다.
+- Claude session resolution은 `sessionId + cwd + startedAt` 기준 cross-process shared cache를 사용해 session file path를 새 CLI 실행 간 재사용한다.
+- Claude phase detect는 `sessionFile + mtime + size` 기준 cross-process shared cache를 사용해 JSONL tail parse를 새 CLI 실행 간 재사용한다.
+- Codex phase detect도 `sessionFile + mtime + size` 기준 cross-process shared cache를 사용해 phase parse를 새 CLI 실행 간 재사용한다.
+- `ps-list`와 `pidusage`도 1초짜리 cross-process shared cache를 사용해 같은 PID 집합에 대한 process scan/metrics 조회를 새 CLI 실행 간 재사용한다.
+- 완료 기준
+  - Codex / Claude가 전체 스캔 비용의 대부분을 차지하지 않게 된다.
+
+5. tmux 실측 검증
+- 15초 statusline 갱신 중 타이핑 렉이 줄었는지 확인한다.
+- attention / jump / dock / watch에서 동작이 깨지지 않는지 확인한다.
+- PR 본문에는 before / after timings을 넣는다.
+
+작업 로그
+- 2026-03-31: 계획 문서 작성 시작.
+- 2026-03-31: 1단계 계측 완료. `statusline` light 경로를 도입하고, Claude / Gemini 토큰 파싱만 light에서 제외했다.
+- 2026-03-31: `lsof`를 cwd-only로 좁히고, light 경로 동작을 `parseGeminiSessionContent` / `parseClaudeSession` 테스트로 고정했다.
+- 2026-03-31: `npm run build`, `npm run lint`, `npm test` 통과.
+- 2026-03-31: 현재 샌드박스에서는 `ps` spawn EPERM 때문에 실시간 `statusline` 실행 검증이 불안정하다.
+- 2026-03-31: `statusline` phase 판정을 유지한 채 light snapshot + snapshot lock으로 refresh를 직렬화했다.
+- 2026-03-31: snapshot lock이 실패할 때는 무한 대기 대신 안전하게 폴백하도록 정리했다.
+- 2026-03-31: Codex light 인덱스는 session_meta만 읽도록 바꾸고, synthetic 40-file benchmark에서 full 1147.4ms / light 126.6ms를 확인했다.
+- 2026-03-31: Codex light/full index cache를 분리하고, file cache도 light 결과가 full 결과를 덮지 않도록 정리했다.
+- 2026-03-31: `scanAgents`는 Codex 프로세스가 있을 때만 Codex 인덱스를 만들고, cwd가 단일 매칭이면 `ps` 시작 시각 조회를 건너뛰도록 바꿨다.
+- 2026-03-31: `debug-phase`의 Codex 경로도 light 인덱스를 사용하도록 조정했다.
+- 2026-03-31: `npm run build`, `npm run lint`, `npm test` 재통과. 총 166개 테스트 통과.
+- 2026-03-31: 임시 `HOME`/`CODEX_SESSIONS`로 격리한 synthetic 40-file benchmark에서 full avg 22.2ms / light avg 15.6ms를 확인했다. 이 측정은 default Codex 경로를 제외한 isolated run이다.
+- 2026-03-31: `resolveTmuxJumpTarget`는 in-flight tmux runtime snapshot을 공유하도록 바꿨다. 같은 시점의 `tmux list-panes` / `ps -eo pid=,ppid=`는 한 번만 수행한다.
+- 2026-03-31: tmux snapshot single-flight는 `tests/tmux.test.mjs`에 회귀 테스트를 추가해 고정했다.
+- 2026-03-31: `scanAgents`와 `debug-phase`는 runtime path를 1회만 계산하고 Claude / Codex session helper에 재사용하도록 바꿨다.
+- 2026-03-31: Gemini project-dir는 cwd별 캐시를 도입하되, cached `.project_root`를 다시 읽어 stale entry를 자동 무효화하도록 정리했다.
+- 2026-03-31: Codex day directory / Gemini tmp-chats / dead Claude session scan은 `existsSync` preflight를 줄이고 실제 I/O 실패를 그대로 분기 조건으로 사용하도록 정리했다.
+- 2026-03-31: `tests/scanner.test.mjs`에 mixed Gemini directory, missing Codex root 회귀 테스트를 추가했다.
+- 2026-03-31: `npm run build`, `npm run lint`, `npm test` 재통과. 총 175개 테스트 통과.
+- 2026-03-31: 실제 tmux 기준 live run에서 baseline cold `2.02s`, current cold `2.04s`, current immediate warm `0.04s`를 확인했다.
+- 2026-03-31: `stdout heuristic`와 `process cwd`에 cross-process shared cache를 추가했다.
+- 2026-03-31: `tests/runtime-cache.test.mjs`로 stdout heuristic / cwd shared cache hit와 negative cache hit를 회귀 테스트로 고정했다.
+- 2026-03-31: snapshot/statusline cache만 지우고 shared cache는 남긴 forced miss 시나리오에서 baseline `2.15s`, current `1.09s`를 확인했다.
+- 2026-03-31: 이 forced miss current run에서는 perf 로그상 `lsof` 단계가 사라졌고, tmux stdout heuristic 비용도 공유 cache hit로 대체된 것으로 해석된다.
+- 2026-03-31: `npm run build`, `npm run lint`, `npm test` 재통과. 총 180개 테스트 통과.
+- 2026-03-31: Claude session-file shared cache를 추가해 `sessionId + cwd + startedAt` 기준으로 resolved JSONL path를 새 CLI 실행 간 재사용하도록 정리했다.
+- 2026-03-31: Claude / Codex phase detect에 `sessionFile + mtime + size` 기준 shared cache를 추가해 새 CLI 실행에서도 phase parse를 재사용하도록 정리했다.
+- 2026-03-31: `tests/runtime-cache.test.mjs`에 Claude session-file shared cache, Claude phase shared cache, Codex phase shared cache 회귀 테스트를 추가했다.
+- 2026-03-31: `npm run build`, `npm run lint`, `npm test` 재통과. 총 183개 테스트 통과.
+- 2026-03-31: `ps-list`와 `pidusage`를 1초짜리 cross-process shared cache로 감쌌다. 목적은 완전 cold start가 아니라 forced snapshot miss 구간의 중복 process scan을 줄이는 것이다.
+- 2026-03-31: `tests/runtime-cache.test.mjs`에 process list shared cache, pidusage shared cache 회귀 테스트를 추가했다.
+- 2026-03-31: `npm run build`, `npm run lint`, `npm test` 재통과. 총 185개 테스트 통과.
+- 2026-03-31: 실제 tmux 기준 재실측에서 forced snapshot miss wall time은 `1.25s`, `1.50s`였고, 같은 구간의 `pidusage`는 `677ms`, `806ms`, `ps-list`는 `114ms`, `218ms` 수준이었다.

--- a/docs/marmonitor-statusline-live-findings.txt
+++ b/docs/marmonitor-statusline-live-findings.txt
@@ -65,14 +65,14 @@ marmonitor statusline live findings
 - Claude session resolution은 `sessionId + cwd + startedAt` 기준 cross-process shared cache를 사용한다.
 - Claude phase detect는 `sessionFile + mtime + size` 기준 cross-process shared cache를 사용한다.
 - Codex phase detect도 `sessionFile + mtime + size` 기준 cross-process shared cache를 사용한다.
-- `getProcessStartTime`도 같은 PID에 대한 `ps -o lstart=` 결과를 cross-process shared cache로 재사용한다.
-- shared cache 파일 쓰기는 temp file + rename으로 바꿔 partial write가 cache miss 폴백으로만 이어지게 정리했다.
+- `getProcessStartTime`도 cross-process shared cache를 사용하되, shared key를 `pid + ppid + name + cmd`로 강화하고 shared TTL은 더 짧게 유지한다.
+- shared cache뿐 아니라 snapshot/statusline cache 파일 쓰기도 temp file + rename으로 바꿔 partial write가 cache miss 폴백으로만 이어지게 정리했다.
 - 이 변경은 기능 의미를 바꾸지 않고, 새 CLI 실행이 동일한 session file path / phase 결과를 다시 읽지 않게 만드는 구조 개선이다.
 - 회귀 테스트는 shared cache hit 시 in-memory cache를 비워도 `open()` 재호출 없이 같은 결과를 반환하는 방식으로 고정했다.
 - 이 후속 변경은 보수적 안정화 성격이라 live perf 재실측은 아직 다시 하지 않았다.
 
 ps-list / pidusage 후속 측정
-- `ps-list`와 `pidusage`에도 1초짜리 cross-process shared cache를 추가했다.
+- `ps-list`와 `pidusage`에도 1초짜리 cross-process shared cache를 추가했지만, 현재는 `statusline` 경로에서만 사용한다.
 - 목적은 완전 cold start를 줄이는 것이 아니라, `snapshot/statusline` cache miss가 나더라도 바로 직전 CLI 실행이 이미 process scan을 했다면 그 결과를 새 프로세스가 다시 쓰게 만드는 것이다.
 - 같은 실제 tmux 세션에서 2회씩 다시 측정한 결과:
   - cold wall time: `1.27s`, `4.72s`

--- a/docs/marmonitor-statusline-live-findings.txt
+++ b/docs/marmonitor-statusline-live-findings.txt
@@ -1,0 +1,83 @@
+marmonitor statusline live findings
+
+목표
+- 실제 tmux 세션 기준으로 `--statusline` 경로의 before/after 실행 비용을 확인한다.
+- 체감 타이핑 렉의 원인이 cold path인지, cache hit path인지 구분한다.
+- 다음 최적화 우선순위를 정한다.
+
+실측 환경
+- 실제 tmux 세션에 연결된 상태에서 `--statusline --statusline-format compact` 실행
+- 현재 로드된 runtime config
+  - `snapshotTtlMs = 10000`
+  - `statuslineTtlMs = 10000`
+  - `stdoutHeuristicTtlMs = 10000`
+- tmux 갱신 주기는 별도 설정 기준 15초
+
+실측 결과
+- baseline cold: `real 2.02s`
+- baseline warm: `real 4.66s`
+- baseline warm2: `real 4.32s`
+- current cold: `real 2.04s`
+- current warm immediate: `real 0.04s`
+- current warm2 after TTL window drift: `real 2.67s`
+- baseline forced snapshot miss with primed runtime state: `real 2.15s`
+- current forced snapshot miss with primed shared caches: `real 1.09s`
+
+해석
+- 이번 변경은 `cold path wall time` 자체를 줄이기보다 `cache hit path`와 `중복 호출`을 줄이는 데 효과가 컸다.
+- 실제 current cold는 baseline cold와 거의 같다.
+- 반면 current warm immediate는 즉시 cache hit로 내려가면 매우 빠르다.
+- 현재 config에서는 TTL이 10초, tmux refresh가 15초라서 독립 refresh는 자주 cold로 돌아갈 수 있다.
+- 다만 `snapshot/statusline cache miss`라도 동일한 PID 집합에 대한 `stdout heuristic`과 `cwd`가 최근에 계산되어 있으면, shared cache 덕분에 miss 비용이 크게 줄어든다.
+- live forced-miss 비교에서는 `2.15s -> 1.09s`로 약 49% 줄었다.
+
+현재 cold 병목
+- `lsof` cwd 조회
+- `detectCliStdoutPhase`
+- `resolveTmuxJumpTarget` / `captureTmuxPaneOutput`
+- Claude session parse / phase detect
+- `ps-list`, `pidusage`
+- Codex index는 더 이상 주병목이 아니다.
+
+우선순위
+1. stdout heuristic shared cache
+   - 새 CLI 프로세스 간에도 heuristic 결과를 재사용
+   - 목표: `detectCliStdoutPhase`와 tmux pane lookup 반복 감소
+2. cwd shared cache
+   - 새 CLI 프로세스 간에도 pid -> cwd 결과를 재사용
+   - 목표: `lsof` 반복 감소
+
+진행 상태
+- [완료] 실측 결과 정리
+- [완료] stdout heuristic shared cache
+- [완료] cwd shared cache
+- [완료] Claude session-file / phase shared cache
+- [완료] Codex phase shared cache
+- [완료] 회귀 테스트 추가
+- [완료] build/lint/test 재검증
+
+구현 후 관찰
+- shared cache가 살아 있는 forced snapshot miss 시나리오에서 perf 로그상 `lsof` 단계가 사라졌다.
+- 같은 시나리오에서 tmux 관련 perf 라벨도 출력되지 않았고, stdout heuristic은 shared cache hit로 대체된 것으로 해석된다.
+- 남은 핵심 변수는 `stdoutHeuristicTtlMs=10000`과 tmux refresh 15초의 간극이다.
+
+후속 구조 개선
+- Claude session resolution은 `sessionId + cwd + startedAt` 기준 cross-process shared cache를 사용한다.
+- Claude phase detect는 `sessionFile + mtime + size` 기준 cross-process shared cache를 사용한다.
+- Codex phase detect도 `sessionFile + mtime + size` 기준 cross-process shared cache를 사용한다.
+- 이 변경은 기능 의미를 바꾸지 않고, 새 CLI 실행이 동일한 session file path / phase 결과를 다시 읽지 않게 만드는 구조 개선이다.
+- 회귀 테스트는 shared cache hit 시 in-memory cache를 비워도 `open()` 재호출 없이 같은 결과를 반환하는 방식으로 고정했다.
+- 이 후속 변경에 대한 live perf 재실측은 아직 다시 하지 않았다.
+
+ps-list / pidusage 후속 측정
+- `ps-list`와 `pidusage`에도 1초짜리 cross-process shared cache를 추가했다.
+- 목적은 완전 cold start를 줄이는 것이 아니라, `snapshot/statusline` cache miss가 나더라도 바로 직전 CLI 실행이 이미 process scan을 했다면 그 결과를 새 프로세스가 다시 쓰게 만드는 것이다.
+- 같은 실제 tmux 세션에서 2회씩 다시 측정한 결과:
+  - cold wall time: `1.27s`, `4.72s`
+  - warm wall time: `0.05s`, `0.10s`
+  - forced snapshot miss wall time: `1.25s`, `1.50s`
+- 직전 측정에서 forced snapshot miss는 `1.07s`, `2.91s`였다.
+- 호스트 부하 편차가 커서 숫자 자체는 noisy하지만, 이번 측정에서는 forced miss 구간의 `pidusage`가 `677ms`, `806ms`로 내려왔고 `ps-list`는 `114ms`, `218ms` 수준이었다.
+- 해석:
+  - `stdout/tmux/lsof/Claude/Codex` 재사용에 더해 `pidusage`까지 재사용되면 forced miss 구간은 더 안정적으로 짧아진다.
+  - 다만 shared cache가 비어 있는 완전 cold start는 여전히 `pidusage`와 session phase 해석 비용에 크게 흔들린다.

--- a/docs/marmonitor-statusline-live-findings.txt
+++ b/docs/marmonitor-statusline-live-findings.txt
@@ -65,9 +65,11 @@ marmonitor statusline live findings
 - Claude session resolution은 `sessionId + cwd + startedAt` 기준 cross-process shared cache를 사용한다.
 - Claude phase detect는 `sessionFile + mtime + size` 기준 cross-process shared cache를 사용한다.
 - Codex phase detect도 `sessionFile + mtime + size` 기준 cross-process shared cache를 사용한다.
+- `getProcessStartTime`도 같은 PID에 대한 `ps -o lstart=` 결과를 cross-process shared cache로 재사용한다.
+- shared cache 파일 쓰기는 temp file + rename으로 바꿔 partial write가 cache miss 폴백으로만 이어지게 정리했다.
 - 이 변경은 기능 의미를 바꾸지 않고, 새 CLI 실행이 동일한 session file path / phase 결과를 다시 읽지 않게 만드는 구조 개선이다.
 - 회귀 테스트는 shared cache hit 시 in-memory cache를 비워도 `open()` 재호출 없이 같은 결과를 반환하는 방식으로 고정했다.
-- 이 후속 변경에 대한 live perf 재실측은 아직 다시 하지 않았다.
+- 이 후속 변경은 보수적 안정화 성격이라 live perf 재실측은 아직 다시 하지 않았다.
 
 ps-list / pidusage 후속 측정
 - `ps-list`와 `pidusage`에도 1초짜리 cross-process shared cache를 추가했다.

--- a/docs/marmonitor-statusline-live-findings.txt
+++ b/docs/marmonitor-statusline-live-findings.txt
@@ -1,100 +1,92 @@
 marmonitor statusline live findings
 
 목표
-- 실제 tmux 세션 기준으로 `--statusline` 경로의 before/after 실행 비용을 확인한다.
-- 체감 타이핑 렉의 원인이 cold path인지, cache hit path인지 구분한다.
-- 다음 최적화 우선순위를 정한다.
+- 실제 tmux 세션 기준으로 `--statusline` 경로의 실행 비용을 수치로 확인한다.
+- `cold`, `warm`, `forced-miss`를 구분해서 체감 타이핑 렉이 어느 경로와 더 가깝게 연결되는지 판단한다.
 
-실측 환경
-- 실제 tmux 세션에 연결된 상태에서 `--statusline --statusline-format compact` 실행
-- 현재 로드된 runtime config
+권위 있는 측정 방법
+- 현재 이 문서의 수치는 모두 아래 스크립트 출력에 기반한다.
+  - [scripts/bench-statusline-live.mjs](/Users/jaewankim/Desktop/jaewan-develop/marmonitor/scripts/bench-statusline-live.mjs)
+- 실행 명령
+  - `node scripts/bench-statusline-live.mjs --json`
+- 이 스크립트는
+  - 모든 cache를 비운 `cold`
+  - 즉시 재실행한 `warm`
+  - `snapshot-*`, `statusline-*`만 지운 `forced-miss`
+  를 순서대로 측정한다.
+
+최신 측정 환경
+- 측정 시점 current commit: `b26bdf5ffcfae05f42a8bd6ec4f704a3b010949b`
+- baseline commit: `6f04e60c4605db77586dc7a73a2e4bfe8814d8d6`
+- host
+  - CPU: `Apple M3 Max`
+  - logical CPU: `14`
+  - RAM: `36GB`
+- tmux
+  - sessions: `3`
+  - panes: `7`
+- agents
+  - `37`
+- runtime config
   - `snapshotTtlMs = 10000`
   - `statuslineTtlMs = 10000`
   - `stdoutHeuristicTtlMs = 10000`
-- tmux 갱신 주기는 별도 설정 기준 15초
 
-실측 결과
-- baseline cold: `real 2.02s`
-- baseline warm: `real 4.66s`
-- baseline warm2: `real 4.32s`
-- current cold: `real 2.04s`
-- current warm immediate: `real 0.04s`
-- current warm2 after TTL window drift: `real 2.67s`
-- baseline forced snapshot miss with primed runtime state: `real 2.15s`
-- current forced snapshot miss with primed shared caches: `real 1.09s`
+최신 측정 결과
+- `cold`
+  - real: `1413.3ms`
+  - snapshot: `1233.3ms`
+  - scanAgents: `1230.6ms`
+  - ps-list: `136.7ms`
+  - pidusage: `239.5ms`
+  - buildSessions: `830.2ms`
+  - lsof: `7785.4ms`
+  - ps_lstart: `596.2ms`
+  - stdout heuristic: `4209ms`
+  - tmux resolve: `2870.4ms`
+  - tmux capture: `294ms`
+  - renderStatusline: `75.4ms`
+- `warm`
+  - real: `66.1ms`
+- `forced-miss #1`
+  - real: `550.1ms`
+  - snapshot: `448.3ms`
+  - scanAgents: `446.5ms`
+  - ps-list: `150.3ms`
+  - pidusage: `263.1ms`
+  - buildSessions: `7.1ms`
+  - stdout heuristic: `35ms`
+  - renderStatusline: `35.5ms`
+- `forced-miss #2`
+  - real: `118.4ms`
+  - snapshot: `26.4ms`
+  - scanAgents: `24.9ms`
+  - buildSessions: `6.2ms`
+  - stdout heuristic: `29.2ms`
+  - renderStatusline: `34.8ms`
 
-해석
-- 이번 변경은 `cold path wall time` 자체를 줄이기보다 `cache hit path`와 `중복 호출`을 줄이는 데 효과가 컸다.
-- 실제 current cold는 baseline cold와 거의 같다.
-- 반면 current warm immediate는 즉시 cache hit로 내려가면 매우 빠르다.
-- 현재 config에서는 TTL이 10초, tmux refresh가 15초라서 독립 refresh는 자주 cold로 돌아갈 수 있다.
-- 다만 `snapshot/statusline cache miss`라도 동일한 PID 집합에 대한 `stdout heuristic`과 `cwd`가 최근에 계산되어 있으면, shared cache 덕분에 miss 비용이 크게 줄어든다.
-- live forced-miss 비교에서는 `2.15s -> 1.09s`로 약 49% 줄었다.
+현재 해석
+- 현재 PR은 `cold path 자체를 근본적으로 줄였다`기보다 `warm path`와 `forced-miss`를 크게 줄이는 쪽에 더 가깝다.
+- `cold`에서 상위 누적 비용은 여전히 `buildSessions`, `stdout heuristic`, `tmux resolve`, `lsof`, `pidusage` 계열이다.
+- 반면 `forced-miss`에서는 shared cache가 이미 살아 있으므로 `lsof`, `tmux`, `session phase` 쪽 비용이 많이 빠진다.
+- 지금 환경에서는 TTL이 `10초`, tmux refresh가 `15초`라서 독립 refresh는 다시 colder path로 갈 수 있다.
 
-현재 cold 병목
-- `lsof` cwd 조회
-- `detectCliStdoutPhase`
-- `resolveTmuxJumpTarget` / `captureTmuxPaneOutput`
-- Claude session parse / phase detect
-- `ps-list`, `pidusage`
-- Codex index는 더 이상 주병목이 아니다.
+초기 수동 실측과의 관계
+- 아래 수치는 초기 탐색 단계에서 수동으로 남긴 값이다.
+  - baseline cold: `2.02s`
+  - current cold: `2.04s`
+  - baseline forced miss with primed runtime state: `2.15s`
+  - current forced miss with primed shared caches: `1.09s`
+- 이 값들은 방향성 확인에는 유용했지만, 측정 환경과 명령이 완전히 구조화돼 있지 않았다.
+- 따라서 현재는 이 문서의 스크립트 기반 측정과 [docs/performance-benchmarking.md](/Users/jaewankim/Desktop/jaewan-develop/marmonitor/docs/performance-benchmarking.md)를 권위 있는 기준으로 본다.
 
-우선순위
-1. stdout heuristic shared cache
-   - 새 CLI 프로세스 간에도 heuristic 결과를 재사용
-   - 목표: `detectCliStdoutPhase`와 tmux pane lookup 반복 감소
-2. cwd shared cache
-   - 새 CLI 프로세스 간에도 pid -> cwd 결과를 재사용
-   - 목표: `lsof` 반복 감소
+구조 개선 요약
+- `stdout heuristic`는 cross-process shared cache를 사용한다.
+- process cwd는 cross-process shared cache를 사용한다.
+- Claude session resolution과 Claude/Codex phase detect도 cross-process shared cache를 사용한다.
+- `ps-list`와 `pidusage`의 1초 shared snapshot은 `statusline` 경로에서만 사용한다.
+- shared cache와 snapshot/statusline cache write는 temp file + rename으로 정리했다.
 
-진행 상태
-- [완료] 실측 결과 정리
-- [완료] stdout heuristic shared cache
-- [완료] cwd shared cache
-- [완료] Claude session-file / phase shared cache
-- [완료] Codex phase shared cache
-- [완료] 회귀 테스트 추가
-- [완료] build/lint/test 재검증
-
-구현 후 관찰
-- shared cache가 살아 있는 forced snapshot miss 시나리오에서 perf 로그상 `lsof` 단계가 사라졌다.
-- 같은 시나리오에서 tmux 관련 perf 라벨도 출력되지 않았고, stdout heuristic은 shared cache hit로 대체된 것으로 해석된다.
-- 남은 핵심 변수는 `stdoutHeuristicTtlMs=10000`과 tmux refresh 15초의 간극이다.
-
-후속 구조 개선
-- Claude session resolution은 `sessionId + cwd + startedAt` 기준 cross-process shared cache를 사용한다.
-- Claude phase detect는 `sessionFile + mtime + size` 기준 cross-process shared cache를 사용한다.
-- Codex phase detect도 `sessionFile + mtime + size` 기준 cross-process shared cache를 사용한다.
-- `getProcessStartTime`도 cross-process shared cache를 사용하되, shared key를 `pid + ppid + name + cmd`로 강화하고 shared TTL은 더 짧게 유지한다.
-- shared cache뿐 아니라 snapshot/statusline cache 파일 쓰기도 temp file + rename으로 바꿔 partial write가 cache miss 폴백으로만 이어지게 정리했다.
-- 이 변경은 기능 의미를 바꾸지 않고, 새 CLI 실행이 동일한 session file path / phase 결과를 다시 읽지 않게 만드는 구조 개선이다.
-- 회귀 테스트는 shared cache hit 시 in-memory cache를 비워도 `open()` 재호출 없이 같은 결과를 반환하는 방식으로 고정했다.
-- 이 후속 변경 뒤 실제 tmux에서 다시 재실측했다.
-
-ps-list / pidusage 후속 측정
-- `ps-list`와 `pidusage`에도 1초짜리 cross-process shared cache를 추가했지만, 현재는 `statusline` 경로에서만 사용한다.
-- 목적은 완전 cold start를 줄이는 것이 아니라, `snapshot/statusline` cache miss가 나더라도 바로 직전 CLI 실행이 이미 process scan을 했다면 그 결과를 새 프로세스가 다시 쓰게 만드는 것이다.
-- 같은 실제 tmux 세션에서 2회씩 다시 측정한 결과:
-  - cold wall time: `1.27s`, `4.72s`
-  - warm wall time: `0.05s`, `0.10s`
-  - forced snapshot miss wall time: `1.25s`, `1.50s`
-- 직전 측정에서 forced snapshot miss는 `1.07s`, `2.91s`였다.
-- 호스트 부하 편차가 커서 숫자 자체는 noisy하지만, 이번 측정에서는 forced miss 구간의 `pidusage`가 `677ms`, `806ms`로 내려왔고 `ps-list`는 `114ms`, `218ms` 수준이었다.
-- 해석:
-  - `stdout/tmux/lsof/Claude/Codex` 재사용에 더해 `pidusage`까지 재사용되면 forced miss 구간은 더 안정적으로 짧아진다.
-  - 다만 shared cache가 비어 있는 완전 cold start는 여전히 `pidusage`와 session phase 해석 비용에 크게 흔들린다.
-
-최신 head 재실측
-- `ps-list` / `pidusage` 1초 shared snapshot을 `--statusline` 경로로만 좁힌 뒤 실제 tmux에서 다시 측정했다.
-- 같은 환경에서 재측정한 결과:
-  - cold wall time: `1.47s`
-  - warm wall time: `0.05s`
-  - forced snapshot miss wall time: `1.35s`, `1.16s`
-- 같은 forced miss 구간의 주요 단계:
-  - `pidusage`: `933.5ms`, `769.1ms`
-  - `ps-list`: `166.6ms`, `194.3ms`
-  - `renderStatusline`: `80.1ms`, `48.0ms`
-- forced miss summary에는 `lsof`, `ps_lstart`, `resolveTmuxJumpTarget`, `captureTmuxPaneOutput`가 더 이상 별도 상위 단계로 나타나지 않았다.
-- 해석:
-  - `statusline-only`로 shared runtime snapshot 범위를 좁혀도 warm path와 forced miss 개선은 유지된다.
-  - 현재 남은 주병목은 여전히 `pidusage`다.
+남은 핵심 병목
+- 완전 cold run에서는 여전히 `buildSessions`, `stdout heuristic`, `tmux resolve`, `pidusage`가 크다.
+- 현재 최신 수치 기준으로도 `warm`과 `forced-miss`는 충분히 빨라졌지만, `cold`는 아직 구조적으로 무겁다.

--- a/docs/marmonitor-statusline-live-findings.txt
+++ b/docs/marmonitor-statusline-live-findings.txt
@@ -6,7 +6,7 @@ marmonitor statusline live findings
 
 권위 있는 측정 방법
 - 현재 이 문서의 수치는 모두 아래 스크립트 출력에 기반한다.
-  - [scripts/bench-statusline-live.mjs](/Users/jaewankim/Desktop/jaewan-develop/marmonitor/scripts/bench-statusline-live.mjs)
+  - [`scripts/bench-statusline-live.mjs`](../scripts/bench-statusline-live.mjs)
 - 실행 명령
   - `node scripts/bench-statusline-live.mjs --json`
 - 이 스크립트는
@@ -78,7 +78,7 @@ marmonitor statusline live findings
   - baseline forced miss with primed runtime state: `2.15s`
   - current forced miss with primed shared caches: `1.09s`
 - 이 값들은 방향성 확인에는 유용했지만, 측정 환경과 명령이 완전히 구조화돼 있지 않았다.
-- 따라서 현재는 이 문서의 스크립트 기반 측정과 [docs/performance-benchmarking.md](/Users/jaewankim/Desktop/jaewan-develop/marmonitor/docs/performance-benchmarking.md)를 권위 있는 기준으로 본다.
+- 따라서 현재는 이 문서의 스크립트 기반 측정과 [`docs/performance-benchmarking.md`](./performance-benchmarking.md)를 권위 있는 기준으로 본다.
 
 구조 개선 요약
 - `stdout heuristic`는 cross-process shared cache를 사용한다.

--- a/docs/marmonitor-statusline-live-findings.txt
+++ b/docs/marmonitor-statusline-live-findings.txt
@@ -69,7 +69,7 @@ marmonitor statusline live findings
 - shared cache뿐 아니라 snapshot/statusline cache 파일 쓰기도 temp file + rename으로 바꿔 partial write가 cache miss 폴백으로만 이어지게 정리했다.
 - 이 변경은 기능 의미를 바꾸지 않고, 새 CLI 실행이 동일한 session file path / phase 결과를 다시 읽지 않게 만드는 구조 개선이다.
 - 회귀 테스트는 shared cache hit 시 in-memory cache를 비워도 `open()` 재호출 없이 같은 결과를 반환하는 방식으로 고정했다.
-- 이 후속 변경은 보수적 안정화 성격이라 live perf 재실측은 아직 다시 하지 않았다.
+- 이 후속 변경 뒤 실제 tmux에서 다시 재실측했다.
 
 ps-list / pidusage 후속 측정
 - `ps-list`와 `pidusage`에도 1초짜리 cross-process shared cache를 추가했지만, 현재는 `statusline` 경로에서만 사용한다.
@@ -83,3 +83,18 @@ ps-list / pidusage 후속 측정
 - 해석:
   - `stdout/tmux/lsof/Claude/Codex` 재사용에 더해 `pidusage`까지 재사용되면 forced miss 구간은 더 안정적으로 짧아진다.
   - 다만 shared cache가 비어 있는 완전 cold start는 여전히 `pidusage`와 session phase 해석 비용에 크게 흔들린다.
+
+최신 head 재실측
+- `ps-list` / `pidusage` 1초 shared snapshot을 `--statusline` 경로로만 좁힌 뒤 실제 tmux에서 다시 측정했다.
+- 같은 환경에서 재측정한 결과:
+  - cold wall time: `1.47s`
+  - warm wall time: `0.05s`
+  - forced snapshot miss wall time: `1.35s`, `1.16s`
+- 같은 forced miss 구간의 주요 단계:
+  - `pidusage`: `933.5ms`, `769.1ms`
+  - `ps-list`: `166.6ms`, `194.3ms`
+  - `renderStatusline`: `80.1ms`, `48.0ms`
+- forced miss summary에는 `lsof`, `ps_lstart`, `resolveTmuxJumpTarget`, `captureTmuxPaneOutput`가 더 이상 별도 상위 단계로 나타나지 않았다.
+- 해석:
+  - `statusline-only`로 shared runtime snapshot 범위를 좁혀도 warm path와 forced miss 개선은 유지된다.
+  - 현재 남은 주병목은 여전히 `pidusage`다.

--- a/docs/performance-benchmarking.md
+++ b/docs/performance-benchmarking.md
@@ -1,0 +1,92 @@
+성능 벤치마크 가이드
+
+목적
+- scanner/statusline 성능 변경을 감각이 아니라 재현 가능한 숫자로 비교한다.
+- `JSONL 파싱 비용`과 `실제 tmux statusline 실행 비용`을 같은 숫자로 뭉개지 않고 분리해서 본다.
+
+왜 벤치마크를 둘로 나눴는가
+- `Codex synthetic benchmark`는 재현 가능한 fixture 기반 측정이다.
+  - JSONL 크기, 파일 수, cache 상태를 통제할 수 있다.
+  - tmux, `lsof`, `pidusage`, 실제 세션 혼합도는 반영하지 않는다.
+- `Statusline live benchmark`는 현재 tmux/runtime 환경에서 실제 `--statusline` 경로를 측정한다.
+  - 실제 병목을 잘 드러낸다.
+  - 대신 호스트 스펙, 활성 pane 수, 세션 수, TTL 설정에 따라 숫자가 달라진다.
+- 따라서 같은 `40-file`이라는 표현만으로는 성능을 설명할 수 없다.
+
+재현 가능한 synthetic benchmark
+- 명령
+  - `npm run bench:codex-index`
+  - JSON 출력: `npm run bench:codex-index -- --json`
+- 스크립트
+  - [scripts/bench-codex-index.mjs](/Users/jaewankim/Desktop/jaewan-develop/marmonitor/scripts/bench-codex-index.mjs)
+- 기본 동작
+  - temp 디렉터리에 결정적인 40-file fixture를 생성한다.
+  - 두 fixture profile을 측정한다.
+    - `heavy`: 긴 tail과 큰 JSONL을 가진 세션
+    - `compact`: 더 짧고 작은 세션
+  - 두 cache scenario를 측정한다.
+    - `cold_empty_caches`
+    - `warm_file_cache`
+- 출력 항목
+  - current commit
+  - baseline ref commit
+  - CPU model / logical CPU count / RAM
+  - fixture file count / repeat count
+  - profile별 full/light timing 요약
+
+실제 statusline live benchmark
+- 명령
+  - `npm run bench:statusline-live`
+  - JSON 출력: `npm run bench:statusline-live -- --json`
+- 스크립트
+  - [scripts/bench-statusline-live.mjs](/Users/jaewankim/Desktop/jaewan-develop/marmonitor/scripts/bench-statusline-live.mjs)
+- 기본 동작
+  - 모든 marmonitor cache를 비우고 `cold`를 측정한다.
+  - 즉시 한 번 더 실행해서 `warm`을 측정한다.
+  - `snapshot-*`, `statusline-*`만 지우고 `forced-miss`를 2회 측정한다.
+- 출력 항목
+  - current commit
+  - baseline ref commit
+  - CPU model / logical CPU count / RAM
+  - tmux session 수 / pane 수
+  - 현재 agent 수
+  - runtime config에서 읽은 TTL 값
+  - `MARMONITOR_PERF` 단계별 timing
+
+현재 예시 측정
+- synthetic benchmark
+  - 측정 명령: `node scripts/bench-codex-index.mjs --json`
+  - 측정 시점 commit: `b26bdf5ffcfae05f42a8bd6ec4f704a3b010949b`
+  - baseline commit: `6f04e60c4605db77586dc7a73a2e4bfe8814d8d6`
+  - host: `Apple M3 Max`, `14` logical CPU, `36GB RAM`
+  - 결과 요약
+    - `heavy / cold_empty_caches`: full avg `20.9ms`, light avg `4.6ms`
+    - `compact / cold_empty_caches`: full avg `5.6ms`, light avg `3.4ms`
+    - `warm_file_cache`: full/light 모두 약 `1ms`
+- live statusline benchmark
+  - 측정 명령: `node scripts/bench-statusline-live.mjs --json`
+  - 측정 시점 commit: `b26bdf5ffcfae05f42a8bd6ec4f704a3b010949b`
+  - baseline commit: `6f04e60c4605db77586dc7a73a2e4bfe8814d8d6`
+  - host: `Apple M3 Max`, `14` logical CPU, `36GB RAM`
+  - tmux: `3` sessions, `7` panes
+  - agents: `37`
+  - TTL: `snapshot=10000ms`, `statusline=10000ms`, `stdout=10000ms`
+  - 결과 요약
+    - `cold`: `1413.3ms`
+    - `warm`: `66.1ms`
+    - `forced-miss`: `550.1ms`, `118.4ms`
+
+검토 순서
+1. `npm run bench:codex-index -- --json`로 fixture 기반 숫자를 캡처한다.
+2. 실제 tmux 세션 안에서 `npm run bench:statusline-live -- --json`를 실행한다.
+3. PR이나 이슈에는 두 결과를 함께 적되, fixture profile과 runtime 환경을 같이 적는다.
+
+대안 검토
+- `tests/perf.benchmark.mjs`로 넣는 대안도 있었지만, CI 테스트와 host-dependent live benchmark를 섞으면 flaky해진다.
+- repo에 고정 fixture JSONL을 넣는 대안도 있었지만, 생성형 fixture가 더 작고 profile 조정이 쉽다.
+- 라이브 벤치마크를 내부 함수 import 기반으로 만드는 대안도 있었지만, spawn 비용과 실제 CLI cache 경로를 놓치게 된다.
+
+주의
+- synthetic 비율과 live 비율을 직접 비교하면 안 된다.
+- authoritative한 숫자는 문서의 고정 값이 아니라 스크립트 출력이다.
+- 문서의 예시 값은 해석 예시일 뿐이고, 최종 비교는 항상 같은 명령을 다시 실행해서 얻은 JSON 출력으로 해야 한다.

--- a/docs/performance-benchmarking.md
+++ b/docs/performance-benchmarking.md
@@ -16,9 +16,9 @@
 재현 가능한 synthetic benchmark
 - 명령
   - `npm run bench:codex-index`
-  - JSON 출력: `npm run bench:codex-index -- --json`
+- JSON 출력: `npm run bench:codex-index -- --json`
 - 스크립트
-  - [scripts/bench-codex-index.mjs](/Users/jaewankim/Desktop/jaewan-develop/marmonitor/scripts/bench-codex-index.mjs)
+  - [`scripts/bench-codex-index.mjs`](../scripts/bench-codex-index.mjs)
 - 기본 동작
   - temp 디렉터리에 결정적인 40-file fixture를 생성한다.
   - 두 fixture profile을 측정한다.
@@ -37,9 +37,9 @@
 실제 statusline live benchmark
 - 명령
   - `npm run bench:statusline-live`
-  - JSON 출력: `npm run bench:statusline-live -- --json`
+- JSON 출력: `npm run bench:statusline-live -- --json`
 - 스크립트
-  - [scripts/bench-statusline-live.mjs](/Users/jaewankim/Desktop/jaewan-develop/marmonitor/scripts/bench-statusline-live.mjs)
+  - [`scripts/bench-statusline-live.mjs`](../scripts/bench-statusline-live.mjs)
 - 기본 동작
   - 모든 marmonitor cache를 비우고 `cold`를 측정한다.
   - 즉시 한 번 더 실행해서 `warm`을 측정한다.

--- a/package.json
+++ b/package.json
@@ -46,8 +46,10 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "start": "node bin/marmonitor.js",
-    "lint": "biome check src tests",
+    "lint": "biome check src tests scripts",
     "test": "node --test tests/*.test.mjs",
+    "bench:codex-index": "npm run build && node scripts/bench-codex-index.mjs",
+    "bench:statusline-live": "npm run build && node scripts/bench-statusline-live.mjs",
     "postinstall": "node bin/postinstall.cjs",
     "preuninstall": "node bin/preuninstall.cjs",
     "prepublishOnly": "npm run build && npm test"

--- a/scripts/bench-codex-index.mjs
+++ b/scripts/bench-codex-index.mjs
@@ -1,0 +1,306 @@
+#!/usr/bin/env node
+
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import { join } from "node:path";
+import { performance } from "node:perf_hooks";
+import { parseArgs, promisify } from "node:util";
+
+import {
+  codexSessionFileCache,
+  codexSessionRegistry,
+  setCodexIndexCache,
+} from "../dist/scanner/cache.js";
+import { indexCodexSessions } from "../dist/scanner/codex.js";
+
+const execFileAsync = promisify(execFile);
+
+const PROFILES = {
+  heavy: {
+    label: "long-tail token sessions",
+    noiseLines: 400,
+    paddingBytes: 512,
+  },
+  compact: {
+    label: "shorter compact sessions",
+    noiseLines: 40,
+    paddingBytes: 96,
+  },
+};
+
+function percentile(sortedValues, ratio) {
+  if (sortedValues.length === 0) return 0;
+  const index = Math.min(
+    sortedValues.length - 1,
+    Math.max(0, Math.round((sortedValues.length - 1) * ratio)),
+  );
+  return sortedValues[index];
+}
+
+function summarize(samples) {
+  const sorted = [...samples].sort((a, b) => a - b);
+  const total = samples.reduce((sum, value) => sum + value, 0);
+  const averageMs = total / samples.length;
+  return {
+    runs: samples.length,
+    minMs: Number(sorted[0].toFixed(1)),
+    p50Ms: Number(percentile(sorted, 0.5).toFixed(1)),
+    p95Ms: Number(percentile(sorted, 0.95).toFixed(1)),
+    maxMs: Number(sorted[sorted.length - 1].toFixed(1)),
+    averageMs: Number(averageMs.toFixed(1)),
+    samplesMs: samples.map((value) => Number(value.toFixed(1))),
+  };
+}
+
+function resetCodexCaches() {
+  setCodexIndexCache(undefined);
+  codexSessionFileCache.clear();
+  codexSessionRegistry.clear();
+}
+
+async function getGitCommit(revision) {
+  try {
+    const { stdout } = await execFileAsync("git", ["rev-parse", revision], { encoding: "utf8" });
+    return stdout.trim();
+  } catch {
+    return undefined;
+  }
+}
+
+async function createFixture(rootDir, fileCount, profileName) {
+  const profile = PROFILES[profileName];
+  const now = new Date("2026-03-31T10:00:00.000Z");
+  const yyyy = now.getUTCFullYear().toString();
+  const mm = String(now.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(now.getUTCDate()).padStart(2, "0");
+  const sessionsRoot = join(rootDir, profileName, "sessions");
+  const dayDir = join(sessionsRoot, yyyy, mm, dd);
+  const padding = "x".repeat(profile.paddingBytes);
+
+  await mkdir(dayDir, { recursive: true });
+
+  for (let i = 0; i < fileCount; i += 1) {
+    const timestamp = new Date(now.getTime() + i * 1_000).toISOString();
+    const cwd = `/tmp/marmonitor-bench/${profileName}/repo-${String(i).padStart(2, "0")}`;
+    const lines = [
+      JSON.stringify({
+        type: "session_meta",
+        payload: {
+          id: `${profileName}-session-${i}`,
+          cwd,
+          timestamp,
+          model_provider: "gpt-5.4",
+        },
+      }),
+      JSON.stringify({
+        type: "turn_context",
+        payload: {
+          model: "gpt-5.4",
+        },
+      }),
+    ];
+
+    for (let line = 0; line < profile.noiseLines; line += 1) {
+      lines.push(
+        JSON.stringify({
+          type: "event_msg",
+          payload: {
+            type: "progress",
+            index: line,
+            padding,
+          },
+        }),
+      );
+    }
+
+    lines.push(
+      JSON.stringify({
+        type: "event_msg",
+        payload: {
+          type: "token_count",
+          info: {
+            total_token_usage: {
+              input_tokens: 1000 + i,
+              cached_input_tokens: 200 + i,
+              output_tokens: 300 + i,
+              total_tokens: 1500 + i,
+            },
+          },
+        },
+      }),
+    );
+
+    await writeFile(join(dayDir, `${profileName}-${i}.jsonl`), `${lines.join("\n")}\n`, "utf8");
+  }
+
+  return {
+    codexSessions: [sessionsRoot],
+    claudeProjects: [],
+    claudeSessions: [],
+    extraRoots: [],
+  };
+}
+
+async function measureColdScenario({ runtimePaths, includeTokenUsage, repeats }) {
+  const samples = [];
+  for (let i = 0; i < repeats; i += 1) {
+    resetCodexCaches();
+    const startedAt = performance.now();
+    await indexCodexSessions(undefined, { includeTokenUsage, runtimePaths });
+    samples.push(performance.now() - startedAt);
+  }
+  return summarize(samples);
+}
+
+async function measureWarmFileCacheScenario({ runtimePaths, includeTokenUsage, repeats }) {
+  const samples = [];
+  for (let i = 0; i < repeats; i += 1) {
+    resetCodexCaches();
+    await indexCodexSessions(undefined, { includeTokenUsage, runtimePaths });
+    setCodexIndexCache(undefined);
+    const startedAt = performance.now();
+    await indexCodexSessions(undefined, { includeTokenUsage, runtimePaths });
+    samples.push(performance.now() - startedAt);
+  }
+  return summarize(samples);
+}
+
+function printHumanSummary(result) {
+  console.log("Codex index benchmark");
+  console.log(`commit: ${result.environment.currentCommit ?? "(unknown)"}`);
+  if (result.environment.baselineCommit) {
+    console.log(`baseline: ${result.environment.baselineCommit}`);
+  }
+  console.log(
+    `host: ${result.environment.cpuModel} | ${result.environment.logicalCpuCount} logical CPU | ${result.environment.totalMemoryGb} GB RAM`,
+  );
+  console.log(
+    `fixture: ${result.fixture.fileCount} files | profiles=${result.fixture.profiles.join(", ")} | repeats=${result.fixture.repeats}`,
+  );
+
+  for (const profile of result.results) {
+    console.log(`\n[${profile.profile}] ${profile.label}`);
+    for (const scenario of profile.scenarios) {
+      const full = scenario.full.averageMs;
+      const light = scenario.light.averageMs;
+      const ratio = full > 0 ? Number((full / light).toFixed(1)) : 0;
+      console.log(
+        `  ${scenario.name}: full avg ${full}ms | light avg ${light}ms | ratio ${ratio}x`,
+      );
+    }
+  }
+}
+
+async function main() {
+  const { values } = parseArgs({
+    args: process.argv.slice(2),
+    options: {
+      files: { type: "string", default: "40" },
+      repeats: { type: "string", default: "5" },
+      profiles: { type: "string", default: "heavy,compact" },
+      json: { type: "boolean", default: false },
+      "baseline-ref": { type: "string", default: "origin/main" },
+    },
+    allowPositionals: false,
+  });
+
+  const fileCount = Number(values.files);
+  const repeats = Number(values.repeats);
+  const profiles = String(values.profiles)
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  const invalidProfiles = profiles.filter((profile) => !(profile in PROFILES));
+  if (!Number.isInteger(fileCount) || fileCount <= 0) {
+    throw new Error(`Invalid --files value: ${values.files}`);
+  }
+  if (!Number.isInteger(repeats) || repeats <= 0) {
+    throw new Error(`Invalid --repeats value: ${values.repeats}`);
+  }
+  if (invalidProfiles.length > 0) {
+    throw new Error(`Unknown profiles: ${invalidProfiles.join(", ")}`);
+  }
+
+  const rootDir = await mkdtemp(join(os.tmpdir(), "marmonitor-bench-codex-"));
+
+  try {
+    const results = [];
+    for (const profile of profiles) {
+      const runtimePaths = await createFixture(rootDir, fileCount, profile);
+      const coldFull = await measureColdScenario({
+        runtimePaths,
+        includeTokenUsage: true,
+        repeats,
+      });
+      const coldLight = await measureColdScenario({
+        runtimePaths,
+        includeTokenUsage: false,
+        repeats,
+      });
+      const warmFull = await measureWarmFileCacheScenario({
+        runtimePaths,
+        includeTokenUsage: true,
+        repeats,
+      });
+      const warmLight = await measureWarmFileCacheScenario({
+        runtimePaths,
+        includeTokenUsage: false,
+        repeats,
+      });
+
+      results.push({
+        profile,
+        label: PROFILES[profile].label,
+        scenarios: [
+          {
+            name: "cold_empty_caches",
+            full: coldFull,
+            light: coldLight,
+          },
+          {
+            name: "warm_file_cache",
+            full: warmFull,
+            light: warmLight,
+          },
+        ],
+      });
+    }
+
+    const summary = {
+      environment: {
+        currentCommit: await getGitCommit("HEAD"),
+        baselineCommit: await getGitCommit(String(values["baseline-ref"])),
+        node: process.version,
+        platform: process.platform,
+        arch: process.arch,
+        cpuModel: os.cpus()[0]?.model ?? "unknown",
+        logicalCpuCount: os.cpus().length,
+        totalMemoryGb: Number((os.totalmem() / 1024 ** 3).toFixed(1)),
+      },
+      fixture: {
+        fileCount,
+        repeats,
+        profiles,
+      },
+      results,
+    };
+
+    if (values.json) {
+      console.log(JSON.stringify(summary, null, 2));
+      return;
+    }
+
+    printHumanSummary(summary);
+    console.log("\nUse --json for machine-readable output.");
+  } finally {
+    resetCodexCaches();
+    await rm(rootDir, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/scripts/bench-statusline-live.mjs
+++ b/scripts/bench-statusline-live.mjs
@@ -1,0 +1,282 @@
+#!/usr/bin/env node
+
+import { execFile, spawn } from "node:child_process";
+import { mkdir, readdir, rm, unlink } from "node:fs/promises";
+import os from "node:os";
+import { dirname, join } from "node:path";
+import { performance } from "node:perf_hooks";
+import { fileURLToPath } from "node:url";
+import { parseArgs, promisify } from "node:util";
+
+import { loadConfig } from "../dist/config/index.js";
+
+const execFileAsync = promisify(execFile);
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const binPath = join(repoRoot, "bin", "marmonitor.js");
+const cacheRoot = join(os.tmpdir(), "marmonitor");
+
+function roundMs(value) {
+  return Number(value.toFixed(1));
+}
+
+async function getGitValue(args) {
+  try {
+    const { stdout } = await execFileAsync("git", args, {
+      cwd: repoRoot,
+      encoding: "utf8",
+    });
+    return stdout.trim();
+  } catch {
+    return undefined;
+  }
+}
+
+async function getTmuxMetric(args) {
+  try {
+    const { stdout } = await execFileAsync("tmux", args, {
+      cwd: repoRoot,
+      encoding: "utf8",
+    });
+    return {
+      items: stdout
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean),
+      error: undefined,
+    };
+  } catch {
+    return {
+      items: [],
+      error: "tmux unavailable from current execution context",
+    };
+  }
+}
+
+function pickStep(perf, label, step) {
+  return perf[label]?.steps?.[step];
+}
+
+function parsePerf(stderr, durationMs) {
+  const result = {
+    realMs: roundMs(durationMs),
+    perf: {},
+  };
+  const lines = stderr
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  for (const line of lines) {
+    if (!line.startsWith("MARMONITOR_PERF ")) continue;
+    const payload = JSON.parse(line.slice("MARMONITOR_PERF ".length));
+    result.perf[payload.label] = {
+      totalMs: payload.totalMs,
+      steps: Object.fromEntries((payload.steps ?? []).map((step) => [step.step, step.totalMs])),
+    };
+  }
+
+  return {
+    realMs: result.realMs,
+    snapshotMs: pickStep(result.perf, "snapshot", "getAgentsSnapshot"),
+    scanMs: pickStep(result.perf, "snapshot", "scanAgents"),
+    psListMs: pickStep(result.perf, "scanAgents", "ps_list"),
+    pidusageMs: pickStep(result.perf, "scanAgents", "pidusage"),
+    buildSessionsMs: pickStep(result.perf, "scanAgents", "build_sessions"),
+    lsofMs: pickStep(result.perf, "process", "lsof"),
+    psLstartMs: pickStep(result.perf, "process", "ps_lstart"),
+    stdoutMs: pickStep(result.perf, "stdout_heuristic", "detectCliStdoutPhase"),
+    tmuxResolveMs: pickStep(result.perf, "tmux", "resolve_jump_target"),
+    tmuxCaptureMs: pickStep(result.perf, "tmux", "capture_pane"),
+    renderMs: pickStep(result.perf, "output", "renderStatusline"),
+  };
+}
+
+async function runMarmonitor(args, env = {}) {
+  return await new Promise((resolve, reject) => {
+    const startedAt = performance.now();
+    const child = spawn(process.execPath, [binPath, ...args], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        ...env,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+
+    child.on("error", reject);
+    child.on("close", (code) => {
+      const durationMs = performance.now() - startedAt;
+      if (code !== 0) {
+        reject(new Error(stderr || `marmonitor exited with code ${code}`));
+        return;
+      }
+      resolve({
+        stdout,
+        stderr,
+        durationMs,
+      });
+    });
+  });
+}
+
+async function clearAllCaches() {
+  await rm(cacheRoot, { recursive: true, force: true });
+  await mkdir(cacheRoot, { recursive: true });
+}
+
+async function clearSnapshotArtifacts() {
+  try {
+    const entries = await readdir(cacheRoot);
+    await Promise.all(
+      entries
+        .filter((entry) => entry.startsWith("snapshot-") || entry.startsWith("statusline-"))
+        .map((entry) => unlink(join(cacheRoot, entry))),
+    );
+  } catch {
+    // best effort only
+  }
+}
+
+async function collectAgentCount(configPath) {
+  try {
+    const { stdout } = await runMarmonitor(
+      ["status", "--json", ...(configPath ? ["--config", configPath] : [])],
+      {},
+    );
+    const parsed = JSON.parse(stdout);
+    const count = Array.isArray(parsed)
+      ? parsed.length
+      : Array.isArray(parsed?.agents)
+        ? parsed.agents.length
+        : undefined;
+    return {
+      count,
+      error: count === undefined ? "status --json returned an unknown payload shape" : undefined,
+    };
+  } catch {
+    return {
+      count: undefined,
+      error: "status --json collection failed",
+    };
+  }
+}
+
+function printHumanSummary(summary) {
+  console.log("Statusline live benchmark");
+  console.log(`current: ${summary.environment.currentCommit ?? "(unknown)"}`);
+  if (summary.environment.baselineCommit) {
+    console.log(`baseline: ${summary.environment.baselineCommit}`);
+  }
+  console.log(
+    `host: ${summary.environment.cpuModel} | ${summary.environment.logicalCpuCount} logical CPU | ${summary.environment.totalMemoryGb} GB RAM`,
+  );
+  console.log(
+    `tmux: ${summary.environment.tmuxSessionCount ?? "unavailable"} sessions | ${summary.environment.tmuxPaneCount ?? "unavailable"} panes | agents=${summary.environment.agentCount ?? "unknown"}`,
+  );
+  if (summary.environment.tmuxError) {
+    console.log(`tmux access: ${summary.environment.tmuxError}`);
+  }
+  console.log(
+    `ttl: snapshot=${summary.environment.snapshotTtlMs}ms statusline=${summary.environment.statuslineTtlMs}ms stdout=${summary.environment.stdoutHeuristicTtlMs}ms`,
+  );
+  console.log(`cold: ${summary.measurements.cold.realMs}ms`);
+  console.log(`warm: ${summary.measurements.warm.realMs}ms`);
+  for (const [index, measurement] of summary.measurements.forcedMiss.entries()) {
+    console.log(
+      `forced-miss #${index + 1}: ${measurement.realMs}ms (pidusage=${measurement.pidusageMs ?? "n/a"}ms, ps_list=${measurement.psListMs ?? "n/a"}ms)`,
+    );
+  }
+  console.log("\nUse --json for machine-readable output.");
+}
+
+async function main() {
+  const { values } = parseArgs({
+    args: process.argv.slice(2),
+    options: {
+      format: { type: "string", default: "compact" },
+      width: { type: "string" },
+      config: { type: "string" },
+      json: { type: "boolean", default: false },
+      "forced-runs": { type: "string", default: "2" },
+      "baseline-ref": { type: "string", default: "origin/main" },
+    },
+    allowPositionals: false,
+  });
+
+  const forcedRuns = Number(values["forced-runs"]);
+  if (!Number.isInteger(forcedRuns) || forcedRuns <= 0) {
+    throw new Error(`Invalid --forced-runs value: ${values["forced-runs"]}`);
+  }
+
+  const configPath = values.config ? String(values.config) : undefined;
+  const config = await loadConfig(configPath);
+  const statuslineArgs = [
+    "--statusline",
+    "--statusline-format",
+    String(values.format),
+    ...(values.width ? ["--width", String(values.width)] : []),
+    ...(configPath ? ["--config", configPath] : []),
+  ];
+
+  await clearAllCaches();
+  const cold = await runMarmonitor(statuslineArgs, { MARMONITOR_PERF: "1" });
+  const warm = await runMarmonitor(statuslineArgs, { MARMONITOR_PERF: "1" });
+
+  const forcedMiss = [];
+  for (let i = 0; i < forcedRuns; i += 1) {
+    await clearSnapshotArtifacts();
+    const measurement = await runMarmonitor(statuslineArgs, { MARMONITOR_PERF: "1" });
+    forcedMiss.push(parsePerf(measurement.stderr, measurement.durationMs));
+  }
+
+  const tmuxSessions = await getTmuxMetric(["ls"]);
+  const tmuxPanes = await getTmuxMetric(["list-panes", "-a"]);
+  const agentCount = await collectAgentCount(configPath);
+
+  const summary = {
+    environment: {
+      currentCommit: await getGitValue(["rev-parse", "HEAD"]),
+      baselineCommit: await getGitValue(["rev-parse", String(values["baseline-ref"])]),
+      node: process.version,
+      platform: process.platform,
+      arch: process.arch,
+      cpuModel: os.cpus()[0]?.model ?? "unknown",
+      logicalCpuCount: os.cpus().length,
+      totalMemoryGb: Number((os.totalmem() / 1024 ** 3).toFixed(1)),
+      tmuxSessionCount: tmuxSessions.error ? null : tmuxSessions.items.length,
+      tmuxPaneCount: tmuxPanes.error ? null : tmuxPanes.items.length,
+      tmuxError: tmuxSessions.error ?? tmuxPanes.error,
+      agentCount: agentCount.count ?? null,
+      agentCountError: agentCount.error,
+      snapshotTtlMs: config.performance.snapshotTtlMs,
+      statuslineTtlMs: config.performance.statuslineTtlMs,
+      stdoutHeuristicTtlMs: config.performance.stdoutHeuristicTtlMs,
+    },
+    measurements: {
+      cold: parsePerf(cold.stderr, cold.durationMs),
+      warm: parsePerf(warm.stderr, warm.durationMs),
+      forcedMiss,
+    },
+  };
+
+  if (values.json) {
+    console.log(JSON.stringify(summary, null, 2));
+    return;
+  }
+
+  printHumanSummary(summary);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -535,6 +535,75 @@ async function writeCachedSnapshot(
   });
 }
 
+type SnapshotRequestContext = {
+  enrichmentMode: "full" | "light";
+  showDead: boolean;
+  ttlMs: number;
+  useCache: boolean;
+};
+
+type SnapshotScanOptions = {
+  includeTokenUsage?: boolean;
+  includeStdoutHeuristic?: boolean;
+  useSharedRuntimeSnapshots?: boolean;
+};
+
+async function readFreshSnapshotIfAvailable(
+  context: SnapshotRequestContext,
+): Promise<AgentSession[] | undefined> {
+  if (!context.useCache) return undefined;
+  return await readCachedSnapshot(context.enrichmentMode, context.showDead, context.ttlMs);
+}
+
+async function acquireSnapshotRefreshLockWithPolling(
+  context: SnapshotRequestContext,
+): Promise<boolean> {
+  if (!context.useCache) return true;
+
+  let acquired = false;
+  let lockUnavailable = false;
+
+  while (!acquired && !lockUnavailable) {
+    const cached = await readFreshSnapshotIfAvailable(context);
+    if (cached) return false;
+
+    try {
+      acquired = await profileAsync("snapshot", "acquireSnapshotRefreshLock", () =>
+        acquireSnapshotRefreshLock(context.enrichmentMode, context.showDead),
+      );
+    } catch {
+      lockUnavailable = true;
+    }
+
+    if (!acquired && !lockUnavailable) {
+      await sleep(SNAPSHOT_LOCK_POLL_MS);
+    }
+  }
+
+  return acquired;
+}
+
+async function scanAndPersistSnapshot(
+  config: Awaited<ReturnType<typeof loadConfig>>,
+  context: SnapshotRequestContext,
+  options: SnapshotScanOptions,
+): Promise<AgentSession[]> {
+  const agents = await profileAsync("snapshot", "scanAgents", () =>
+    scanAgents(config, {
+      enrichmentMode: context.enrichmentMode,
+      includeTokenUsage: options.includeTokenUsage,
+      includeStdoutHeuristic: options.includeStdoutHeuristic,
+      useSharedRuntimeSnapshots: options.useSharedRuntimeSnapshots,
+    }),
+  );
+
+  if (context.useCache) {
+    await writeCachedSnapshot(context.enrichmentMode, context.showDead, agents);
+  }
+
+  return agents;
+}
+
 async function getAgentsSnapshot(
   config: Awaited<ReturnType<typeof loadConfig>>,
   options: {
@@ -545,55 +614,28 @@ async function getAgentsSnapshot(
     useSharedRuntimeSnapshots?: boolean;
   } = {},
 ): Promise<AgentSession[]> {
-  const enrichmentMode = options.enrichmentMode ?? "full";
   const ttlMs = options.ttlMs ?? config.performance.snapshotTtlMs;
-  const useCache = ttlMs > 0;
+  const context: SnapshotRequestContext = {
+    enrichmentMode: options.enrichmentMode ?? "full",
+    showDead: config.display.showDead,
+    ttlMs,
+    useCache: ttlMs > 0,
+  };
 
   return await profileAsync("snapshot", "getAgentsSnapshot", async () => {
-    if (useCache) {
-      const cached = await readCachedSnapshot(enrichmentMode, config.display.showDead, ttlMs);
-      if (cached) return cached;
-    }
+    const cachedBeforeLock = await readFreshSnapshotIfAvailable(context);
+    if (cachedBeforeLock) return cachedBeforeLock;
 
-    let acquired = !useCache;
-    let lockUnavailable = false;
-    while (useCache && !acquired && !lockUnavailable) {
-      const cached = await readCachedSnapshot(enrichmentMode, config.display.showDead, ttlMs);
-      if (cached) return cached;
-
-      try {
-        acquired = await profileAsync("snapshot", "acquireSnapshotRefreshLock", () =>
-          acquireSnapshotRefreshLock(enrichmentMode, config.display.showDead),
-        );
-      } catch {
-        lockUnavailable = true;
-      }
-      if (!acquired) {
-        await sleep(SNAPSHOT_LOCK_POLL_MS);
-      }
-    }
+    const acquired = await acquireSnapshotRefreshLockWithPolling(context);
 
     try {
-      if (useCache) {
-        const cached = await readCachedSnapshot(enrichmentMode, config.display.showDead, ttlMs);
-        if (cached) return cached;
-      }
+      const cachedAfterLock = await readFreshSnapshotIfAvailable(context);
+      if (cachedAfterLock) return cachedAfterLock;
 
-      const agents = await profileAsync("snapshot", "scanAgents", () =>
-        scanAgents(config, {
-          enrichmentMode,
-          includeTokenUsage: options.includeTokenUsage,
-          includeStdoutHeuristic: options.includeStdoutHeuristic,
-          useSharedRuntimeSnapshots: options.useSharedRuntimeSnapshots,
-        }),
-      );
-      if (useCache) {
-        await writeCachedSnapshot(enrichmentMode, config.display.showDead, agents);
-      }
-      return agents;
+      return await scanAndPersistSnapshot(config, context, options);
     } finally {
-      if (useCache && acquired) {
-        await releaseSnapshotRefreshLock(enrichmentMode, config.display.showDead);
+      if (context.useCache && acquired) {
+        await releaseSnapshotRefreshLock(context.enrichmentMode, context.showDead);
       }
     }
   });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,6 +41,7 @@ import {
   releaseSnapshotRefreshLock,
   snapshotCacheFile,
   statuslineCacheFile,
+  writeCacheFileAtomically,
 } from "./snapshot-cache.js";
 import { captureTmuxPaneOutput, jumpToAgent, resolveTmuxJumpTarget } from "./tmux/index.js";
 import type { AgentSession } from "./types.js";
@@ -494,7 +495,7 @@ async function writeCachedStatusline(
     const path = statuslineCacheFile(format, attentionLimit, width);
     try {
       await mkdir(join(tmpdir(), "marmonitor"), { recursive: true });
-      await writeFile(path, value, "utf-8");
+      await writeCacheFileAtomically(path, value);
     } catch {
       // cache failures must never break statusline rendering
     }
@@ -527,7 +528,7 @@ async function writeCachedSnapshot(
     const path = snapshotCacheFile(enrichmentMode, showDead);
     try {
       await mkdir(join(tmpdir(), "marmonitor"), { recursive: true });
-      await writeFile(path, JSON.stringify(agents), "utf-8");
+      await writeCacheFileAtomically(path, JSON.stringify(agents));
     } catch {
       // snapshot cache failures must never break command execution
     }
@@ -541,6 +542,7 @@ async function getAgentsSnapshot(
     ttlMs?: number;
     includeTokenUsage?: boolean;
     includeStdoutHeuristic?: boolean;
+    useSharedRuntimeSnapshots?: boolean;
   } = {},
 ): Promise<AgentSession[]> {
   const enrichmentMode = options.enrichmentMode ?? "full";
@@ -582,6 +584,7 @@ async function getAgentsSnapshot(
           enrichmentMode,
           includeTokenUsage: options.includeTokenUsage,
           includeStdoutHeuristic: options.includeStdoutHeuristic,
+          useSharedRuntimeSnapshots: options.useSharedRuntimeSnapshots,
         }),
       );
       if (useCache) {
@@ -633,6 +636,7 @@ program
         const agents = await getAgentsSnapshot(config, {
           enrichmentMode: "light",
           includeStdoutHeuristic: true,
+          useSharedRuntimeSnapshots: true,
         });
         const rendered = await renderStatusline(
           agents,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ import {
   getDefaultConfigPath,
   loadConfig,
   resolveConfigPath as resolveLoadedConfigPath,
+  resolveRuntimeDataPaths,
 } from "./config/index.js";
 import { evaluateGuard, formatGuardOutput, parseHookEvent, readStdin } from "./guard/index.js";
 import {
@@ -28,12 +29,19 @@ import {
   renderUnavailableStatusline,
 } from "./output/index.js";
 import { selectJumpAttentionItem, selectUnmatchedTargets } from "./output/utils.js";
+import { profileAsync } from "./perf.js";
 import { TERMINAL_RESTORE_SEQUENCE, formatProcessFailure } from "./process-safety.js";
 import { detectClaudePhase } from "./scanner/claude.js";
 import { detectCodexPhase, indexCodexSessions, matchCodexSession } from "./scanner/codex.js";
 import { parseGeminiSession } from "./scanner/gemini.js";
 import { scanAgents } from "./scanner/index.js";
 import { detectCliStdoutPhase } from "./scanner/status.js";
+import {
+  acquireSnapshotRefreshLock,
+  releaseSnapshotRefreshLock,
+  snapshotCacheFile,
+  statuslineCacheFile,
+} from "./snapshot-cache.js";
 import { captureTmuxPaneOutput, jumpToAgent, resolveTmuxJumpTarget } from "./tmux/index.js";
 import type { AgentSession } from "./types.js";
 import { VERSION } from "./version.js";
@@ -456,18 +464,7 @@ function resolveAttentionLimit(
   return Math.min(Math.max(Math.floor(fallback), 1), 10);
 }
 
-function statuslineCacheFile(format: string, attentionLimit: number, width?: number): string {
-  const widthKey = width && width > 0 ? String(width) : "auto";
-  return join(tmpdir(), "marmonitor", `statusline-${format}-${attentionLimit}-${widthKey}.txt`);
-}
-
-function snapshotCacheFile(enrichmentMode: "full" | "light", showDead: boolean): string {
-  return join(
-    tmpdir(),
-    "marmonitor",
-    `snapshot-${enrichmentMode}-${showDead ? "dead" : "alive"}.json`,
-  );
-}
+const SNAPSHOT_LOCK_POLL_MS = 150;
 
 async function readCachedStatusline(
   format: string,
@@ -475,14 +472,16 @@ async function readCachedStatusline(
   width: number | undefined,
   ttlMs: number,
 ): Promise<string | undefined> {
-  const path = statuslineCacheFile(format, attentionLimit, width);
-  try {
-    const fileStat = await stat(path);
-    if (Date.now() - fileStat.mtimeMs > ttlMs) return undefined;
-    return (await readFile(path, "utf-8")).trimEnd();
-  } catch {
-    return undefined;
-  }
+  return await profileAsync("cli", "readCachedStatusline", async () => {
+    const path = statuslineCacheFile(format, attentionLimit, width);
+    try {
+      const fileStat = await stat(path);
+      if (Date.now() - fileStat.mtimeMs > ttlMs) return undefined;
+      return (await readFile(path, "utf-8")).trimEnd();
+    } catch {
+      return undefined;
+    }
+  });
 }
 
 async function writeCachedStatusline(
@@ -491,13 +490,15 @@ async function writeCachedStatusline(
   width: number | undefined,
   value: string,
 ): Promise<void> {
-  const path = statuslineCacheFile(format, attentionLimit, width);
-  try {
-    await mkdir(join(tmpdir(), "marmonitor"), { recursive: true });
-    await writeFile(path, value, "utf-8");
-  } catch {
-    // cache failures must never break statusline rendering
-  }
+  await profileAsync("cli", "writeCachedStatusline", async () => {
+    const path = statuslineCacheFile(format, attentionLimit, width);
+    try {
+      await mkdir(join(tmpdir(), "marmonitor"), { recursive: true });
+      await writeFile(path, value, "utf-8");
+    } catch {
+      // cache failures must never break statusline rendering
+    }
+  });
 }
 
 async function readCachedSnapshot(
@@ -505,14 +506,16 @@ async function readCachedSnapshot(
   showDead: boolean,
   ttlMs: number,
 ): Promise<AgentSession[] | undefined> {
-  const path = snapshotCacheFile(enrichmentMode, showDead);
-  try {
-    const fileStat = await stat(path);
-    if (Date.now() - fileStat.mtimeMs > ttlMs) return undefined;
-    return JSON.parse(await readFile(path, "utf-8")) as AgentSession[];
-  } catch {
-    return undefined;
-  }
+  return await profileAsync("snapshot", "readCachedSnapshot", async () => {
+    const path = snapshotCacheFile(enrichmentMode, showDead);
+    try {
+      const fileStat = await stat(path);
+      if (Date.now() - fileStat.mtimeMs > ttlMs) return undefined;
+      return JSON.parse(await readFile(path, "utf-8")) as AgentSession[];
+    } catch {
+      return undefined;
+    }
+  });
 }
 
 async function writeCachedSnapshot(
@@ -520,33 +523,77 @@ async function writeCachedSnapshot(
   showDead: boolean,
   agents: AgentSession[],
 ): Promise<void> {
-  const path = snapshotCacheFile(enrichmentMode, showDead);
-  try {
-    await mkdir(join(tmpdir(), "marmonitor"), { recursive: true });
-    await writeFile(path, JSON.stringify(agents), "utf-8");
-  } catch {
-    // snapshot cache failures must never break command execution
-  }
+  await profileAsync("snapshot", "writeCachedSnapshot", async () => {
+    const path = snapshotCacheFile(enrichmentMode, showDead);
+    try {
+      await mkdir(join(tmpdir(), "marmonitor"), { recursive: true });
+      await writeFile(path, JSON.stringify(agents), "utf-8");
+    } catch {
+      // snapshot cache failures must never break command execution
+    }
+  });
 }
 
 async function getAgentsSnapshot(
   config: Awaited<ReturnType<typeof loadConfig>>,
-  options: { enrichmentMode?: "full" | "light"; ttlMs?: number } = {},
+  options: {
+    enrichmentMode?: "full" | "light";
+    ttlMs?: number;
+    includeTokenUsage?: boolean;
+    includeStdoutHeuristic?: boolean;
+  } = {},
 ): Promise<AgentSession[]> {
   const enrichmentMode = options.enrichmentMode ?? "full";
   const ttlMs = options.ttlMs ?? config.performance.snapshotTtlMs;
   const useCache = ttlMs > 0;
 
-  if (useCache) {
-    const cached = await readCachedSnapshot(enrichmentMode, config.display.showDead, ttlMs);
-    if (cached) return cached;
-  }
+  return await profileAsync("snapshot", "getAgentsSnapshot", async () => {
+    if (useCache) {
+      const cached = await readCachedSnapshot(enrichmentMode, config.display.showDead, ttlMs);
+      if (cached) return cached;
+    }
 
-  const agents = await scanAgents(config, { enrichmentMode });
-  if (useCache) {
-    await writeCachedSnapshot(enrichmentMode, config.display.showDead, agents);
-  }
-  return agents;
+    let acquired = !useCache;
+    let lockUnavailable = false;
+    while (useCache && !acquired && !lockUnavailable) {
+      const cached = await readCachedSnapshot(enrichmentMode, config.display.showDead, ttlMs);
+      if (cached) return cached;
+
+      try {
+        acquired = await profileAsync("snapshot", "acquireSnapshotRefreshLock", () =>
+          acquireSnapshotRefreshLock(enrichmentMode, config.display.showDead),
+        );
+      } catch {
+        lockUnavailable = true;
+      }
+      if (!acquired) {
+        await sleep(SNAPSHOT_LOCK_POLL_MS);
+      }
+    }
+
+    try {
+      if (useCache) {
+        const cached = await readCachedSnapshot(enrichmentMode, config.display.showDead, ttlMs);
+        if (cached) return cached;
+      }
+
+      const agents = await profileAsync("snapshot", "scanAgents", () =>
+        scanAgents(config, {
+          enrichmentMode,
+          includeTokenUsage: options.includeTokenUsage,
+          includeStdoutHeuristic: options.includeStdoutHeuristic,
+        }),
+      );
+      if (useCache) {
+        await writeCachedSnapshot(enrichmentMode, config.display.showDead, agents);
+      }
+      return agents;
+    } finally {
+      if (useCache && acquired) {
+        await releaseSnapshotRefreshLock(enrichmentMode, config.display.showDead);
+      }
+    }
+  });
 }
 
 program
@@ -583,7 +630,10 @@ program
           console.log(cached);
           return;
         }
-        const agents = await getAgentsSnapshot(config, { enrichmentMode: "full" });
+        const agents = await getAgentsSnapshot(config, {
+          enrichmentMode: "light",
+          includeStdoutHeuristic: true,
+        });
         const rendered = await renderStatusline(
           agents,
           opts.statuslineFormat,
@@ -641,7 +691,10 @@ program
   .option("--config <path>", "Path to settings.json")
   .action(async (opts) => {
     const config = await loadConfig(resolveConfigPath(opts));
-    const agents = await getAgentsSnapshot(config, { enrichmentMode: "full" });
+    const agents = await getAgentsSnapshot(config, {
+      enrichmentMode: "light",
+      includeStdoutHeuristic: true,
+    });
     const limit = resolveAttentionLimit(opts, config.display.attentionLimit);
     const interactiveLimit = resolveAttentionLimit(opts, config.display.attentionLimit, true);
     if (opts.interactive && opts.json) {
@@ -715,10 +768,14 @@ program
 
     const lines = Math.max(Number.parseInt(opts.lines, 10) || 40, 10);
     const config = await loadConfig(resolveConfigPath(opts));
+    const runtimePaths = resolveRuntimeDataPaths(config);
 
     let agents: AgentSession[];
     try {
-      agents = await scanAgents(config, { enrichmentMode: "full" });
+      agents = await scanAgents(config, {
+        enrichmentMode: "light",
+        includeStdoutHeuristic: true,
+      });
     } catch (error) {
       const payload = {
         found: false,
@@ -761,7 +818,10 @@ program
       sessionLastActivityAt = gemini.lastActivityAt;
       sessionLastResponseAt = gemini.lastResponseAt;
     } else if (agent.agentName === "Codex") {
-      const codexSessions = await indexCodexSessions(config);
+      const codexSessions = await indexCodexSessions(config, {
+        includeTokenUsage: false,
+        runtimePaths,
+      });
       const matched = matchCodexSession(agent.cwd, agent.startedAt, codexSessions);
       sessionPhase = await detectCodexPhase(matched?.filePath, config);
       sessionSourceFile = matched?.filePath;
@@ -771,6 +831,7 @@ program
         agent.cwd,
         agent.startedAt,
         config,
+        runtimePaths,
       );
       sessionPhase = phaseResult.phase;
       sessionLastActivityAt = phaseResult.lastActivityAt;
@@ -832,7 +893,10 @@ program
   .option("--config <path>", "Path to settings.json")
   .action(async (opts) => {
     const config = await loadConfig(resolveConfigPath(opts));
-    const agents = await getAgentsSnapshot(config, { enrichmentMode: "full" });
+    const agents = await getAgentsSnapshot(config, {
+      enrichmentMode: "light",
+      includeStdoutHeuristic: true,
+    });
     const useAttention = Boolean(opts.attention);
     const useAttentionIndex = typeof opts.attentionIndex === "string";
     const usePid = typeof opts.pid === "string";
@@ -928,6 +992,7 @@ program
       const needsHeavy = lastHeavyAt === 0 || now - lastHeavyAt >= detailMs;
       const agents = await scanAgents(config, {
         enrichmentMode: needsHeavy ? "full" : "light",
+        includeStdoutHeuristic: true,
       });
       if (needsHeavy) lastHeavyAt = now;
       clearScreen();
@@ -963,6 +1028,7 @@ program
       const needsHeavy = lastHeavyAt === 0 || now - lastHeavyAt >= detailIntervalMs;
       const agents = await scanAgents(config, {
         enrichmentMode: needsHeavy ? "full" : "light",
+        includeStdoutHeuristic: true,
       });
       if (needsHeavy) lastHeavyAt = now;
       clearScreen();
@@ -984,7 +1050,10 @@ program
   .option("--pid <pid...>", "Only include specific unmatched PID(s)")
   .action(async (opts) => {
     const config = await loadConfig(resolveConfigPath(opts));
-    const agents = await scanAgents(config);
+    const agents = await scanAgents(config, {
+      enrichmentMode: "light",
+      includeStdoutHeuristic: true,
+    });
     const selectedPids = Array.isArray(opts.pid)
       ? opts.pid
           .map((value: string) => Number.parseInt(value, 10))

--- a/src/output/index.ts
+++ b/src/output/index.ts
@@ -1,5 +1,6 @@
 import chalk from "chalk";
 import * as si from "systeminformation";
+import { profileAsync } from "../perf.js";
 import type { TmuxJumpResult } from "../tmux/index.js";
 import type {
   AgentSession,
@@ -25,20 +26,22 @@ import {
 
 /** Collect system resource info */
 export async function getSystemInfo(): Promise<SystemInfo> {
-  const [cpu, mem, battery] = await Promise.all([si.currentLoad(), si.mem(), si.battery()]);
+  return await profileAsync("output", "getSystemInfo", async () => {
+    const [cpu, mem, battery] = await Promise.all([si.currentLoad(), si.mem(), si.battery()]);
 
-  const info: SystemInfo = {
-    cpuPercent: Math.round(cpu.currentLoad * 10) / 10,
-    memoryUsedGb: Math.round((mem.used / 1024 ** 3) * 10) / 10,
-    memoryTotalGb: Math.round(mem.total / 1024 ** 3),
-  };
+    const info: SystemInfo = {
+      cpuPercent: Math.round(cpu.currentLoad * 10) / 10,
+      memoryUsedGb: Math.round((mem.used / 1024 ** 3) * 10) / 10,
+      memoryTotalGb: Math.round(mem.total / 1024 ** 3),
+    };
 
-  if (battery.hasBattery) {
-    info.batteryPercent = battery.percent;
-    info.batteryCharging = battery.isCharging;
-  }
+    if (battery.hasBattery) {
+      info.batteryPercent = battery.percent;
+      info.batteryCharging = battery.isCharging;
+    }
 
-  return info;
+    return info;
+  });
 }
 
 // shortenPath, formatElapsed, formatTokens imported from ./utils.js
@@ -506,55 +509,57 @@ export async function renderStatusline(
   attentionLimit = 5,
   width?: number,
 ): Promise<string> {
-  const alive = agents.filter((a) => a.status !== "Dead" && a.status !== "Unmatched");
-  const unmatched = agents.filter((a) => a.status === "Unmatched");
+  return await profileAsync("output", "renderStatusline", async () => {
+    const alive = agents.filter((a) => a.status !== "Dead" && a.status !== "Unmatched");
+    const unmatched = agents.filter((a) => a.status === "Unmatched");
 
-  if (alive.length === 0) {
-    return format === "wezterm-pills" ? renderUnavailableStatusline(format) : "AI:0";
-  }
+    if (alive.length === 0) {
+      return format === "wezterm-pills" ? renderUnavailableStatusline(format) : "AI:0";
+    }
 
-  const sys = await getSystemInfo();
-  const waitingCount = alive.filter((a) => a.phase === "permission").length;
-  const stalledCount = alive.filter((a) => a.status === "Stalled").length;
-  const activeCount = alive.filter((a) => a.status === "Active").length;
-  const highCpuCount = alive.filter((a) => a.cpuPercent >= 10).length;
-  const thinkingCount = alive.filter((a) => a.phase === "thinking").length;
-  const toolCount = alive.filter((a) => a.phase === "tool").length;
-  const claudeCount = alive.filter((a) => a.agentName === "Claude Code").length;
-  const codexCount = alive.filter((a) => a.agentName === "Codex").length;
-  const geminiCount = alive.filter((a) => a.agentName === "Gemini").length;
-  const snapshot = {
-    aliveCount: alive.length,
-    waitingCount,
-    riskCount: 0,
-    stalledCount,
-    unmatchedCount: unmatched.length,
-    activeCount,
-    highCpuCount,
-    thinkingCount,
-    toolCount,
-    claudeCount,
-    codexCount,
-    geminiCount,
-    cpuPercent: sys.cpuPercent,
-    memoryUsedGb: sys.memoryUsedGb,
-  };
+    const sys = await getSystemInfo();
+    const waitingCount = alive.filter((a) => a.phase === "permission").length;
+    const stalledCount = alive.filter((a) => a.status === "Stalled").length;
+    const activeCount = alive.filter((a) => a.status === "Active").length;
+    const highCpuCount = alive.filter((a) => a.cpuPercent >= 10).length;
+    const thinkingCount = alive.filter((a) => a.phase === "thinking").length;
+    const toolCount = alive.filter((a) => a.phase === "tool").length;
+    const claudeCount = alive.filter((a) => a.agentName === "Claude Code").length;
+    const codexCount = alive.filter((a) => a.agentName === "Codex").length;
+    const geminiCount = alive.filter((a) => a.agentName === "Gemini").length;
+    const snapshot = {
+      aliveCount: alive.length,
+      waitingCount,
+      riskCount: 0,
+      stalledCount,
+      unmatchedCount: unmatched.length,
+      activeCount,
+      highCpuCount,
+      thinkingCount,
+      toolCount,
+      claudeCount,
+      codexCount,
+      geminiCount,
+      cpuPercent: sys.cpuPercent,
+      memoryUsedGb: sys.memoryUsedGb,
+    };
 
-  if (format === "tmux-badges") {
-    const focusText = buildTmuxAttentionPills(
-      buildJumpAttentionItems(agents),
-      attentionLimit,
-      width,
-    );
-    return buildTmuxBadgeBar(snapshot, focusText);
-  }
+    if (format === "tmux-badges") {
+      const focusText = buildTmuxAttentionPills(
+        buildJumpAttentionItems(agents),
+        attentionLimit,
+        width,
+      );
+      return buildTmuxBadgeBar(snapshot, focusText);
+    }
 
-  if (format === "wezterm-pills") {
-    const focusText = buildAttentionFocusText(buildAttentionItems(agents), attentionLimit, width);
-    return serializeWeztermPills(snapshot, focusText);
-  }
+    if (format === "wezterm-pills") {
+      const focusText = buildAttentionFocusText(buildAttentionItems(agents), attentionLimit, width);
+      return serializeWeztermPills(snapshot, focusText);
+    }
 
-  return buildStatuslineSummary(snapshot, format);
+    return buildStatuslineSummary(snapshot, format);
+  });
 }
 
 /** Print one-line summary for tmux/terminal status bar */

--- a/src/perf.ts
+++ b/src/perf.ts
@@ -1,0 +1,123 @@
+import { performance } from "node:perf_hooks";
+
+type PerfStepStats = {
+  totalMs: number;
+  calls: number;
+};
+
+type PerfLabelStats = {
+  startedAtMs: number;
+  steps: Map<string, PerfStepStats>;
+};
+
+const PERF_ENABLED = (() => {
+  const value = process.env.MARMONITOR_PERF?.trim().toLowerCase();
+  return value === "1" || value === "true" || value === "json" || value === "on";
+})();
+
+const perfBuckets = new Map<string, PerfLabelStats>();
+let flushHookInstalled = false;
+
+function roundMs(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+function getBucket(label: string): PerfLabelStats {
+  const existing = perfBuckets.get(label);
+  if (existing) return existing;
+
+  const created: PerfLabelStats = {
+    startedAtMs: performance.now(),
+    steps: new Map(),
+  };
+  perfBuckets.set(label, created);
+  return created;
+}
+
+function record(label: string, step: string, elapsedMs: number): void {
+  const bucket = getBucket(label);
+  const entry = bucket.steps.get(step) ?? { totalMs: 0, calls: 0 };
+  entry.totalMs += elapsedMs;
+  entry.calls += 1;
+  bucket.steps.set(step, entry);
+}
+
+function flushPerf(): void {
+  if (!PERF_ENABLED || perfBuckets.size === 0) return;
+
+  const buckets = [...perfBuckets.entries()].sort(
+    (a, b) => bucketTotalMs(b[1]) - bucketTotalMs(a[1]),
+  );
+
+  for (const [label, bucket] of buckets) {
+    const totalMs = roundMs(performance.now() - bucket.startedAtMs);
+    const steps = [...bucket.steps.entries()]
+      .map(([step, stats]) => ({
+        step,
+        totalMs: roundMs(stats.totalMs),
+        calls: stats.calls,
+        avgMs: roundMs(stats.totalMs / stats.calls),
+      }))
+      .sort((a, b) => b.totalMs - a.totalMs || a.step.localeCompare(b.step));
+
+    process.stderr.write(
+      `MARMONITOR_PERF ${JSON.stringify({
+        label,
+        totalMs,
+        steps,
+      })}\n`,
+    );
+  }
+
+  perfBuckets.clear();
+}
+
+function bucketTotalMs(bucket: PerfLabelStats): number {
+  let total = 0;
+  for (const step of bucket.steps.values()) total += step.totalMs;
+  return total;
+}
+
+function installFlushHook(): void {
+  if (!PERF_ENABLED || flushHookInstalled) return;
+  flushHookInstalled = true;
+  process.once("beforeExit", flushPerf);
+  process.once("SIGINT", () => {
+    flushPerf();
+  });
+  process.once("SIGTERM", () => {
+    flushPerf();
+  });
+}
+
+export async function profileAsync<T>(
+  label: string,
+  step: string,
+  fn: () => Promise<T> | T,
+): Promise<T> {
+  if (!PERF_ENABLED) return await fn();
+
+  installFlushHook();
+  const startedAt = performance.now();
+  try {
+    return await fn();
+  } finally {
+    record(label, step, performance.now() - startedAt);
+  }
+}
+
+export function profileSync<T>(label: string, step: string, fn: () => T): T {
+  if (!PERF_ENABLED) return fn();
+
+  installFlushHook();
+  const startedAt = performance.now();
+  try {
+    return fn();
+  } finally {
+    record(label, step, performance.now() - startedAt);
+  }
+}
+
+export function isPerfEnabled(): boolean {
+  return PERF_ENABLED;
+}

--- a/src/scanner/cache.ts
+++ b/src/scanner/cache.ts
@@ -82,6 +82,7 @@ export const claudeProjectDirCache = new BoundedMap<string, string>(64);
 export const claudeTokenCache = new BoundedMap<string, FileTokenCacheEntry>(64);
 export const claudePhaseCache = new BoundedMap<string, PhaseCacheEntry>(64);
 export const codexPhaseCache = new BoundedMap<string, PhaseCacheEntry>(64);
+export const geminiProjectDirCache = new BoundedMap<string, string>(64);
 export const codexSessionFileCache = new BoundedMap<
   string,
   CodexSessionMeta & { mtimeMs?: number; size?: number }
@@ -95,13 +96,24 @@ export const sessionEnrichmentCache = new BoundedMap<string, Partial<AgentSessio
 
 // ─── Codex Index Cache ─────────────────────────────────────────────
 
-export let codexIndexCache:
-  | {
-      builtAt: number;
-      sessions: CodexSessionMeta[];
-    }
-  | undefined;
+export interface CodexIndexCacheEntry {
+  builtAt: number;
+  sessions: CodexSessionMeta[];
+}
 
-export function setCodexIndexCache(value: typeof codexIndexCache): void {
-  codexIndexCache = value;
+export const codexIndexCache = {
+  full: undefined as CodexIndexCacheEntry | undefined,
+  light: undefined as CodexIndexCacheEntry | undefined,
+};
+
+export function setCodexIndexCache(
+  value:
+    | {
+        full?: CodexIndexCacheEntry;
+        light?: CodexIndexCacheEntry;
+      }
+    | undefined,
+): void {
+  codexIndexCache.full = value?.full;
+  codexIndexCache.light = value?.light;
 }

--- a/src/scanner/cache.ts
+++ b/src/scanner/cache.ts
@@ -12,6 +12,7 @@ import { BoundedMap } from "./bounded-map.js";
 export const HOME = homedir();
 export const PROCESS_CWD_TTL_MS = 60_000;
 export const PROCESS_START_TTL_MS = 300_000;
+export const PROCESS_START_SHARED_TTL_MS = 60_000;
 export const CODEX_INDEX_TTL_MS = 30_000;
 export const CLAUDE_SESSION_MTIME_MATCH_SEC = 120;
 export const CLAUDE_SESSION_AMBIGUITY_GAP_SEC = 300;

--- a/src/scanner/claude.ts
+++ b/src/scanner/claude.ts
@@ -6,7 +6,7 @@ import { existsSync } from "node:fs";
 import { realpath as fsRealpath, open, readFile, readdir, stat } from "node:fs/promises";
 import { join } from "node:path";
 
-import type { MarmonitorConfig } from "../config/index.js";
+import type { MarmonitorConfig, RuntimeDataPaths } from "../config/index.js";
 import { resolveRuntimeDataPaths } from "../config/index.js";
 import {
   advanceJsonlCursor,
@@ -17,6 +17,7 @@ import {
   updatePhaseHistory,
   upsertSessionRegistryEntry,
 } from "../output/utils.js";
+import { profileAsync } from "../perf.js";
 import type { AgentSession, SessionPhase, TokenUsage } from "../types.js";
 import {
   CLAUDE_PHASE_RECENT_LINES,
@@ -30,13 +31,21 @@ import {
 } from "./cache.js";
 import type { PhaseResult } from "./cache.js";
 
-export function getClaudeProjectRoots(config?: MarmonitorConfig): string[] {
+export function getClaudeProjectRoots(
+  config?: MarmonitorConfig,
+  runtimePaths?: RuntimeDataPaths,
+): string[] {
+  if (runtimePaths) return runtimePaths.claudeProjects;
   return config
     ? resolveRuntimeDataPaths(config).claudeProjects
     : [join(HOME, ".claude", "projects")];
 }
 
-export function getClaudeSessionRoots(config?: MarmonitorConfig): string[] {
+export function getClaudeSessionRoots(
+  config?: MarmonitorConfig,
+  runtimePaths?: RuntimeDataPaths,
+): string[] {
+  if (runtimePaths) return runtimePaths.claudeSessions;
   return config
     ? resolveRuntimeDataPaths(config).claudeSessions
     : [join(HOME, ".claude", "sessions")];
@@ -50,78 +59,81 @@ export async function findClaudeProjectDir(
   cwd: string,
   sessionId?: string,
   config?: MarmonitorConfig,
+  runtimePaths?: RuntimeDataPaths,
 ): Promise<string | undefined> {
-  const projectRoots = getClaudeProjectRoots(config);
-  if (!projectRoots.some((projectsDir) => existsSync(projectsDir))) return undefined;
-  const cacheKey = `${cwd}::${sessionId ?? ""}`;
-  const cached = claudeProjectDirCache.get(cacheKey);
-  if (cached && projectRoots.some((projectsDir) => existsSync(join(projectsDir, cached)))) {
-    return cached;
-  }
-
-  // Claude Code encodes cwd by replacing both "/" and "." with "-"
-  const encodeCwd = (p: string) => p.replace(/[/.]/g, "-");
-
-  // 1st: realpath → encode → direct check
-  try {
-    const canonical = await fsRealpath(cwd).catch(() => cwd);
-    const encoded = encodeCwd(canonical);
-    for (const projectsDir of projectRoots) {
-      if (existsSync(join(projectsDir, encoded))) {
-        claudeProjectDirCache.set(cacheKey, encoded);
-        return encoded;
-      }
-    }
-  } catch {
-    // continue to fallback
-  }
-
-  // 2nd: raw cwd encode (without realpath)
-  const rawEncoded = encodeCwd(cwd);
-  for (const projectsDir of projectRoots) {
-    if (existsSync(join(projectsDir, rawEncoded))) {
-      claudeProjectDirCache.set(cacheKey, rawEncoded);
-      return rawEncoded;
-    }
-  }
-
-  // 3rd: fallback scan — find dir containing sessionId.jsonl
-  if (sessionId) {
-    const registeredPath = resolveSessionRegistryPath(claudeSessionRegistry, sessionId);
-    if (registeredPath && existsSync(registeredPath)) {
-      const parts = registeredPath.split("/");
-      const dir = parts.at(-2);
-      if (dir) {
-        claudeProjectDirCache.set(cacheKey, dir);
-        return dir;
-      }
+  return await profileAsync("claude", "findClaudeProjectDir", async () => {
+    const projectRoots = getClaudeProjectRoots(config, runtimePaths);
+    if (!projectRoots.some((projectsDir) => existsSync(projectsDir))) return undefined;
+    const cacheKey = `${cwd}::${sessionId ?? ""}`;
+    const cached = claudeProjectDirCache.get(cacheKey);
+    if (cached && projectRoots.some((projectsDir) => existsSync(join(projectsDir, cached)))) {
+      return cached;
     }
 
+    // Claude Code encodes cwd by replacing both "/" and "." with "-"
+    const encodeCwd = (p: string) => p.replace(/[/.]/g, "-");
+
+    // 1st: realpath → encode → direct check
     try {
+      const canonical = await fsRealpath(cwd).catch(() => cwd);
+      const encoded = encodeCwd(canonical);
       for (const projectsDir of projectRoots) {
-        if (!existsSync(projectsDir)) continue;
-        const dirs = await readdir(projectsDir);
-        for (const dir of dirs) {
-          const sessionFile = join(projectsDir, dir, `${sessionId}.jsonl`);
-          if (existsSync(sessionFile)) {
-            upsertSessionRegistryEntry(claudeSessionRegistry, {
-              filePath: sessionFile,
-              sessionId,
-              cwd,
-              firstSeenOffset: 0,
-              source: "claude",
-            });
-            claudeProjectDirCache.set(cacheKey, dir);
-            return dir;
-          }
+        if (existsSync(join(projectsDir, encoded))) {
+          claudeProjectDirCache.set(cacheKey, encoded);
+          return encoded;
         }
       }
     } catch {
-      // scan failed
+      // continue to fallback
     }
-  }
 
-  return undefined;
+    // 2nd: raw cwd encode (without realpath)
+    const rawEncoded = encodeCwd(cwd);
+    for (const projectsDir of projectRoots) {
+      if (existsSync(join(projectsDir, rawEncoded))) {
+        claudeProjectDirCache.set(cacheKey, rawEncoded);
+        return rawEncoded;
+      }
+    }
+
+    // 3rd: fallback scan — find dir containing sessionId.jsonl
+    if (sessionId) {
+      const registeredPath = resolveSessionRegistryPath(claudeSessionRegistry, sessionId);
+      if (registeredPath && existsSync(registeredPath)) {
+        const parts = registeredPath.split("/");
+        const dir = parts.at(-2);
+        if (dir) {
+          claudeProjectDirCache.set(cacheKey, dir);
+          return dir;
+        }
+      }
+
+      try {
+        for (const projectsDir of projectRoots) {
+          if (!existsSync(projectsDir)) continue;
+          const dirs = await readdir(projectsDir);
+          for (const dir of dirs) {
+            const sessionFile = join(projectsDir, dir, `${sessionId}.jsonl`);
+            if (existsSync(sessionFile)) {
+              upsertSessionRegistryEntry(claudeSessionRegistry, {
+                filePath: sessionFile,
+                sessionId,
+                cwd,
+                firstSeenOffset: 0,
+                source: "claude",
+              });
+              claudeProjectDirCache.set(cacheKey, dir);
+              return dir;
+            }
+          }
+        }
+      } catch {
+        // scan failed
+      }
+    }
+
+    return undefined;
+  });
 }
 
 export async function resolveClaudeSessionFile(
@@ -129,95 +141,98 @@ export async function resolveClaudeSessionFile(
   cwd: string,
   startedAt?: number,
   config?: MarmonitorConfig,
+  runtimePaths?: RuntimeDataPaths,
 ): Promise<string | undefined> {
-  const registeredPath = resolveSessionRegistryPath(claudeSessionRegistry, sessionId);
-  if (registeredPath && existsSync(registeredPath)) return registeredPath;
+  return await profileAsync("claude", "resolveClaudeSessionFile", async () => {
+    const registeredPath = resolveSessionRegistryPath(claudeSessionRegistry, sessionId);
+    if (registeredPath && existsSync(registeredPath)) return registeredPath;
 
-  const projectDirName = await findClaudeProjectDir(cwd, sessionId, config);
-  if (!projectDirName) return undefined;
-  const projectRoots = getClaudeProjectRoots(config);
-
-  for (const projectsDir of projectRoots) {
-    const directPath = join(projectsDir, projectDirName, `${sessionId}.jsonl`);
-    if (existsSync(directPath)) {
-      upsertSessionRegistryEntry(claudeSessionRegistry, {
-        filePath: directPath,
-        sessionId,
-        cwd,
-        firstSeenOffset: 0,
-        startedAt,
-        source: "claude",
-      });
-      return directPath;
-    }
-  }
-
-  if (!startedAt) return undefined;
-
-  try {
-    const candidates: Array<{ path: string; deltaSec: number; mtimeMs: number }> = [];
+    const projectDirName = await findClaudeProjectDir(cwd, sessionId, config, runtimePaths);
+    if (!projectDirName) return undefined;
+    const projectRoots = getClaudeProjectRoots(config, runtimePaths);
 
     for (const projectsDir of projectRoots) {
-      const projectDir = join(projectsDir, projectDirName);
-      if (!existsSync(projectDir)) continue;
-      const files = await readdir(projectDir);
-      for (const file of files) {
-        if (!file.endsWith(".jsonl")) continue;
-        const candidatePath = join(projectDir, file);
-        try {
-          const fileStat = await stat(candidatePath);
-          candidates.push({
-            path: candidatePath,
-            deltaSec: Math.abs(fileStat.mtimeMs / 1000 - startedAt),
-            mtimeMs: fileStat.mtimeMs,
-          });
-        } catch {
-          // skip candidate
-        }
+      const directPath = join(projectsDir, projectDirName, `${sessionId}.jsonl`);
+      if (existsSync(directPath)) {
+        upsertSessionRegistryEntry(claudeSessionRegistry, {
+          filePath: directPath,
+          sessionId,
+          cwd,
+          firstSeenOffset: 0,
+          startedAt,
+          source: "claude",
+        });
+        return directPath;
       }
     }
 
-    candidates.sort((a, b) => a.deltaSec - b.deltaSec);
-    const best = candidates[0];
-    const second = candidates[1];
-    if (!best || best.deltaSec > CLAUDE_SESSION_MTIME_MATCH_SEC) {
-      const fallbackPath = selectRecentSessionFile(candidates);
-      if (!fallbackPath) return undefined;
+    if (!startedAt) return undefined;
+
+    try {
+      const candidates: Array<{ path: string; deltaSec: number; mtimeMs: number }> = [];
+
+      for (const projectsDir of projectRoots) {
+        const projectDir = join(projectsDir, projectDirName);
+        if (!existsSync(projectDir)) continue;
+        const files = await readdir(projectDir);
+        for (const file of files) {
+          if (!file.endsWith(".jsonl")) continue;
+          const candidatePath = join(projectDir, file);
+          try {
+            const fileStat = await stat(candidatePath);
+            candidates.push({
+              path: candidatePath,
+              deltaSec: Math.abs(fileStat.mtimeMs / 1000 - startedAt),
+              mtimeMs: fileStat.mtimeMs,
+            });
+          } catch {
+            // skip candidate
+          }
+        }
+      }
+
+      candidates.sort((a, b) => a.deltaSec - b.deltaSec);
+      const best = candidates[0];
+      const second = candidates[1];
+      if (!best || best.deltaSec > CLAUDE_SESSION_MTIME_MATCH_SEC) {
+        const fallbackPath = selectRecentSessionFile(candidates);
+        if (!fallbackPath) return undefined;
+        upsertSessionRegistryEntry(claudeSessionRegistry, {
+          filePath: fallbackPath,
+          sessionId,
+          cwd,
+          firstSeenOffset: 0,
+          startedAt,
+          source: "claude",
+        });
+        return fallbackPath;
+      }
+      if (second && second.deltaSec - best.deltaSec < CLAUDE_SESSION_AMBIGUITY_GAP_SEC) {
+        const fallbackPath = selectRecentSessionFile(candidates);
+        if (!fallbackPath) return undefined;
+        upsertSessionRegistryEntry(claudeSessionRegistry, {
+          filePath: fallbackPath,
+          sessionId,
+          cwd,
+          firstSeenOffset: 0,
+          startedAt,
+          source: "claude",
+        });
+        return fallbackPath;
+      }
       upsertSessionRegistryEntry(claudeSessionRegistry, {
-        filePath: fallbackPath,
+        filePath: best.path,
         sessionId,
         cwd,
         firstSeenOffset: 0,
         startedAt,
         source: "claude",
       });
-      return fallbackPath;
+      return best.path;
+    } catch {
+      return undefined;
     }
-    if (second && second.deltaSec - best.deltaSec < CLAUDE_SESSION_AMBIGUITY_GAP_SEC) {
-      const fallbackPath = selectRecentSessionFile(candidates);
-      if (!fallbackPath) return undefined;
-      upsertSessionRegistryEntry(claudeSessionRegistry, {
-        filePath: fallbackPath,
-        sessionId,
-        cwd,
-        firstSeenOffset: 0,
-        startedAt,
-        source: "claude",
-      });
-      return fallbackPath;
-    }
-    upsertSessionRegistryEntry(claudeSessionRegistry, {
-      filePath: best.path,
-      sessionId,
-      cwd,
-      firstSeenOffset: 0,
-      startedAt,
-      source: "claude",
-    });
-    return best.path;
-  } catch {
-    return undefined;
-  }
+  });
 }
 
 /** Parse Claude session JSONL for token usage (streaming, stops early for large files) */
@@ -226,81 +241,90 @@ export async function parseClaudeTokens(
   cwd: string,
   startedAt?: number,
   config?: MarmonitorConfig,
+  runtimePaths?: RuntimeDataPaths,
 ): Promise<{ tokenUsage?: TokenUsage; model?: string }> {
-  const sessionFile = await resolveClaudeSessionFile(sessionId, cwd, startedAt, config);
-  if (!sessionFile || !existsSync(sessionFile)) return {};
+  return await profileAsync("claude", "parseClaudeTokens", async () => {
+    const sessionFile = await resolveClaudeSessionFile(
+      sessionId,
+      cwd,
+      startedAt,
+      config,
+      runtimePaths,
+    );
+    if (!sessionFile || !existsSync(sessionFile)) return {};
 
-  try {
-    const fileStat = await stat(sessionFile);
-    const cached = claudeTokenCache.get(sessionFile);
-    if (cached && cached.mtimeMs === fileStat.mtimeMs && cached.size === fileStat.size) {
-      return cached.result;
-    }
-
-    let inputTokens = cached?.result.tokenUsage?.inputTokens ?? 0;
-    let outputTokens = cached?.result.tokenUsage?.outputTokens ?? 0;
-    let cacheCreationTokens = cached?.result.tokenUsage?.cacheCreationTokens ?? 0;
-    let cacheReadTokens = cached?.result.tokenUsage?.cacheReadTokens ?? 0;
-    let model: string | undefined = cached?.result.model;
-
-    let raw: string;
-    if (cached && fileStat.size > cached.size) {
-      const appendSize = fileStat.size - cached.size;
-      const fd = await open(sessionFile, "r");
-      const buf = Buffer.alloc(appendSize);
-      await fd.read(buf, 0, appendSize, cached.size);
-      await fd.close();
-      raw = buf.toString("utf-8");
-    } else {
-      raw = await readFile(sessionFile, "utf-8");
-      inputTokens = 0;
-      outputTokens = 0;
-      cacheCreationTokens = 0;
-      cacheReadTokens = 0;
-      model = undefined;
-    }
-
-    const lines = raw.split("\n").filter((line) => line.trim());
-
-    for (const line of lines) {
-      try {
-        const entry = JSON.parse(line);
-        const usage = entry?.message?.usage;
-        if (!usage) continue;
-
-        inputTokens += usage.input_tokens ?? 0;
-        outputTokens += usage.output_tokens ?? 0;
-        cacheCreationTokens += usage.cache_creation_input_tokens ?? 0;
-        cacheReadTokens += usage.cache_read_input_tokens ?? 0;
-
-        if (entry?.message?.model) model = entry.message.model;
-      } catch {
-        // skip malformed lines
+    try {
+      const fileStat = await stat(sessionFile);
+      const cached = claudeTokenCache.get(sessionFile);
+      if (cached && cached.mtimeMs === fileStat.mtimeMs && cached.size === fileStat.size) {
+        return cached.result;
       }
-    }
 
-    const result = {
-      tokenUsage:
-        inputTokens === 0 && outputTokens === 0
-          ? undefined
-          : {
-              inputTokens,
-              outputTokens,
-              cacheCreationTokens,
-              cacheReadTokens,
-              totalTokens: inputTokens + outputTokens,
-            },
-      model,
-    };
-    claudeTokenCache.set(sessionFile, {
-      mtimeMs: fileStat.mtimeMs,
-      size: fileStat.size,
-      result,
-    });
-    return result;
-  } catch {
-    return {};
-  }
+      let inputTokens = cached?.result.tokenUsage?.inputTokens ?? 0;
+      let outputTokens = cached?.result.tokenUsage?.outputTokens ?? 0;
+      let cacheCreationTokens = cached?.result.tokenUsage?.cacheCreationTokens ?? 0;
+      let cacheReadTokens = cached?.result.tokenUsage?.cacheReadTokens ?? 0;
+      let model: string | undefined = cached?.result.model;
+
+      let raw: string;
+      if (cached && fileStat.size > cached.size) {
+        const appendSize = fileStat.size - cached.size;
+        const fd = await open(sessionFile, "r");
+        const buf = Buffer.alloc(appendSize);
+        await fd.read(buf, 0, appendSize, cached.size);
+        await fd.close();
+        raw = buf.toString("utf-8");
+      } else {
+        raw = await readFile(sessionFile, "utf-8");
+        inputTokens = 0;
+        outputTokens = 0;
+        cacheCreationTokens = 0;
+        cacheReadTokens = 0;
+        model = undefined;
+      }
+
+      const lines = raw.split("\n").filter((line) => line.trim());
+
+      for (const line of lines) {
+        try {
+          const entry = JSON.parse(line);
+          const usage = entry?.message?.usage;
+          if (!usage) continue;
+
+          inputTokens += usage.input_tokens ?? 0;
+          outputTokens += usage.output_tokens ?? 0;
+          cacheCreationTokens += usage.cache_creation_input_tokens ?? 0;
+          cacheReadTokens += usage.cache_read_input_tokens ?? 0;
+
+          if (entry?.message?.model) model = entry.message.model;
+        } catch {
+          // skip malformed lines
+        }
+      }
+
+      const result = {
+        tokenUsage:
+          inputTokens === 0 && outputTokens === 0
+            ? undefined
+            : {
+                inputTokens,
+                outputTokens,
+                cacheCreationTokens,
+                cacheReadTokens,
+                totalTokens: inputTokens + outputTokens,
+              },
+        model,
+      };
+      claudeTokenCache.set(sessionFile, {
+        mtimeMs: fileStat.mtimeMs,
+        size: fileStat.size,
+        result,
+      });
+      return result;
+    } catch {
+      return {};
+    }
+  });
 }
 
 /**
@@ -311,203 +335,221 @@ export async function detectClaudePhase(
   cwd: string,
   startedAt?: number,
   config?: MarmonitorConfig,
+  runtimePaths?: RuntimeDataPaths,
 ): Promise<PhaseResult> {
-  const sessionFile = await resolveClaudeSessionFile(sessionId, cwd, startedAt, config);
-  if (!sessionFile || !existsSync(sessionFile)) return {};
-
-  try {
-    const fileStat = await stat(sessionFile);
-    const cached = claudePhaseCache.get(sessionFile);
-    if (cached && cached.mtimeMs === fileStat.mtimeMs && cached.size === fileStat.size) {
-      return {
-        ...cached.result,
-        phase: config
-          ? resolvePhaseWithDecay(
-              cached.result.phase,
-              cached.result.phase,
-              cached.phaseDetectedAtMs,
-              config.status.phaseDecay,
-            )
-          : cached.result.phase,
-      };
-    }
-
-    const { size } = fileStat;
-    const shouldAppend = Boolean(cached) && size >= (cached?.offset ?? 0);
-    const readFrom = shouldAppend ? (cached?.offset ?? 0) : 0;
-    const previousRemainder = shouldAppend ? (cached?.remainder ?? "") : "";
-    const previousLines = shouldAppend ? (cached?.recentLines ?? []) : [];
-    const readSize = Math.max(0, size - readFrom);
-    const fd = await open(sessionFile, "r");
-    const buf = Buffer.alloc(readSize);
-    await fd.read(buf, 0, readSize, readFrom);
-    await fd.close();
-
-    const chunk = buf.toString("utf-8");
-    const cursor = advanceJsonlCursor(
-      {
-        offset: readFrom,
-        remainder: previousRemainder,
-        recentLines: previousLines,
-      },
-      chunk,
-      CLAUDE_PHASE_RECENT_LINES,
+  return await profileAsync("claude", "detectClaudePhase", async () => {
+    const sessionFile = await resolveClaudeSessionFile(
+      sessionId,
+      cwd,
+      startedAt,
+      config,
+      runtimePaths,
     );
-    const lines = cursor.recentLines;
+    if (!sessionFile || !existsSync(sessionFile)) return {};
 
-    let lastResponseAt: number | undefined;
-    let lastActivityAt: number | undefined;
-    let phase: SessionPhase;
-    const getContentTypes = (content: unknown): string[] => {
-      if (!Array.isArray(content)) return [];
-      return content
-        .map((item) => {
-          if (item && typeof item === "object" && "type" in item) {
-            const type = (item as { type?: unknown }).type;
-            return typeof type === "string" ? type : undefined;
-          }
-          return undefined;
-        })
-        .filter((value): value is string => Boolean(value));
-    };
+    try {
+      const fileStat = await stat(sessionFile);
+      const cached = claudePhaseCache.get(sessionFile);
+      if (cached && cached.mtimeMs === fileStat.mtimeMs && cached.size === fileStat.size) {
+        return {
+          ...cached.result,
+          phase: config
+            ? resolvePhaseWithDecay(
+                cached.result.phase,
+                cached.result.phase,
+                cached.phaseDetectedAtMs,
+                config.status.phaseDecay,
+              )
+            : cached.result.phase,
+        };
+      }
 
-    // Walk backwards through the last events
-    for (let i = lines.length - 1; i >= Math.max(0, lines.length - 20); i--) {
-      try {
-        const entry = JSON.parse(lines[i]);
-        const type = entry.type;
-        const ts = entry.timestamp ? new Date(entry.timestamp).getTime() / 1000 : undefined;
+      const { size } = fileStat;
+      const shouldAppend = Boolean(cached) && size >= (cached?.offset ?? 0);
+      const readFrom = shouldAppend ? (cached?.offset ?? 0) : 0;
+      const previousRemainder = shouldAppend ? (cached?.remainder ?? "") : "";
+      const previousLines = shouldAppend ? (cached?.recentLines ?? []) : [];
+      const readSize = Math.max(0, size - readFrom);
+      const fd = await open(sessionFile, "r");
+      const buf = Buffer.alloc(readSize);
+      await fd.read(buf, 0, readSize, readFrom);
+      await fd.close();
 
-        // Track latest timestamps
-        if (ts && !lastActivityAt) lastActivityAt = ts;
-        if (ts && type === "assistant" && !lastResponseAt) lastResponseAt = ts;
+      const chunk = buf.toString("utf-8");
+      const cursor = advanceJsonlCursor(
+        {
+          offset: readFrom,
+          remainder: previousRemainder,
+          recentLines: previousLines,
+        },
+        chunk,
+        CLAUDE_PHASE_RECENT_LINES,
+      );
+      const lines = cursor.recentLines;
 
-        // Phase detection (only set once — first match wins)
-        if (!phase) {
-          if (type === "progress") {
-            const data = entry.data;
-            if (data?.type === "hook_progress") {
-              phase = "tool";
+      let lastResponseAt: number | undefined;
+      let lastActivityAt: number | undefined;
+      let phase: SessionPhase;
+      const getContentTypes = (content: unknown): string[] => {
+        if (!Array.isArray(content)) return [];
+        return content
+          .map((item) => {
+            if (item && typeof item === "object" && "type" in item) {
+              const type = (item as { type?: unknown }).type;
+              return typeof type === "string" ? type : undefined;
             }
-            continue;
-          }
+            return undefined;
+          })
+          .filter((value): value is string => Boolean(value));
+      };
 
-          if (type === "assistant") {
-            const stopReason = entry.message?.stop_reason;
-            const contentTypes = getContentTypes(entry.message?.content);
+      // Walk backwards through the last events
+      for (let i = lines.length - 1; i >= Math.max(0, lines.length - 20); i--) {
+        try {
+          const entry = JSON.parse(lines[i]);
+          const type = entry.type;
+          const ts = entry.timestamp ? new Date(entry.timestamp).getTime() / 1000 : undefined;
 
-            if (stopReason === "tool_use") {
-              const hasResult = lines.slice(i + 1).some((l) => {
-                try {
-                  const e = JSON.parse(l);
-                  return (
-                    e.type === "user" && getContentTypes(e.message?.content).includes("tool_result")
-                  );
-                } catch {
-                  return false;
-                }
-              });
+          // Track latest timestamps
+          if (ts && !lastActivityAt) lastActivityAt = ts;
+          if (ts && type === "assistant" && !lastResponseAt) lastResponseAt = ts;
 
-              if (!hasResult) phase = "permission";
+          // Phase detection (only set once — first match wins)
+          if (!phase) {
+            if (type === "progress") {
+              const data = entry.data;
+              if (data?.type === "hook_progress") {
+                phase = "tool";
+              }
               continue;
             }
 
-            if (stopReason === null || stopReason === undefined) {
-              if (contentTypes.includes("text") || contentTypes.includes("tool_use")) {
-                phase = "thinking";
+            if (type === "assistant") {
+              const stopReason = entry.message?.stop_reason;
+              const contentTypes = getContentTypes(entry.message?.content);
+
+              if (stopReason === "tool_use") {
+                const hasResult = lines.slice(i + 1).some((l) => {
+                  try {
+                    const e = JSON.parse(l);
+                    return (
+                      e.type === "user" &&
+                      getContentTypes(e.message?.content).includes("tool_result")
+                    );
+                  } catch {
+                    return false;
+                  }
+                });
+
+                if (!hasResult) phase = "permission";
+                continue;
+              }
+
+              if (stopReason === null || stopReason === undefined) {
+                if (contentTypes.includes("text") || contentTypes.includes("tool_use")) {
+                  phase = "thinking";
+                }
+              }
+
+              if (stopReason === "end_turn") {
+                phase = "done";
               }
             }
 
-            if (stopReason === "end_turn") {
-              phase = "done";
+            if (type === "user") {
+              phase = "thinking";
             }
           }
 
-          if (type === "user") {
-            phase = "thinking";
-          }
-        }
+          // Stop early if we have everything
+          if (phase && lastResponseAt && lastActivityAt) break;
+        } catch {}
+      }
 
-        // Stop early if we have everything
-        if (phase && lastResponseAt && lastActivityAt) break;
-      } catch {}
+      // If event timestamps were not parseable, fall back to the project JSONL mtime.
+      if (!lastActivityAt) {
+        lastActivityAt = fileStat.mtimeMs / 1000;
+      }
+
+      const decayedPhase = config
+        ? resolvePhaseWithDecay(
+            phase,
+            cached?.result.phase,
+            cached?.phaseDetectedAtMs,
+            config.status.phaseDecay,
+          )
+        : phase;
+      const resolvedPhase = resolvePhaseFromHistory(
+        decayedPhase,
+        cached?.history ?? [],
+        Date.now(),
+      );
+
+      const nowMs = Date.now();
+      const transition = updatePhaseHistory(
+        cached?.result.phase,
+        cached?.history ?? [],
+        resolvedPhase,
+        nowMs,
+      );
+      const result = { phase: resolvedPhase, lastResponseAt, lastActivityAt };
+      claudePhaseCache.set(sessionFile, {
+        mtimeMs: fileStat.mtimeMs,
+        size: fileStat.size,
+        phaseDetectedAtMs: resolvedPhase ? nowMs : cached?.phaseDetectedAtMs,
+        offset: cursor.offset,
+        remainder: cursor.remainder,
+        recentLines: cursor.recentLines,
+        previousPhase: transition.previousPhase,
+        history: transition.history,
+        result,
+      });
+      return result;
+    } catch {
+      return {};
     }
-
-    // If event timestamps were not parseable, fall back to the project JSONL mtime.
-    if (!lastActivityAt) {
-      lastActivityAt = fileStat.mtimeMs / 1000;
-    }
-
-    const decayedPhase = config
-      ? resolvePhaseWithDecay(
-          phase,
-          cached?.result.phase,
-          cached?.phaseDetectedAtMs,
-          config.status.phaseDecay,
-        )
-      : phase;
-    const resolvedPhase = resolvePhaseFromHistory(decayedPhase, cached?.history ?? [], Date.now());
-
-    const nowMs = Date.now();
-    const transition = updatePhaseHistory(
-      cached?.result.phase,
-      cached?.history ?? [],
-      resolvedPhase,
-      nowMs,
-    );
-    const result = { phase: resolvedPhase, lastResponseAt, lastActivityAt };
-    claudePhaseCache.set(sessionFile, {
-      mtimeMs: fileStat.mtimeMs,
-      size: fileStat.size,
-      phaseDetectedAtMs: resolvedPhase ? nowMs : cached?.phaseDetectedAtMs,
-      offset: cursor.offset,
-      remainder: cursor.remainder,
-      recentLines: cursor.recentLines,
-      previousPhase: transition.previousPhase,
-      history: transition.history,
-      result,
-    });
-    return result;
-  } catch {
-    return {};
-  }
+  });
 }
 
 /** Parse Claude Code session file for enriched data */
 export async function parseClaudeSession(
   pid: number,
   config?: MarmonitorConfig,
+  options: { includeTokenUsage?: boolean; runtimePaths?: RuntimeDataPaths } = {},
 ): Promise<Partial<AgentSession>> {
-  const sessionFile = getClaudeSessionRoots(config)
-    .map((root) => join(root, `${pid}.json`))
-    .find((candidate) => existsSync(candidate));
-  if (!sessionFile) return {};
-  try {
-    const fileStat = await stat(sessionFile);
-    const raw = await readFile(sessionFile, "utf-8");
-    const data = JSON.parse(raw);
+  return await profileAsync("claude", "parseClaudeSession", async () => {
+    const sessionFile = getClaudeSessionRoots(config, options.runtimePaths)
+      .map((root) => join(root, `${pid}.json`))
+      .find((candidate) => existsSync(candidate));
+    if (!sessionFile) return {};
+    try {
+      const fileStat = await stat(sessionFile);
+      const raw = await readFile(sessionFile, "utf-8");
+      const data = JSON.parse(raw);
 
-    const result: Partial<AgentSession> = {
-      cwd: data.cwd,
-      sessionId: data.sessionId,
-      startedAt: data.startedAt ? data.startedAt / 1000 : undefined,
-      lastActivityAt: fileStat.mtimeMs / 1000,
-      sessionMatched: true,
-    };
+      const result: Partial<AgentSession> = {
+        cwd: data.cwd,
+        sessionId: data.sessionId,
+        startedAt: data.startedAt ? data.startedAt / 1000 : undefined,
+        lastActivityAt: fileStat.mtimeMs / 1000,
+        sessionMatched: true,
+      };
 
-    if (data.sessionId && data.cwd) {
-      const tokenData = await parseClaudeTokens(
-        data.sessionId,
-        data.cwd,
-        data.startedAt ? data.startedAt / 1000 : undefined,
-        config,
-      );
-      result.tokenUsage = tokenData.tokenUsage;
-      result.model = tokenData.model;
+      if (options.includeTokenUsage !== false && data.sessionId && data.cwd) {
+        const tokenData = await parseClaudeTokens(
+          data.sessionId,
+          data.cwd,
+          data.startedAt ? data.startedAt / 1000 : undefined,
+          config,
+          options.runtimePaths,
+        );
+        result.tokenUsage = tokenData.tokenUsage;
+        result.model = tokenData.model;
+      }
+
+      return result;
+    } catch {
+      return {};
     }
-
-    return result;
-  } catch {
-    return {};
-  }
+  });
 }

--- a/src/scanner/claude.ts
+++ b/src/scanner/claude.ts
@@ -30,6 +30,17 @@ import {
   claudeTokenCache,
 } from "./cache.js";
 import type { PhaseResult } from "./cache.js";
+import { readSharedCache, writeSharedCache } from "./shared-cache.js";
+
+const CLAUDE_SHARED_SESSION_TTL_MS = 60_000;
+const CLAUDE_SHARED_PHASE_TTL_MS = 60_000;
+
+interface ClaudeSharedCacheOptions {
+  cacheRoot?: string;
+  nowMs?: number;
+  openFile?: typeof open;
+  statFile?: typeof stat;
+}
 
 export function getClaudeProjectRoots(
   config?: MarmonitorConfig,
@@ -142,10 +153,38 @@ export async function resolveClaudeSessionFile(
   startedAt?: number,
   config?: MarmonitorConfig,
   runtimePaths?: RuntimeDataPaths,
+  options: ClaudeSharedCacheOptions = {},
 ): Promise<string | undefined> {
   return await profileAsync("claude", "resolveClaudeSessionFile", async () => {
+    const nowMs = options.nowMs ?? Date.now();
     const registeredPath = resolveSessionRegistryPath(claudeSessionRegistry, sessionId);
     if (registeredPath && existsSync(registeredPath)) return registeredPath;
+
+    const sharedKey = `${sessionId}:${cwd}:${startedAt ?? ""}`;
+    const sharedCached = await readSharedCache<string>(
+      "claude-session-file",
+      sharedKey,
+      CLAUDE_SHARED_SESSION_TTL_MS,
+      {
+        cacheRoot: options.cacheRoot,
+        nowMs,
+      },
+    );
+    if (sharedCached?.value && existsSync(sharedCached.value)) {
+      upsertSessionRegistryEntry(claudeSessionRegistry, {
+        filePath: sharedCached.value,
+        sessionId,
+        cwd,
+        firstSeenOffset: 0,
+        startedAt,
+        source: "claude",
+      });
+      const sharedDir = sharedCached.value.split("/").at(-2);
+      if (sharedDir) {
+        claudeProjectDirCache.set(`${cwd}::${sessionId ?? ""}`, sharedDir);
+      }
+      return sharedCached.value;
+    }
 
     const projectDirName = await findClaudeProjectDir(cwd, sessionId, config, runtimePaths);
     if (!projectDirName) return undefined;
@@ -161,6 +200,10 @@ export async function resolveClaudeSessionFile(
           firstSeenOffset: 0,
           startedAt,
           source: "claude",
+        });
+        await writeSharedCache("claude-session-file", sharedKey, directPath, {
+          cacheRoot: options.cacheRoot,
+          nowMs,
         });
         return directPath;
       }
@@ -205,6 +248,10 @@ export async function resolveClaudeSessionFile(
           startedAt,
           source: "claude",
         });
+        await writeSharedCache("claude-session-file", sharedKey, fallbackPath, {
+          cacheRoot: options.cacheRoot,
+          nowMs,
+        });
         return fallbackPath;
       }
       if (second && second.deltaSec - best.deltaSec < CLAUDE_SESSION_AMBIGUITY_GAP_SEC) {
@@ -218,6 +265,10 @@ export async function resolveClaudeSessionFile(
           startedAt,
           source: "claude",
         });
+        await writeSharedCache("claude-session-file", sharedKey, fallbackPath, {
+          cacheRoot: options.cacheRoot,
+          nowMs,
+        });
         return fallbackPath;
       }
       upsertSessionRegistryEntry(claudeSessionRegistry, {
@@ -227,6 +278,10 @@ export async function resolveClaudeSessionFile(
         firstSeenOffset: 0,
         startedAt,
         source: "claude",
+      });
+      await writeSharedCache("claude-session-file", sharedKey, best.path, {
+        cacheRoot: options.cacheRoot,
+        nowMs,
       });
       return best.path;
     } catch {
@@ -336,6 +391,7 @@ export async function detectClaudePhase(
   startedAt?: number,
   config?: MarmonitorConfig,
   runtimePaths?: RuntimeDataPaths,
+  options: ClaudeSharedCacheOptions = {},
 ): Promise<PhaseResult> {
   return await profileAsync("claude", "detectClaudePhase", async () => {
     const sessionFile = await resolveClaudeSessionFile(
@@ -344,11 +400,15 @@ export async function detectClaudePhase(
       startedAt,
       config,
       runtimePaths,
+      options,
     );
     if (!sessionFile || !existsSync(sessionFile)) return {};
 
     try {
-      const fileStat = await stat(sessionFile);
+      const nowMs = options.nowMs ?? Date.now();
+      const statFile = options.statFile ?? stat;
+      const openFile = options.openFile ?? open;
+      const fileStat = await statFile(sessionFile);
       const cached = claudePhaseCache.get(sessionFile);
       if (cached && cached.mtimeMs === fileStat.mtimeMs && cached.size === fileStat.size) {
         return {
@@ -364,13 +424,51 @@ export async function detectClaudePhase(
         };
       }
 
+      const sharedKey = `${sessionFile}:${fileStat.mtimeMs}:${fileStat.size}`;
+      const sharedCached = await readSharedCache<PhaseResult>(
+        "claude-phase",
+        sharedKey,
+        CLAUDE_SHARED_PHASE_TTL_MS,
+        {
+          cacheRoot: options.cacheRoot,
+          nowMs,
+        },
+      );
+      if (sharedCached) {
+        const sharedResult = sharedCached.value;
+        claudePhaseCache.set(sessionFile, {
+          mtimeMs: fileStat.mtimeMs,
+          size: fileStat.size,
+          phaseDetectedAtMs: sharedResult.phase ? sharedCached.checkedAt : undefined,
+          offset: fileStat.size,
+          remainder: "",
+          recentLines: [],
+          previousPhase: sharedResult.phase,
+          history: sharedResult.phase
+            ? [{ phase: sharedResult.phase, at: sharedCached.checkedAt }]
+            : [],
+          result: sharedResult,
+        });
+        return {
+          ...sharedResult,
+          phase: config
+            ? resolvePhaseWithDecay(
+                sharedResult.phase,
+                sharedResult.phase,
+                sharedResult.phase ? sharedCached.checkedAt : undefined,
+                config.status.phaseDecay,
+              )
+            : sharedResult.phase,
+        };
+      }
+
       const { size } = fileStat;
       const shouldAppend = Boolean(cached) && size >= (cached?.offset ?? 0);
       const readFrom = shouldAppend ? (cached?.offset ?? 0) : 0;
       const previousRemainder = shouldAppend ? (cached?.remainder ?? "") : "";
       const previousLines = shouldAppend ? (cached?.recentLines ?? []) : [];
       const readSize = Math.max(0, size - readFrom);
-      const fd = await open(sessionFile, "r");
+      const fd = await openFile(sessionFile, "r");
       const buf = Buffer.alloc(readSize);
       await fd.read(buf, 0, readSize, readFrom);
       await fd.close();
@@ -479,13 +577,8 @@ export async function detectClaudePhase(
             config.status.phaseDecay,
           )
         : phase;
-      const resolvedPhase = resolvePhaseFromHistory(
-        decayedPhase,
-        cached?.history ?? [],
-        Date.now(),
-      );
+      const resolvedPhase = resolvePhaseFromHistory(decayedPhase, cached?.history ?? [], nowMs);
 
-      const nowMs = Date.now();
       const transition = updatePhaseHistory(
         cached?.result.phase,
         cached?.history ?? [],
@@ -503,6 +596,10 @@ export async function detectClaudePhase(
         previousPhase: transition.previousPhase,
         history: transition.history,
         result,
+      });
+      await writeSharedCache("claude-phase", sharedKey, result, {
+        cacheRoot: options.cacheRoot,
+        nowMs,
       });
       return result;
     } catch {

--- a/src/scanner/codex.ts
+++ b/src/scanner/codex.ts
@@ -6,7 +6,7 @@ import { existsSync } from "node:fs";
 import { open, readFile, readdir, stat } from "node:fs/promises";
 import { join } from "node:path";
 
-import type { MarmonitorConfig } from "../config/index.js";
+import type { MarmonitorConfig, RuntimeDataPaths } from "../config/index.js";
 import { resolveRuntimeDataPaths } from "../config/index.js";
 import {
   advanceJsonlCursor,
@@ -16,6 +16,7 @@ import {
   updatePhaseHistory,
   upsertSessionRegistryEntry,
 } from "../output/utils.js";
+import { profileAsync } from "../perf.js";
 import type { SessionPhase } from "../types.js";
 import {
   CODEX_INDEX_TTL_MS,
@@ -25,13 +26,21 @@ import {
   codexPhaseCache,
   codexSessionFileCache,
   codexSessionRegistry,
-  setCodexIndexCache,
 } from "./cache.js";
 import type { CodexSessionMeta } from "./cache.js";
 
 export type { CodexSessionMeta } from "./cache.js";
 
-export function getCodexSessionRoots(config?: MarmonitorConfig): string[] {
+interface CodexIndexOptions {
+  includeTokenUsage?: boolean;
+  runtimePaths?: RuntimeDataPaths;
+}
+
+export function getCodexSessionRoots(
+  config?: MarmonitorConfig,
+  runtimePaths?: RuntimeDataPaths,
+): string[] {
+  if (runtimePaths) return runtimePaths.codexSessions;
   return config
     ? resolveRuntimeDataPaths(config).codexSessions
     : [join(HOME, ".codex", "sessions")];
@@ -42,214 +51,287 @@ export async function detectCodexPhase(
   sessionFilePath: string | undefined,
   config?: MarmonitorConfig,
 ): Promise<SessionPhase> {
-  if (!sessionFilePath || !existsSync(sessionFilePath)) return undefined;
+  return await profileAsync("codex", "detectCodexPhase", async () => {
+    if (!sessionFilePath || !existsSync(sessionFilePath)) return undefined;
 
-  try {
-    const fileStat = await stat(sessionFilePath);
-    const cached = codexPhaseCache.get(sessionFilePath);
-    if (cached && cached.mtimeMs === fileStat.mtimeMs && cached.size === fileStat.size) {
-      return config
+    try {
+      const fileStat = await stat(sessionFilePath);
+      const cached = codexPhaseCache.get(sessionFilePath);
+      if (cached && cached.mtimeMs === fileStat.mtimeMs && cached.size === fileStat.size) {
+        return config
+          ? resolvePhaseWithDecay(
+              cached.result.phase,
+              cached.result.phase,
+              cached.phaseDetectedAtMs,
+              config.status.phaseDecay,
+            )
+          : cached.result.phase;
+      }
+
+      const { size } = fileStat;
+      const shouldAppend = Boolean(cached) && size >= (cached?.offset ?? 0);
+      const readFrom = shouldAppend ? (cached?.offset ?? 0) : 0;
+      const previousRemainder = shouldAppend ? (cached?.remainder ?? "") : "";
+      const previousLines = shouldAppend ? (cached?.recentLines ?? []) : [];
+      const readSize = Math.max(0, size - readFrom);
+      const fd = await open(sessionFilePath, "r");
+      const buf = Buffer.alloc(readSize);
+      await fd.read(buf, 0, readSize, readFrom);
+      await fd.close();
+
+      const chunk = buf.toString("utf-8");
+      const cursor = advanceJsonlCursor(
+        {
+          offset: readFrom,
+          remainder: previousRemainder,
+          recentLines: previousLines,
+        },
+        chunk,
+        CODEX_PHASE_RECENT_LINES,
+      );
+      const lines = cursor.recentLines;
+      let phase: SessionPhase;
+
+      for (let i = lines.length - 1; i >= Math.max(0, lines.length - 10); i--) {
+        try {
+          const entry = JSON.parse(lines[i]);
+
+          if (entry.type === "event_msg") {
+            const payloadType = entry.payload?.type;
+            if (payloadType === "exec_command" || payloadType === "tool_call") {
+              phase = "tool";
+              break;
+            }
+            if (payloadType === "token_count") {
+              phase = "done";
+              break;
+            }
+          }
+
+          if (entry.type === "response_item") {
+            phase = "thinking";
+            break;
+          }
+        } catch {}
+      }
+      const decayedPhase = config
         ? resolvePhaseWithDecay(
-            cached.result.phase,
-            cached.result.phase,
-            cached.phaseDetectedAtMs,
+            phase,
+            cached?.result.phase,
+            cached?.phaseDetectedAtMs,
             config.status.phaseDecay,
           )
-        : cached.result.phase;
+        : phase;
+      const resolvedPhase = resolvePhaseFromHistory(
+        decayedPhase,
+        cached?.history ?? [],
+        Date.now(),
+      );
+
+      const nowMs = Date.now();
+      const transition = updatePhaseHistory(
+        cached?.result.phase,
+        cached?.history ?? [],
+        resolvedPhase,
+        nowMs,
+      );
+      codexPhaseCache.set(sessionFilePath, {
+        mtimeMs: fileStat.mtimeMs,
+        size: fileStat.size,
+        phaseDetectedAtMs: resolvedPhase ? nowMs : cached?.phaseDetectedAtMs,
+        offset: cursor.offset,
+        remainder: cursor.remainder,
+        recentLines: cursor.recentLines,
+        previousPhase: transition.previousPhase,
+        history: transition.history,
+        result: { phase: resolvedPhase },
+      });
+      return resolvedPhase;
+    } catch {
+      return undefined;
     }
-
-    const { size } = fileStat;
-    const shouldAppend = Boolean(cached) && size >= (cached?.offset ?? 0);
-    const readFrom = shouldAppend ? (cached?.offset ?? 0) : 0;
-    const previousRemainder = shouldAppend ? (cached?.remainder ?? "") : "";
-    const previousLines = shouldAppend ? (cached?.recentLines ?? []) : [];
-    const readSize = Math.max(0, size - readFrom);
-    const fd = await open(sessionFilePath, "r");
-    const buf = Buffer.alloc(readSize);
-    await fd.read(buf, 0, readSize, readFrom);
-    await fd.close();
-
-    const chunk = buf.toString("utf-8");
-    const cursor = advanceJsonlCursor(
-      {
-        offset: readFrom,
-        remainder: previousRemainder,
-        recentLines: previousLines,
-      },
-      chunk,
-      CODEX_PHASE_RECENT_LINES,
-    );
-    const lines = cursor.recentLines;
-    let phase: SessionPhase;
-
-    for (let i = lines.length - 1; i >= Math.max(0, lines.length - 10); i--) {
-      try {
-        const entry = JSON.parse(lines[i]);
-
-        if (entry.type === "event_msg") {
-          const payloadType = entry.payload?.type;
-          if (payloadType === "exec_command" || payloadType === "tool_call") {
-            phase = "tool";
-            break;
-          }
-          if (payloadType === "token_count") {
-            phase = "done";
-            break;
-          }
-        }
-
-        if (entry.type === "response_item") {
-          phase = "thinking";
-          break;
-        }
-      } catch {}
-    }
-    const decayedPhase = config
-      ? resolvePhaseWithDecay(
-          phase,
-          cached?.result.phase,
-          cached?.phaseDetectedAtMs,
-          config.status.phaseDecay,
-        )
-      : phase;
-    const resolvedPhase = resolvePhaseFromHistory(decayedPhase, cached?.history ?? [], Date.now());
-
-    const nowMs = Date.now();
-    const transition = updatePhaseHistory(
-      cached?.result.phase,
-      cached?.history ?? [],
-      resolvedPhase,
-      nowMs,
-    );
-    codexPhaseCache.set(sessionFilePath, {
-      mtimeMs: fileStat.mtimeMs,
-      size: fileStat.size,
-      phaseDetectedAtMs: resolvedPhase ? nowMs : cached?.phaseDetectedAtMs,
-      offset: cursor.offset,
-      remainder: cursor.remainder,
-      recentLines: cursor.recentLines,
-      previousPhase: transition.previousPhase,
-      history: transition.history,
-      result: { phase: resolvedPhase },
-    });
-    return resolvedPhase;
-  } catch {
-    return undefined;
-  }
+  });
 }
 
 /** Build index of recent Codex sessions (last 7 days) */
-export async function indexCodexSessions(config?: MarmonitorConfig): Promise<CodexSessionMeta[]> {
-  if (codexIndexCache && Date.now() - codexIndexCache.builtAt < CODEX_INDEX_TTL_MS) {
-    return codexIndexCache.sessions;
-  }
+export async function indexCodexSessions(
+  config?: MarmonitorConfig,
+  options: CodexIndexOptions = {},
+): Promise<CodexSessionMeta[]> {
+  return await profileAsync("codex", "indexCodexSessions", async () => {
+    const includeTokenUsage = options.includeTokenUsage !== false;
+    const cachedIndex = includeTokenUsage
+      ? codexIndexCache.full
+      : (codexIndexCache.light ?? codexIndexCache.full);
+    if (cachedIndex && Date.now() - cachedIndex.builtAt < CODEX_INDEX_TTL_MS) {
+      return cachedIndex.sessions;
+    }
 
-  const sessionRoots = getCodexSessionRoots(config);
-  if (!sessionRoots.some((sessionsDir) => existsSync(sessionsDir))) return [];
+    const sessionRoots = getCodexSessionRoots(config, options.runtimePaths);
 
-  const metas: CodexSessionMeta[] = [];
-  const now = new Date();
+    const metas: CodexSessionMeta[] = [];
+    const now = new Date();
 
-  try {
-    for (const sessionsDir of sessionRoots) {
-      for (let daysBack = 0; daysBack < 7; daysBack++) {
-        const d = new Date(now.getTime() - daysBack * 86400000);
-        const yyyy = d.getFullYear().toString();
-        const mm = String(d.getMonth() + 1).padStart(2, "0");
-        const dd = String(d.getDate()).padStart(2, "0");
-        const dayDir = join(sessionsDir, yyyy, mm, dd);
+    const parseCodexSessionMeta = (
+      raw: string,
+      filePath: string,
+      fileStat: Awaited<ReturnType<typeof stat>>,
+      includeTokens: boolean,
+    ): CodexSessionMeta | undefined => {
+      const fileMtimeMs = Number(fileStat.mtimeMs);
+      const fileSize = Number(fileStat.size);
+      const lines = raw.trim().split("\n");
+      const meta: Partial<CodexSessionMeta> = { filePath };
+      let lastTokenCount: CodexSessionMeta["totalTokenUsage"];
 
-        if (!existsSync(dayDir)) continue;
+      for (const line of lines) {
+        try {
+          const entry = JSON.parse(line);
 
-        const files = await readdir(dayDir);
-        for (const f of files) {
-          if (!f.endsWith(".jsonl")) continue;
-          const filePath = join(dayDir, f);
+          if (entry.type === "session_meta") {
+            meta.id = entry.payload?.id;
+            meta.cwd = entry.payload?.cwd;
+            meta.model = entry.payload?.model_provider;
+            if (entry.payload?.timestamp) {
+              meta.timestamp = new Date(entry.payload.timestamp).getTime() / 1000;
+            }
+          }
 
+          if (entry.type === "turn_context" && entry.payload?.model) {
+            meta.model = entry.payload.model;
+          }
+
+          if (
+            includeTokens &&
+            entry.type === "event_msg" &&
+            entry.payload?.type === "token_count"
+          ) {
+            lastTokenCount = entry.payload.info.total_token_usage;
+          }
+
+          if (meta.id && meta.cwd && meta.timestamp && (!includeTokens || lastTokenCount)) {
+            break;
+          }
+        } catch {
+          // skip
+        }
+      }
+
+      if (!meta.id || !meta.cwd || !meta.timestamp) return undefined;
+
+      return {
+        filePath,
+        id: meta.id,
+        cwd: meta.cwd,
+        timestamp: meta.timestamp,
+        lastActivityAt: fileMtimeMs / 1000,
+        totalTokenUsage: includeTokens ? lastTokenCount : undefined,
+        model: meta.model,
+        mtimeMs: fileMtimeMs,
+        size: fileSize,
+      } as CodexSessionMeta & { mtimeMs: number; size: number };
+    };
+
+    const readCodexSessionMeta = async (
+      filePath: string,
+      fileStat: Awaited<ReturnType<typeof stat>>,
+    ): Promise<CodexSessionMeta | undefined> => {
+      const fileMtimeMs = Number(fileStat.mtimeMs);
+      const fileSize = Number(fileStat.size);
+      const cachedMeta = codexSessionFileCache.get(filePath);
+      if (
+        cachedMeta?.timestamp &&
+        (cachedMeta as CodexSessionMeta & { mtimeMs?: number; size?: number }).mtimeMs ===
+          fileMtimeMs &&
+        (cachedMeta as CodexSessionMeta & { mtimeMs?: number; size?: number }).size === fileSize &&
+        (!includeTokenUsage || cachedMeta.totalTokenUsage)
+      ) {
+        return cachedMeta;
+      }
+
+      if (!includeTokenUsage) {
+        try {
+          const fd = await open(filePath, "r");
           try {
-            const fileStat = await stat(filePath);
-            const cachedMeta = codexSessionFileCache.get(filePath);
-            if (
-              cachedMeta?.timestamp &&
-              (cachedMeta as CodexSessionMeta & { mtimeMs?: number; size?: number }).mtimeMs ===
-                fileStat.mtimeMs &&
-              (cachedMeta as CodexSessionMeta & { mtimeMs?: number; size?: number }).size ===
-                fileStat.size
-            ) {
-              metas.push(cachedMeta);
-              continue;
-            }
+            const readSize = Math.min(fileSize, 16_384);
+            const buf = Buffer.alloc(readSize);
+            const { bytesRead } = await fd.read(buf, 0, readSize, 0);
+            const parsed = parseCodexSessionMeta(
+              buf.toString("utf-8", 0, bytesRead),
+              filePath,
+              fileStat,
+              false,
+            );
+            if (parsed) return parsed;
+          } finally {
+            await fd.close();
+          }
+        } catch {
+          // fall back to full read
+        }
+      }
 
-            const raw = await readFile(filePath, "utf-8");
-            const lines = raw.trim().split("\n");
+      const raw = await readFile(filePath, "utf-8");
+      return parseCodexSessionMeta(raw, filePath, fileStat, includeTokenUsage);
+    };
 
-            const meta: Partial<CodexSessionMeta> = { filePath };
-            let lastTokenCount: CodexSessionMeta["totalTokenUsage"];
+    try {
+      for (const sessionsDir of sessionRoots) {
+        for (let daysBack = 0; daysBack < 7; daysBack++) {
+          const d = new Date(now.getTime() - daysBack * 86400000);
+          const yyyy = d.getFullYear().toString();
+          const mm = String(d.getMonth() + 1).padStart(2, "0");
+          const dd = String(d.getDate()).padStart(2, "0");
+          const dayDir = join(sessionsDir, yyyy, mm, dd);
 
-            for (const line of lines) {
-              try {
-                const entry = JSON.parse(line);
-
-                if (entry.type === "session_meta") {
-                  meta.id = entry.payload?.id;
-                  meta.cwd = entry.payload?.cwd;
-                  meta.model = entry.payload?.model_provider;
-                  if (entry.payload?.timestamp) {
-                    meta.timestamp = new Date(entry.payload.timestamp).getTime() / 1000;
-                  }
-                }
-
-                if (entry.type === "turn_context" && entry.payload?.model) {
-                  meta.model = entry.payload.model;
-                }
-
-                if (entry.type === "event_msg" && entry.payload?.type === "token_count") {
-                  lastTokenCount = entry.payload.info.total_token_usage;
-                }
-              } catch {
-                // skip
-              }
-            }
-
-            if (meta.id && meta.cwd && meta.timestamp) {
-              const parsed = {
-                filePath,
-                id: meta.id,
-                cwd: meta.cwd,
-                timestamp: meta.timestamp,
-                lastActivityAt: fileStat.mtimeMs / 1000,
-                totalTokenUsage: lastTokenCount,
-                model: meta.model,
-                mtimeMs: fileStat.mtimeMs,
-                size: fileStat.size,
-              } as CodexSessionMeta & { mtimeMs: number; size: number };
-              codexSessionFileCache.set(filePath, parsed);
-              upsertSessionRegistryEntry(codexSessionRegistry, {
-                filePath,
-                sessionId: meta.id,
-                cwd: meta.cwd,
-                firstSeenOffset: 0,
-                startedAt: meta.timestamp,
-                model: meta.model,
-                source: "codex",
-              });
-              metas.push(parsed);
-            }
+          let files: string[];
+          try {
+            files = await readdir(dayDir);
           } catch {
-            // skip file
+            continue;
+          }
+          for (const f of files) {
+            if (!f.endsWith(".jsonl")) continue;
+            const filePath = join(dayDir, f);
+
+            try {
+              const fileStat = await stat(filePath);
+              const parsed = await readCodexSessionMeta(filePath, fileStat);
+              if (parsed) {
+                codexSessionFileCache.set(filePath, parsed);
+                upsertSessionRegistryEntry(codexSessionRegistry, {
+                  filePath,
+                  sessionId: parsed.id,
+                  cwd: parsed.cwd,
+                  firstSeenOffset: 0,
+                  startedAt: parsed.timestamp,
+                  model: parsed.model,
+                  source: "codex",
+                });
+                metas.push(parsed);
+              }
+            } catch {
+              // skip file
+            }
           }
         }
       }
+    } catch {
+      // sessions dir error
     }
-  } catch {
-    // sessions dir error
-  }
 
-  setCodexIndexCache({
-    builtAt: Date.now(),
-    sessions: metas,
+    const cacheEntry = {
+      builtAt: Date.now(),
+      sessions: metas,
+    };
+    if (includeTokenUsage) {
+      codexIndexCache.full = cacheEntry;
+      codexIndexCache.light = cacheEntry;
+    } else {
+      codexIndexCache.light = cacheEntry;
+    }
+    return metas;
   });
-  return metas;
 }
 
 /** Match a Codex process to a session by cwd + closest timestamp */

--- a/src/scanner/codex.ts
+++ b/src/scanner/codex.ts
@@ -28,12 +28,22 @@ import {
   codexSessionRegistry,
 } from "./cache.js";
 import type { CodexSessionMeta } from "./cache.js";
+import { readSharedCache, writeSharedCache } from "./shared-cache.js";
 
 export type { CodexSessionMeta } from "./cache.js";
+
+const CODEX_SHARED_PHASE_TTL_MS = 60_000;
 
 interface CodexIndexOptions {
   includeTokenUsage?: boolean;
   runtimePaths?: RuntimeDataPaths;
+}
+
+interface CodexPhaseCacheOptions {
+  cacheRoot?: string;
+  nowMs?: number;
+  openFile?: typeof open;
+  statFile?: typeof stat;
 }
 
 export function getCodexSessionRoots(
@@ -50,12 +60,16 @@ export function getCodexSessionRoots(
 export async function detectCodexPhase(
   sessionFilePath: string | undefined,
   config?: MarmonitorConfig,
+  options: CodexPhaseCacheOptions = {},
 ): Promise<SessionPhase> {
   return await profileAsync("codex", "detectCodexPhase", async () => {
     if (!sessionFilePath || !existsSync(sessionFilePath)) return undefined;
 
     try {
-      const fileStat = await stat(sessionFilePath);
+      const nowMs = options.nowMs ?? Date.now();
+      const statFile = options.statFile ?? stat;
+      const openFile = options.openFile ?? open;
+      const fileStat = await statFile(sessionFilePath);
       const cached = codexPhaseCache.get(sessionFilePath);
       if (cached && cached.mtimeMs === fileStat.mtimeMs && cached.size === fileStat.size) {
         return config
@@ -68,13 +82,47 @@ export async function detectCodexPhase(
           : cached.result.phase;
       }
 
+      const sharedKey = `${sessionFilePath}:${fileStat.mtimeMs}:${fileStat.size}`;
+      const sharedCached = await readSharedCache<SessionPhase>(
+        "codex-phase",
+        sharedKey,
+        CODEX_SHARED_PHASE_TTL_MS,
+        {
+          cacheRoot: options.cacheRoot,
+          nowMs,
+        },
+      );
+      if (sharedCached) {
+        codexPhaseCache.set(sessionFilePath, {
+          mtimeMs: fileStat.mtimeMs,
+          size: fileStat.size,
+          phaseDetectedAtMs: sharedCached.value ? sharedCached.checkedAt : undefined,
+          offset: fileStat.size,
+          remainder: "",
+          recentLines: [],
+          previousPhase: sharedCached.value,
+          history: sharedCached.value
+            ? [{ phase: sharedCached.value, at: sharedCached.checkedAt }]
+            : [],
+          result: { phase: sharedCached.value },
+        });
+        return config
+          ? resolvePhaseWithDecay(
+              sharedCached.value,
+              sharedCached.value,
+              sharedCached.value ? sharedCached.checkedAt : undefined,
+              config.status.phaseDecay,
+            )
+          : sharedCached.value;
+      }
+
       const { size } = fileStat;
       const shouldAppend = Boolean(cached) && size >= (cached?.offset ?? 0);
       const readFrom = shouldAppend ? (cached?.offset ?? 0) : 0;
       const previousRemainder = shouldAppend ? (cached?.remainder ?? "") : "";
       const previousLines = shouldAppend ? (cached?.recentLines ?? []) : [];
       const readSize = Math.max(0, size - readFrom);
-      const fd = await open(sessionFilePath, "r");
+      const fd = await openFile(sessionFilePath, "r");
       const buf = Buffer.alloc(readSize);
       await fd.read(buf, 0, readSize, readFrom);
       await fd.close();
@@ -122,13 +170,8 @@ export async function detectCodexPhase(
             config.status.phaseDecay,
           )
         : phase;
-      const resolvedPhase = resolvePhaseFromHistory(
-        decayedPhase,
-        cached?.history ?? [],
-        Date.now(),
-      );
+      const resolvedPhase = resolvePhaseFromHistory(decayedPhase, cached?.history ?? [], nowMs);
 
-      const nowMs = Date.now();
       const transition = updatePhaseHistory(
         cached?.result.phase,
         cached?.history ?? [],
@@ -145,6 +188,10 @@ export async function detectCodexPhase(
         previousPhase: transition.previousPhase,
         history: transition.history,
         result: { phase: resolvedPhase },
+      });
+      await writeSharedCache("codex-phase", sharedKey, resolvedPhase, {
+        cacheRoot: options.cacheRoot,
+        nowMs,
       });
       return resolvedPhase;
     } catch {

--- a/src/scanner/gemini.ts
+++ b/src/scanner/gemini.ts
@@ -2,12 +2,12 @@
  * Gemini session parsing and phase detection.
  */
 
-import { existsSync } from "node:fs";
 import { readFile, readdir, stat } from "node:fs/promises";
 import { join } from "node:path";
 
+import { profileAsync } from "../perf.js";
 import type { AgentSession, SessionPhase, TokenUsage } from "../types.js";
-import { HOME } from "./cache.js";
+import { HOME, geminiProjectDirCache } from "./cache.js";
 
 export interface GeminiSessionMeta {
   filePath: string;
@@ -19,6 +19,11 @@ export interface GeminiSessionMeta {
   tokenUsage?: TokenUsage;
   model?: string;
   phase?: SessionPhase;
+}
+
+interface GeminiParseOptions {
+  includeTokenUsage?: boolean;
+  tmpRoot?: string;
 }
 
 type GeminiMessage = {
@@ -40,7 +45,11 @@ export function toEpochSec(value: string | undefined): number | undefined {
   return Number.isNaN(parsed) ? undefined : parsed / 1000;
 }
 
-export function parseGeminiSessionContent(raw: string): Partial<GeminiSessionMeta> {
+export function parseGeminiSessionContent(
+  raw: string,
+  options: GeminiParseOptions = {},
+): Partial<GeminiSessionMeta> {
+  const includeTokenUsage = options.includeTokenUsage !== false;
   try {
     const data = JSON.parse(raw);
     const messages = Array.isArray(data.messages)
@@ -71,16 +80,17 @@ export function parseGeminiSessionContent(raw: string): Partial<GeminiSessionMet
       startedAt: toEpochSec(data.startTime),
       lastActivityAt,
       lastResponseAt,
-      model: latestGeminiMessage?.model,
-      tokenUsage: latestGeminiMessage?.tokens
-        ? {
-            inputTokens: latestGeminiMessage.tokens.input ?? 0,
-            outputTokens: latestGeminiMessage.tokens.output ?? 0,
-            cacheCreationTokens: 0,
-            cacheReadTokens: latestGeminiMessage.tokens.cached ?? 0,
-            totalTokens: latestGeminiMessage.tokens.total ?? 0,
-          }
-        : undefined,
+      model: includeTokenUsage ? latestGeminiMessage?.model : undefined,
+      tokenUsage:
+        includeTokenUsage && latestGeminiMessage?.tokens
+          ? {
+              inputTokens: latestGeminiMessage.tokens.input ?? 0,
+              outputTokens: latestGeminiMessage.tokens.output ?? 0,
+              cacheCreationTokens: 0,
+              cacheReadTokens: latestGeminiMessage.tokens.cached ?? 0,
+              totalTokens: latestGeminiMessage.tokens.total ?? 0,
+            }
+          : undefined,
       phase,
     };
   } catch {
@@ -88,75 +98,94 @@ export function parseGeminiSessionContent(raw: string): Partial<GeminiSessionMet
   }
 }
 
-export async function resolveGeminiProjectDir(cwd: string): Promise<string | undefined> {
-  const geminiTmpRoot = join(HOME, ".gemini", "tmp");
-  if (!existsSync(geminiTmpRoot)) return undefined;
-
-  try {
-    const entries = await readdir(geminiTmpRoot, { withFileTypes: true });
-    for (const entry of entries) {
-      if (!entry.isDirectory()) continue;
-      const projectDir = join(geminiTmpRoot, entry.name);
-      const projectRootFile = join(projectDir, ".project_root");
-      if (!existsSync(projectRootFile)) continue;
+export async function resolveGeminiProjectDir(
+  cwd: string,
+  options: Pick<GeminiParseOptions, "tmpRoot"> = {},
+): Promise<string | undefined> {
+  return await profileAsync("gemini", "resolveGeminiProjectDir", async () => {
+    const geminiTmpRoot = options.tmpRoot ?? join(HOME, ".gemini", "tmp");
+    const cacheKey = `${geminiTmpRoot}::${cwd}`;
+    const cachedProjectDir = geminiProjectDirCache.get(cacheKey);
+    if (cachedProjectDir) {
+      const cachedProjectRootFile = join(cachedProjectDir, ".project_root");
       try {
-        const projectRoot = (await readFile(projectRootFile, "utf-8")).trim();
-        if (projectRoot === cwd) return projectDir;
+        const projectRoot = (await readFile(cachedProjectRootFile, "utf-8")).trim();
+        if (projectRoot === cwd) return cachedProjectDir;
       } catch {
-        // skip unreadable project_root file
+        // fall through to full scan
       }
+      geminiProjectDirCache.delete(cacheKey);
     }
-  } catch {
-    return undefined;
-  }
 
-  return undefined;
+    try {
+      const entries = await readdir(geminiTmpRoot, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        const projectDir = join(geminiTmpRoot, entry.name);
+        const projectRootFile = join(projectDir, ".project_root");
+        try {
+          const projectRoot = (await readFile(projectRootFile, "utf-8")).trim();
+          if (projectRoot === cwd) {
+            geminiProjectDirCache.set(cacheKey, projectDir);
+            return projectDir;
+          }
+        } catch {
+          // skip unreadable project_root file
+        }
+      }
+    } catch {
+      return undefined;
+    }
+
+    return undefined;
+  });
 }
 
 export async function parseGeminiSession(
   cwd: string,
+  options: GeminiParseOptions = {},
 ): Promise<Partial<AgentSession> & { sessionFile?: string }> {
-  const projectDir = await resolveGeminiProjectDir(cwd);
-  if (!projectDir) return {};
+  return await profileAsync("gemini", "parseGeminiSession", async () => {
+    const projectDir = await resolveGeminiProjectDir(cwd, options);
+    if (!projectDir) return {};
 
-  const chatsDir = join(projectDir, "chats");
-  if (!existsSync(chatsDir)) return {};
+    const chatsDir = join(projectDir, "chats");
+    try {
+      const files = (await readdir(chatsDir))
+        .filter((name) => name.startsWith("session-") && name.endsWith(".json"))
+        .map((name) => join(chatsDir, name));
+      if (files.length === 0) return {};
 
-  try {
-    const files = (await readdir(chatsDir))
-      .filter((name) => name.startsWith("session-") && name.endsWith(".json"))
-      .map((name) => join(chatsDir, name));
-    if (files.length === 0) return {};
-
-    let latestFile: string | undefined;
-    let latestMtimeMs = -1;
-    for (const filePath of files) {
-      try {
-        const fileStat = await stat(filePath);
-        if (fileStat.mtimeMs > latestMtimeMs) {
-          latestMtimeMs = fileStat.mtimeMs;
-          latestFile = filePath;
+      let latestFile: string | undefined;
+      let latestMtimeMs = -1;
+      for (const filePath of files) {
+        try {
+          const fileStat = await stat(filePath);
+          if (fileStat.mtimeMs > latestMtimeMs) {
+            latestMtimeMs = fileStat.mtimeMs;
+            latestFile = filePath;
+          }
+        } catch {
+          // skip unreadable file
         }
-      } catch {
-        // skip unreadable file
       }
-    }
-    if (!latestFile) return {};
+      if (!latestFile) return {};
 
-    const parsed = parseGeminiSessionContent(await readFile(latestFile, "utf-8"));
-    return {
-      cwd,
-      sessionId: parsed.sessionId,
-      startedAt: parsed.startedAt,
-      lastActivityAt: parsed.lastActivityAt,
-      lastResponseAt: parsed.lastResponseAt,
-      tokenUsage: parsed.tokenUsage,
-      model: parsed.model,
-      phase: parsed.phase,
-      sessionMatched: true,
-      sessionFile: latestFile,
-    };
-  } catch {
-    return {};
-  }
+      const parsed = parseGeminiSessionContent(await readFile(latestFile, "utf-8"), options);
+      return {
+        cwd,
+        sessionId: parsed.sessionId,
+        startedAt: parsed.startedAt,
+        lastActivityAt: parsed.lastActivityAt,
+        lastResponseAt: parsed.lastResponseAt,
+        tokenUsage: parsed.tokenUsage,
+        model: parsed.model,
+        phase: parsed.phase,
+        sessionMatched: true,
+        sessionFile: latestFile,
+      };
+    } catch {
+      return {};
+    }
+  });
 }

--- a/src/scanner/index.ts
+++ b/src/scanner/index.ts
@@ -40,7 +40,12 @@ import {
   getProcessCwd,
   getProcessStartTime,
 } from "./process.js";
-import { getPidUsageCached, listProcessesCached } from "./runtime-snapshot.js";
+import {
+  getPidUsage,
+  getPidUsageCached,
+  listProcesses,
+  listProcessesCached,
+} from "./runtime-snapshot.js";
 import { detectCliStdoutPhase, determineStatus } from "./status.js";
 
 import type { ScanOptions } from "./types.js";
@@ -56,10 +61,11 @@ export async function scanAgents(
   const isFullEnrichment = enrichmentMode === "full";
   const includeTokenUsage = options.includeTokenUsage ?? isFullEnrichment;
   const includeStdoutHeuristic = options.includeStdoutHeuristic ?? isFullEnrichment;
+  const useSharedRuntimeSnapshots = options.useSharedRuntimeSnapshots ?? false;
   const seenPids = new Set<number>();
 
   // 1. Find running processes
-  const processes = await listProcessesCached();
+  const processes = useSharedRuntimeSnapshots ? await listProcessesCached() : await listProcesses();
 
   // Filter to agent processes
   const agentProcesses: Array<{ proc: (typeof processes)[0]; agentName: string }> = [];
@@ -82,7 +88,9 @@ export async function scanAgents(
   let usageMap: Record<number, { cpu: number; memory: number }> = {};
   if (pids.length > 0) {
     try {
-      usageMap = await getPidUsageCached(pids);
+      usageMap = useSharedRuntimeSnapshots
+        ? await getPidUsageCached(pids)
+        : await getPidUsage(pids);
     } catch {
       // some PIDs may have exited
     }
@@ -173,7 +181,9 @@ export async function scanAgents(
       if (cwdMatches.length === 1) {
         matched = cwdMatches[0];
       } else if (cwdMatches.length > 1) {
-        const processStartTime = await getProcessStartTime(proc.pid);
+        const processStartTime = await getProcessStartTime(proc.pid, {
+          sharedKey: `${proc.pid}:${proc.ppid}:${proc.name}:${proc.cmd ?? ""}`,
+        });
         matched = selectCodexSession(cwd, processStartTime, cwdMatches);
       }
       if (matched) {
@@ -204,7 +214,11 @@ export async function scanAgents(
       const geminiData = await parseGeminiSession(cwd, {
         includeTokenUsage,
       });
-      startedAt = geminiData.startedAt ?? (await getProcessStartTime(proc.pid));
+      startedAt =
+        geminiData.startedAt ??
+        (await getProcessStartTime(proc.pid, {
+          sharedKey: `${proc.pid}:${proc.ppid}:${proc.name}:${proc.cmd ?? ""}`,
+        }));
       sessionId = geminiData.sessionId;
       tokenUsage = geminiData.tokenUsage;
       model = geminiData.model;

--- a/src/scanner/index.ts
+++ b/src/scanner/index.ts
@@ -8,8 +8,6 @@
 
 import { readFile, readdir } from "node:fs/promises";
 import { join } from "node:path";
-import pidusage from "pidusage";
-import psList from "ps-list";
 import type { MarmonitorConfig } from "../config/index.js";
 import { resolveRuntimeDataPaths } from "../config/index.js";
 import { profileAsync } from "../perf.js";
@@ -42,6 +40,7 @@ import {
   getProcessCwd,
   getProcessStartTime,
 } from "./process.js";
+import { getPidUsageCached, listProcessesCached } from "./runtime-snapshot.js";
 import { detectCliStdoutPhase, determineStatus } from "./status.js";
 
 import type { ScanOptions } from "./types.js";
@@ -60,7 +59,7 @@ export async function scanAgents(
   const seenPids = new Set<number>();
 
   // 1. Find running processes
-  const processes = await profileAsync("scanAgents", "ps_list", () => psList());
+  const processes = await listProcessesCached();
 
   // Filter to agent processes
   const agentProcesses: Array<{ proc: (typeof processes)[0]; agentName: string }> = [];
@@ -83,7 +82,7 @@ export async function scanAgents(
   let usageMap: Record<number, { cpu: number; memory: number }> = {};
   if (pids.length > 0) {
     try {
-      usageMap = await profileAsync("scanAgents", "pidusage", () => pidusage(pids));
+      usageMap = await getPidUsageCached(pids);
     } catch {
       // some PIDs may have exited
     }

--- a/src/scanner/index.ts
+++ b/src/scanner/index.ts
@@ -6,12 +6,13 @@
  * and determines activity status.
  */
 
-import { existsSync } from "node:fs";
 import { readFile, readdir } from "node:fs/promises";
 import { join } from "node:path";
 import pidusage from "pidusage";
 import psList from "ps-list";
 import type { MarmonitorConfig } from "../config/index.js";
+import { resolveRuntimeDataPaths } from "../config/index.js";
+import { profileAsync } from "../perf.js";
 import type { AgentSession, SessionPhase, TokenUsage } from "../types.js";
 
 // ─── Re-exports (public API) ──────────────────────────────────────
@@ -23,6 +24,7 @@ export { parseGeminiSessionContent } from "./gemini.js";
 
 // ─── Internal imports ─────────────────────────────────────────────
 
+import { selectCodexSession } from "../output/utils.js";
 import { sessionEnrichmentCache } from "./cache.js";
 import {
   detectClaudePhase,
@@ -30,7 +32,8 @@ import {
   parseClaudeSession,
   parseClaudeTokens,
 } from "./claude.js";
-import { detectCodexPhase, indexCodexSessions, matchCodexSession } from "./codex.js";
+import { detectCodexPhase, indexCodexSessions } from "./codex.js";
+import type { CodexSessionMeta } from "./codex.js";
 import { parseGeminiSession } from "./gemini.js";
 import { groupByParent } from "./group.js";
 import {
@@ -52,10 +55,12 @@ export async function scanAgents(
 ): Promise<AgentSession[]> {
   const enrichmentMode = options.enrichmentMode ?? "full";
   const isFullEnrichment = enrichmentMode === "full";
+  const includeTokenUsage = options.includeTokenUsage ?? isFullEnrichment;
+  const includeStdoutHeuristic = options.includeStdoutHeuristic ?? isFullEnrichment;
   const seenPids = new Set<number>();
 
   // 1. Find running processes
-  const processes = await psList();
+  const processes = await profileAsync("scanAgents", "ps_list", () => psList());
 
   // Filter to agent processes
   const agentProcesses: Array<{ proc: (typeof processes)[0]; agentName: string }> = [];
@@ -67,17 +72,41 @@ export async function scanAgents(
     agentProcesses.push({ proc, agentName });
   }
 
+  if (agentProcesses.length === 0 && !config.display.showDead) {
+    return [];
+  }
+
+  const runtimePaths = resolveRuntimeDataPaths(config);
+
   // 2. Batch pidusage
   const pids = agentProcesses.map((a) => a.proc.pid);
   let usageMap: Record<number, { cpu: number; memory: number }> = {};
-  try {
-    usageMap = await pidusage(pids);
-  } catch {
-    // some PIDs may have exited
+  if (pids.length > 0) {
+    try {
+      usageMap = await profileAsync("scanAgents", "pidusage", () => pidusage(pids));
+    } catch {
+      // some PIDs may have exited
+    }
   }
 
   // 3. Pre-index Codex sessions (once, shared across all Codex processes)
-  const codexSessions = isFullEnrichment ? await indexCodexSessions(config) : [];
+  const codexProcesses = agentProcesses.filter((a) => a.agentName === "Codex");
+  let codexSessions: CodexSessionMeta[] = [];
+  let codexSessionsByCwd: Map<string, CodexSessionMeta[]> | undefined;
+  if (codexProcesses.length > 0) {
+    codexSessions = await profileAsync("scanAgents", "codex_index", () =>
+      indexCodexSessions(config, { includeTokenUsage, runtimePaths }),
+    );
+    codexSessionsByCwd = new Map();
+    for (const session of codexSessions) {
+      const list = codexSessionsByCwd.get(session.cwd);
+      if (list) {
+        list.push(session);
+      } else {
+        codexSessionsByCwd.set(session.cwd, [session]);
+      }
+    }
+  }
 
   // 4. Build sessions with enrichment (parallel)
   const sessionPromises = agentProcesses.map(async ({ proc, agentName }) => {
@@ -113,7 +142,10 @@ export async function scanAgents(
       lastResponseAt = cachedEnrichment.lastResponseAt;
       lastActivityAt = cachedEnrichment.lastActivityAt;
     } else if (agentName === "Claude Code") {
-      const claudeData = await parseClaudeSession(proc.pid, config);
+      const claudeData = await parseClaudeSession(proc.pid, config, {
+        includeTokenUsage,
+        runtimePaths,
+      });
       if (claudeData.cwd) cwd = claudeData.cwd;
       if (cwd === "unknown") cwd = (await getProcessCwd(proc.pid)) ?? "unknown";
       sessionId = claudeData.sessionId;
@@ -124,16 +156,27 @@ export async function scanAgents(
       lastActivityAt = claudeData.lastActivityAt;
 
       if (sessionId && cwd) {
-        const phaseResult = await detectClaudePhase(sessionId, cwd, startedAt, config);
+        const phaseResult = await detectClaudePhase(
+          sessionId,
+          cwd,
+          startedAt,
+          config,
+          runtimePaths,
+        );
         phase = phaseResult.phase;
         lastResponseAt = phaseResult.lastResponseAt;
         lastActivityAt = phaseResult.lastActivityAt ?? lastActivityAt;
       }
     } else if (agentName === "Codex") {
       cwd = cachedEnrichment?.cwd ?? (await getProcessCwd(proc.pid)) ?? "unknown";
-      const processStartTime = await getProcessStartTime(proc.pid);
-
-      const matched = matchCodexSession(cwd, processStartTime, codexSessions);
+      const cwdMatches = codexSessionsByCwd?.get(cwd) ?? [];
+      let matched: CodexSessionMeta | undefined;
+      if (cwdMatches.length === 1) {
+        matched = cwdMatches[0];
+      } else if (cwdMatches.length > 1) {
+        const processStartTime = await getProcessStartTime(proc.pid);
+        matched = selectCodexSession(cwd, processStartTime, cwdMatches);
+      }
       if (matched) {
         sessionMatched = true;
         sessionId = matched.id;
@@ -154,12 +197,14 @@ export async function scanAgents(
 
       // Detect phase from session JSONL
       phase = await detectCodexPhase(codexSessionFile, config);
-      if (phase !== "permission" && runtimeSource === "cli") {
+      if (includeStdoutHeuristic && phase !== "permission" && runtimeSource === "cli") {
         phase = (await detectCliStdoutPhase({ pid: proc.pid, cwd }, config)) ?? phase;
       }
     } else if (agentName === "Gemini") {
       cwd = cachedEnrichment?.cwd ?? (await getProcessCwd(proc.pid)) ?? "unknown";
-      const geminiData = await parseGeminiSession(cwd);
+      const geminiData = await parseGeminiSession(cwd, {
+        includeTokenUsage,
+      });
       startedAt = geminiData.startedAt ?? (await getProcessStartTime(proc.pid));
       sessionId = geminiData.sessionId;
       tokenUsage = geminiData.tokenUsage;
@@ -168,7 +213,7 @@ export async function scanAgents(
       lastResponseAt = geminiData.lastResponseAt;
       lastActivityAt = geminiData.lastActivityAt;
       sessionMatched = geminiData.sessionMatched ?? true;
-      if (phase !== "permission") {
+      if (includeStdoutHeuristic && phase !== "permission") {
         phase = (await detectCliStdoutPhase({ pid: proc.pid, cwd }, config)) ?? phase;
       }
     }
@@ -218,13 +263,14 @@ export async function scanAgents(
     return session;
   });
 
-  const results = await Promise.all(sessionPromises);
+  const results = await profileAsync("scanAgents", "build_sessions", () =>
+    Promise.all(sessionPromises),
+  );
   const sessions: AgentSession[] = results.filter((s): s is AgentSession => s !== null);
 
   // 5. Check for dead sessions (Claude: session file exists but process gone)
   if (config.display.showDead) {
-    for (const claudeSessionDir of getClaudeSessionRoots(config)) {
-      if (!existsSync(claudeSessionDir)) continue;
+    for (const claudeSessionDir of getClaudeSessionRoots(config, runtimePaths)) {
       try {
         const files = await readdir(claudeSessionDir);
         for (const file of files) {
@@ -247,6 +293,7 @@ export async function scanAgents(
                 data.cwd,
                 undefined,
                 config,
+                runtimePaths,
               );
               tokenUsage = tokenData.tokenUsage;
               model = tokenData.model;

--- a/src/scanner/process.ts
+++ b/src/scanner/process.ts
@@ -6,6 +6,7 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 
 import type { MarmonitorConfig } from "../config/index.js";
+import { profileAsync } from "../perf.js";
 import type { RuntimeSource } from "../types.js";
 import {
   PROCESS_CWD_TTL_MS,
@@ -13,32 +14,71 @@ import {
   processCwdCache,
   processStartCache,
 } from "./cache.js";
+import { readSharedCache, writeSharedCache } from "./shared-cache.js";
 
 export const execFileAsync = promisify(execFile);
 
+interface ProcessCwdOptions {
+  cacheRoot?: string;
+  nowMs?: number;
+  execFile?: typeof execFileAsync;
+}
+
 /** Get process cwd via lsof (fallback for non-Claude agents) */
-export async function getProcessCwd(pid: number): Promise<string | undefined> {
+export async function getProcessCwd(
+  pid: number,
+  options: ProcessCwdOptions = {},
+): Promise<string | undefined> {
+  const nowMs = options.nowMs ?? Date.now();
   const cached = processCwdCache.get(pid);
-  if (cached && Date.now() - cached.checkedAt < PROCESS_CWD_TTL_MS) {
+  if (cached && nowMs - cached.checkedAt < PROCESS_CWD_TTL_MS) {
     return cached.cwd;
   }
 
-  try {
-    const { stdout } = await execFileAsync("lsof", ["-p", String(pid), "-Fn"], {
-      encoding: "utf-8",
-      timeout: 3000,
+  const sharedCached = await readSharedCache<string | undefined>(
+    "process-cwd",
+    String(pid),
+    PROCESS_CWD_TTL_MS,
+    {
+      cacheRoot: options.cacheRoot,
+      nowMs,
+    },
+  );
+  if (sharedCached) {
+    processCwdCache.set(pid, {
+      checkedAt: sharedCached.checkedAt,
+      cwd: sharedCached.value,
     });
+    return sharedCached.value;
+  }
+
+  const runExecFile = options.execFile ?? execFileAsync;
+  try {
+    const { stdout } = await profileAsync("process", "lsof", () =>
+      runExecFile("lsof", ["-a", "-d", "cwd", "-p", String(pid), "-Fn"], {
+        encoding: "utf-8",
+        timeout: 3000,
+      }),
+    );
     const match = stdout.split("\n").find((line) => line.startsWith("n/"));
     const cwd = match ? match.slice(1) : undefined;
     processCwdCache.set(pid, {
-      checkedAt: Date.now(),
+      checkedAt: nowMs,
       cwd,
+    });
+    await writeSharedCache("process-cwd", String(pid), cwd, {
+      cacheRoot: options.cacheRoot,
+      nowMs,
     });
     return cwd;
   } catch {
     processCwdCache.set(pid, {
-      checkedAt: Date.now(),
+      checkedAt: nowMs,
       cwd: undefined,
+    });
+    await writeSharedCache("process-cwd", String(pid), undefined, {
+      cacheRoot: options.cacheRoot,
+      nowMs,
     });
     return undefined;
   }
@@ -51,10 +91,12 @@ export async function getProcessStartTime(pid: number): Promise<number | undefin
   }
 
   try {
-    const { stdout } = await execFileAsync("ps", ["-o", "lstart=", "-p", String(pid)], {
-      encoding: "utf-8",
-      timeout: 2000,
-    });
+    const { stdout } = await profileAsync("process", "ps_lstart", () =>
+      execFileAsync("ps", ["-o", "lstart=", "-p", String(pid)], {
+        encoding: "utf-8",
+        timeout: 2000,
+      }),
+    );
     const trimmed = stdout.trim();
     const startedAt = trimmed ? new Date(trimmed).getTime() / 1000 : undefined;
     processStartCache.set(pid, {

--- a/src/scanner/process.ts
+++ b/src/scanner/process.ts
@@ -24,6 +24,12 @@ interface ProcessCwdOptions {
   execFile?: typeof execFileAsync;
 }
 
+interface ProcessStartOptions {
+  cacheRoot?: string;
+  nowMs?: number;
+  execFile?: typeof execFileAsync;
+}
+
 /** Get process cwd via lsof (fallback for non-Claude agents) */
 export async function getProcessCwd(
   pid: number,
@@ -84,15 +90,37 @@ export async function getProcessCwd(
   }
 }
 
-export async function getProcessStartTime(pid: number): Promise<number | undefined> {
+export async function getProcessStartTime(
+  pid: number,
+  options: ProcessStartOptions = {},
+): Promise<number | undefined> {
+  const nowMs = options.nowMs ?? Date.now();
   const cached = processStartCache.get(pid);
-  if (cached && Date.now() - cached.checkedAt < PROCESS_START_TTL_MS) {
+  if (cached && nowMs - cached.checkedAt < PROCESS_START_TTL_MS) {
     return cached.startedAt;
   }
 
+  const sharedCached = await readSharedCache<number | undefined>(
+    "process-start",
+    String(pid),
+    PROCESS_START_TTL_MS,
+    {
+      cacheRoot: options.cacheRoot,
+      nowMs,
+    },
+  );
+  if (sharedCached) {
+    processStartCache.set(pid, {
+      checkedAt: sharedCached.checkedAt,
+      startedAt: sharedCached.value,
+    });
+    return sharedCached.value;
+  }
+
+  const runExecFile = options.execFile ?? execFileAsync;
   try {
     const { stdout } = await profileAsync("process", "ps_lstart", () =>
-      execFileAsync("ps", ["-o", "lstart=", "-p", String(pid)], {
+      runExecFile("ps", ["-o", "lstart=", "-p", String(pid)], {
         encoding: "utf-8",
         timeout: 2000,
       }),
@@ -100,14 +128,22 @@ export async function getProcessStartTime(pid: number): Promise<number | undefin
     const trimmed = stdout.trim();
     const startedAt = trimmed ? new Date(trimmed).getTime() / 1000 : undefined;
     processStartCache.set(pid, {
-      checkedAt: Date.now(),
+      checkedAt: nowMs,
       startedAt,
+    });
+    await writeSharedCache("process-start", String(pid), startedAt, {
+      cacheRoot: options.cacheRoot,
+      nowMs,
     });
     return startedAt;
   } catch {
     processStartCache.set(pid, {
-      checkedAt: Date.now(),
+      checkedAt: nowMs,
       startedAt: undefined,
+    });
+    await writeSharedCache("process-start", String(pid), undefined, {
+      cacheRoot: options.cacheRoot,
+      nowMs,
     });
     return undefined;
   }

--- a/src/scanner/process.ts
+++ b/src/scanner/process.ts
@@ -10,6 +10,7 @@ import { profileAsync } from "../perf.js";
 import type { RuntimeSource } from "../types.js";
 import {
   PROCESS_CWD_TTL_MS,
+  PROCESS_START_SHARED_TTL_MS,
   PROCESS_START_TTL_MS,
   processCwdCache,
   processStartCache,
@@ -28,6 +29,8 @@ interface ProcessStartOptions {
   cacheRoot?: string;
   nowMs?: number;
   execFile?: typeof execFileAsync;
+  sharedKey?: string;
+  sharedTtlMs?: number;
 }
 
 /** Get process cwd via lsof (fallback for non-Claude agents) */
@@ -95,26 +98,30 @@ export async function getProcessStartTime(
   options: ProcessStartOptions = {},
 ): Promise<number | undefined> {
   const nowMs = options.nowMs ?? Date.now();
+  const sharedKey = options.sharedKey ?? String(pid);
+  const sharedTtlMs = options.sharedTtlMs ?? PROCESS_START_SHARED_TTL_MS;
   const cached = processStartCache.get(pid);
   if (cached && nowMs - cached.checkedAt < PROCESS_START_TTL_MS) {
     return cached.startedAt;
   }
 
-  const sharedCached = await readSharedCache<number | undefined>(
-    "process-start",
-    String(pid),
-    PROCESS_START_TTL_MS,
-    {
-      cacheRoot: options.cacheRoot,
-      nowMs,
-    },
-  );
-  if (sharedCached) {
-    processStartCache.set(pid, {
-      checkedAt: sharedCached.checkedAt,
-      startedAt: sharedCached.value,
-    });
-    return sharedCached.value;
+  if (sharedTtlMs > 0) {
+    const sharedCached = await readSharedCache<number | undefined>(
+      "process-start",
+      sharedKey,
+      sharedTtlMs,
+      {
+        cacheRoot: options.cacheRoot,
+        nowMs,
+      },
+    );
+    if (sharedCached) {
+      processStartCache.set(pid, {
+        checkedAt: sharedCached.checkedAt,
+        startedAt: sharedCached.value,
+      });
+      return sharedCached.value;
+    }
   }
 
   const runExecFile = options.execFile ?? execFileAsync;
@@ -131,20 +138,24 @@ export async function getProcessStartTime(
       checkedAt: nowMs,
       startedAt,
     });
-    await writeSharedCache("process-start", String(pid), startedAt, {
-      cacheRoot: options.cacheRoot,
-      nowMs,
-    });
+    if (sharedTtlMs > 0) {
+      await writeSharedCache("process-start", sharedKey, startedAt, {
+        cacheRoot: options.cacheRoot,
+        nowMs,
+      });
+    }
     return startedAt;
   } catch {
     processStartCache.set(pid, {
       checkedAt: nowMs,
       startedAt: undefined,
     });
-    await writeSharedCache("process-start", String(pid), undefined, {
-      cacheRoot: options.cacheRoot,
-      nowMs,
-    });
+    if (sharedTtlMs > 0) {
+      await writeSharedCache("process-start", sharedKey, undefined, {
+        cacheRoot: options.cacheRoot,
+        nowMs,
+      });
+    }
     return undefined;
   }
 }

--- a/src/scanner/runtime-snapshot.ts
+++ b/src/scanner/runtime-snapshot.ts
@@ -1,0 +1,107 @@
+/**
+ * Short-lived cross-process caches for process scans and pidusage.
+ */
+
+import pidusage from "pidusage";
+import psList from "ps-list";
+
+import { profileAsync } from "../perf.js";
+import { readSharedCache, writeSharedCache } from "./shared-cache.js";
+
+const PROCESS_LIST_SHARED_TTL_MS = 1_000;
+const PIDUSAGE_SHARED_TTL_MS = 1_000;
+
+type ProcessListEntry = Awaited<ReturnType<typeof psList>>[number];
+type ProcessUsageMap = Record<number, { cpu: number; memory: number }>;
+
+interface SharedSnapshotOptions {
+  cacheRoot?: string;
+  nowMs?: number;
+}
+
+interface ProcessListOptions extends SharedSnapshotOptions {
+  psList?: typeof psList;
+}
+
+interface PidUsageOptions extends SharedSnapshotOptions {
+  pidusage?: typeof pidusage;
+}
+
+function normalizeProcesses(processes: ProcessListEntry[]): ProcessListEntry[] {
+  return processes.map((proc) => ({
+    pid: proc.pid,
+    ppid: proc.ppid,
+    name: proc.name,
+    cmd: proc.cmd,
+  }));
+}
+
+function normalizePidUsage(usage: Awaited<ReturnType<typeof pidusage>>): ProcessUsageMap {
+  const normalized: ProcessUsageMap = {};
+  for (const [pid, stats] of Object.entries(usage)) {
+    normalized[Number(pid)] = {
+      cpu: stats.cpu,
+      memory: stats.memory,
+    };
+  }
+  return normalized;
+}
+
+export async function listProcessesCached(
+  options: ProcessListOptions = {},
+): Promise<ProcessListEntry[]> {
+  const nowMs = options.nowMs ?? Date.now();
+  const sharedCached = await readSharedCache<ProcessListEntry[]>(
+    "process-list",
+    "all",
+    PROCESS_LIST_SHARED_TTL_MS,
+    {
+      cacheRoot: options.cacheRoot,
+      nowMs,
+    },
+  );
+  if (sharedCached) {
+    return sharedCached.value;
+  }
+
+  const runPsList = options.psList ?? psList;
+  const processes = await profileAsync("scanAgents", "ps_list", () => runPsList());
+  const normalized = normalizeProcesses(processes);
+  await writeSharedCache("process-list", "all", normalized, {
+    cacheRoot: options.cacheRoot,
+    nowMs,
+  });
+  return normalized;
+}
+
+export async function getPidUsageCached(
+  pids: number[],
+  options: PidUsageOptions = {},
+): Promise<ProcessUsageMap> {
+  const normalizedPids = [...new Set(pids)].sort((a, b) => a - b);
+  if (normalizedPids.length === 0) return {};
+
+  const nowMs = options.nowMs ?? Date.now();
+  const sharedKey = normalizedPids.join(",");
+  const sharedCached = await readSharedCache<ProcessUsageMap>(
+    "pidusage",
+    sharedKey,
+    PIDUSAGE_SHARED_TTL_MS,
+    {
+      cacheRoot: options.cacheRoot,
+      nowMs,
+    },
+  );
+  if (sharedCached) {
+    return sharedCached.value;
+  }
+
+  const runPidusage = options.pidusage ?? pidusage;
+  const usage = await profileAsync("scanAgents", "pidusage", () => runPidusage(normalizedPids));
+  const normalized = normalizePidUsage(usage);
+  await writeSharedCache("pidusage", sharedKey, normalized, {
+    cacheRoot: options.cacheRoot,
+    nowMs,
+  });
+  return normalized;
+}

--- a/src/scanner/runtime-snapshot.ts
+++ b/src/scanner/runtime-snapshot.ts
@@ -47,6 +47,12 @@ function normalizePidUsage(usage: Awaited<ReturnType<typeof pidusage>>): Process
   return normalized;
 }
 
+export async function listProcesses(options: ProcessListOptions = {}): Promise<ProcessListEntry[]> {
+  const runPsList = options.psList ?? psList;
+  const processes = await profileAsync("scanAgents", "ps_list", () => runPsList());
+  return normalizeProcesses(processes);
+}
+
 export async function listProcessesCached(
   options: ProcessListOptions = {},
 ): Promise<ProcessListEntry[]> {
@@ -64,14 +70,24 @@ export async function listProcessesCached(
     return sharedCached.value;
   }
 
-  const runPsList = options.psList ?? psList;
-  const processes = await profileAsync("scanAgents", "ps_list", () => runPsList());
-  const normalized = normalizeProcesses(processes);
+  const normalized = await listProcesses(options);
   await writeSharedCache("process-list", "all", normalized, {
     cacheRoot: options.cacheRoot,
     nowMs,
   });
   return normalized;
+}
+
+export async function getPidUsage(
+  pids: number[],
+  options: PidUsageOptions = {},
+): Promise<ProcessUsageMap> {
+  const normalizedPids = [...new Set(pids)].sort((a, b) => a - b);
+  if (normalizedPids.length === 0) return {};
+
+  const runPidusage = options.pidusage ?? pidusage;
+  const usage = await profileAsync("scanAgents", "pidusage", () => runPidusage(normalizedPids));
+  return normalizePidUsage(usage);
 }
 
 export async function getPidUsageCached(
@@ -96,9 +112,7 @@ export async function getPidUsageCached(
     return sharedCached.value;
   }
 
-  const runPidusage = options.pidusage ?? pidusage;
-  const usage = await profileAsync("scanAgents", "pidusage", () => runPidusage(normalizedPids));
-  const normalized = normalizePidUsage(usage);
+  const normalized = await getPidUsage(normalizedPids, options);
   await writeSharedCache("pidusage", sharedKey, normalized, {
     cacheRoot: options.cacheRoot,
     nowMs,

--- a/src/scanner/shared-cache.ts
+++ b/src/scanner/shared-cache.ts
@@ -1,0 +1,69 @@
+/**
+ * Small cross-process cache helpers backed by files under TMPDIR.
+ */
+
+import { createHash } from "node:crypto";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+export interface SharedCacheRecord<T> {
+  checkedAt: number;
+  value: T;
+}
+
+interface SharedCacheOptions {
+  cacheRoot?: string;
+  nowMs?: number;
+}
+
+function resolveSharedCacheRoot(cacheRoot?: string): string {
+  return cacheRoot ?? join(tmpdir(), "marmonitor", "shared");
+}
+
+function resolveSharedCachePath(namespace: string, key: string, cacheRoot?: string): string {
+  const digest = createHash("sha1").update(`${namespace}:${key}`).digest("hex");
+  return join(resolveSharedCacheRoot(cacheRoot), `${namespace}-${digest}.json`);
+}
+
+export async function readSharedCache<T>(
+  namespace: string,
+  key: string,
+  ttlMs: number,
+  options: SharedCacheOptions = {},
+): Promise<SharedCacheRecord<T> | undefined> {
+  if (ttlMs <= 0) return undefined;
+  const path = resolveSharedCachePath(namespace, key, options.cacheRoot);
+  const nowMs = options.nowMs ?? Date.now();
+
+  try {
+    const fileStat = await stat(path);
+    const raw = JSON.parse(await readFile(path, "utf-8")) as {
+      checkedAt?: unknown;
+      value?: T;
+    };
+    const checkedAt =
+      typeof raw.checkedAt === "number" ? raw.checkedAt : Math.floor(fileStat.mtimeMs);
+    if (nowMs - checkedAt > ttlMs) return undefined;
+    return { checkedAt, value: raw.value as T };
+  } catch {
+    return undefined;
+  }
+}
+
+export async function writeSharedCache<T>(
+  namespace: string,
+  key: string,
+  value: T,
+  options: SharedCacheOptions = {},
+): Promise<void> {
+  const path = resolveSharedCachePath(namespace, key, options.cacheRoot);
+  const checkedAt = options.nowMs ?? Date.now();
+
+  try {
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, JSON.stringify({ checkedAt, value }), "utf-8");
+  } catch {
+    // cross-process cache failures must never break scanning
+  }
+}

--- a/src/scanner/shared-cache.ts
+++ b/src/scanner/shared-cache.ts
@@ -2,8 +2,8 @@
  * Small cross-process cache helpers backed by files under TMPDIR.
  */
 
-import { createHash } from "node:crypto";
-import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { createHash, randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -59,11 +59,14 @@ export async function writeSharedCache<T>(
 ): Promise<void> {
   const path = resolveSharedCachePath(namespace, key, options.cacheRoot);
   const checkedAt = options.nowMs ?? Date.now();
+  const tempPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
 
   try {
     await mkdir(dirname(path), { recursive: true });
-    await writeFile(path, JSON.stringify({ checkedAt, value }), "utf-8");
+    await writeFile(tempPath, JSON.stringify({ checkedAt, value }), "utf-8");
+    await rename(tempPath, path);
   } catch {
+    await rm(tempPath, { force: true }).catch(() => undefined);
     // cross-process cache failures must never break scanning
   }
 }

--- a/src/scanner/status.ts
+++ b/src/scanner/status.ts
@@ -4,9 +4,18 @@
 
 import type { MarmonitorConfig } from "../config/index.js";
 import { detectApprovalPromptPhase } from "../output/utils.js";
+import { profileAsync } from "../perf.js";
 import { captureTmuxPaneOutput, resolveTmuxJumpTarget } from "../tmux/index.js";
 import type { AgentSession, SessionPhase, SessionStatus } from "../types.js";
 import { RECENT_ACTIVITY_ACTIVE_SEC, stdoutHeuristicCache } from "./cache.js";
+import { readSharedCache, writeSharedCache } from "./shared-cache.js";
+
+interface StdoutPhaseDetectionOptions {
+  cacheRoot?: string;
+  nowMs?: number;
+  resolveTmuxJumpTarget?: typeof resolveTmuxJumpTarget;
+  captureTmuxPaneOutput?: typeof captureTmuxPaneOutput;
+}
 
 /** Determine agent activity status */
 export function determineStatus(
@@ -42,26 +51,59 @@ export function determineStatus(
 export async function detectCliStdoutPhase(
   agent: Pick<AgentSession, "pid" | "cwd">,
   config: MarmonitorConfig,
+  options: StdoutPhaseDetectionOptions = {},
 ): Promise<SessionPhase> {
-  const cached = stdoutHeuristicCache.get(agent.pid);
-  if (cached && Date.now() - cached.checkedAt < config.performance.stdoutHeuristicTtlMs) {
-    return cached.phase;
-  }
+  return await profileAsync("stdout_heuristic", "detectCliStdoutPhase", async () => {
+    const nowMs = options.nowMs ?? Date.now();
+    const cached = stdoutHeuristicCache.get(agent.pid);
+    if (cached && nowMs - cached.checkedAt < config.performance.stdoutHeuristicTtlMs) {
+      return cached.phase;
+    }
 
-  const target = await resolveTmuxJumpTarget(agent);
-  if (!target) {
-    stdoutHeuristicCache.set(agent.pid, { checkedAt: Date.now(), phase: undefined });
-    return undefined;
-  }
+    const sharedKey = `${agent.pid}:${agent.cwd}`;
+    const sharedCached = await readSharedCache<SessionPhase>(
+      "stdout-heuristic",
+      sharedKey,
+      config.performance.stdoutHeuristicTtlMs,
+      {
+        cacheRoot: options.cacheRoot,
+        nowMs,
+      },
+    );
+    if (sharedCached) {
+      stdoutHeuristicCache.set(agent.pid, {
+        checkedAt: sharedCached.checkedAt,
+        phase: sharedCached.value,
+      });
+      return sharedCached.value;
+    }
 
-  const output = await captureTmuxPaneOutput(target, 30);
-  const phase = output
-    ? detectApprovalPromptPhase(
-        output,
-        config.status.stdoutHeuristic.approvalPatterns,
-        config.status.stdoutHeuristic.clearPatterns,
-      )
-    : undefined;
-  stdoutHeuristicCache.set(agent.pid, { checkedAt: Date.now(), phase });
-  return phase;
+    const resolveTarget = options.resolveTmuxJumpTarget ?? resolveTmuxJumpTarget;
+    const captureOutput = options.captureTmuxPaneOutput ?? captureTmuxPaneOutput;
+
+    const target = await resolveTarget(agent);
+    if (!target) {
+      stdoutHeuristicCache.set(agent.pid, { checkedAt: nowMs, phase: undefined });
+      await writeSharedCache("stdout-heuristic", sharedKey, undefined, {
+        cacheRoot: options.cacheRoot,
+        nowMs,
+      });
+      return undefined;
+    }
+
+    const output = await captureOutput(target, 30);
+    const phase = output
+      ? detectApprovalPromptPhase(
+          output,
+          config.status.stdoutHeuristic.approvalPatterns,
+          config.status.stdoutHeuristic.clearPatterns,
+        )
+      : undefined;
+    stdoutHeuristicCache.set(agent.pid, { checkedAt: nowMs, phase });
+    await writeSharedCache("stdout-heuristic", sharedKey, phase, {
+      cacheRoot: options.cacheRoot,
+      nowMs,
+    });
+    return phase;
+  });
 }

--- a/src/scanner/types.ts
+++ b/src/scanner/types.ts
@@ -4,4 +4,6 @@
 
 export interface ScanOptions {
   enrichmentMode?: "full" | "light";
+  includeTokenUsage?: boolean;
+  includeStdoutHeuristic?: boolean;
 }

--- a/src/scanner/types.ts
+++ b/src/scanner/types.ts
@@ -6,4 +6,5 @@ export interface ScanOptions {
   enrichmentMode?: "full" | "light";
   includeTokenUsage?: boolean;
   includeStdoutHeuristic?: boolean;
+  useSharedRuntimeSnapshots?: boolean;
 }

--- a/src/snapshot-cache.ts
+++ b/src/snapshot-cache.ts
@@ -1,0 +1,115 @@
+import { mkdir, open, stat, unlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+export const SNAPSHOT_LOCK_STALE_MS = 15_000;
+
+function cacheDir(root = tmpdir()): string {
+  return join(root, "marmonitor");
+}
+
+export function statuslineCacheFile(
+  format: string,
+  attentionLimit: number,
+  width?: number,
+  root = tmpdir(),
+): string {
+  const widthKey = width && width > 0 ? String(width) : "auto";
+  return join(cacheDir(root), `statusline-${format}-${attentionLimit}-${widthKey}.txt`);
+}
+
+export function snapshotCacheFile(
+  enrichmentMode: "full" | "light",
+  showDead: boolean,
+  root = tmpdir(),
+): string {
+  return join(cacheDir(root), `snapshot-${enrichmentMode}-${showDead ? "dead" : "alive"}.json`);
+}
+
+export function snapshotRefreshLockFile(
+  enrichmentMode: "full" | "light",
+  showDead: boolean,
+  root = tmpdir(),
+): string {
+  return join(cacheDir(root), `snapshot-${enrichmentMode}-${showDead ? "dead" : "alive"}.lock`);
+}
+
+export async function releaseSnapshotRefreshLock(
+  enrichmentMode: "full" | "light",
+  showDead: boolean,
+  root = tmpdir(),
+): Promise<void> {
+  try {
+    await unlink(snapshotRefreshLockFile(enrichmentMode, showDead, root));
+  } catch {
+    // cache lock cleanup must never break command execution
+  }
+}
+
+export async function acquireSnapshotRefreshLock(
+  enrichmentMode: "full" | "light",
+  showDead: boolean,
+  root = tmpdir(),
+): Promise<boolean> {
+  const path = snapshotRefreshLockFile(enrichmentMode, showDead, root);
+  try {
+    await mkdir(dirname(path), { recursive: true });
+  } catch {
+    return false;
+  }
+
+  try {
+    const handle = await open(path, "wx");
+    try {
+      await handle.writeFile(
+        JSON.stringify({
+          pid: process.pid,
+          createdAt: Date.now(),
+        }),
+      );
+    } finally {
+      await handle.close();
+    }
+    return true;
+  } catch (error) {
+    if (typeof error !== "object" || error === null || !("code" in error)) {
+      return false;
+    }
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+      return false;
+    }
+
+    try {
+      const fileStat = await stat(path);
+      if (Date.now() - fileStat.mtimeMs < SNAPSHOT_LOCK_STALE_MS) {
+        return false;
+      }
+    } catch {
+      return false;
+    }
+
+    try {
+      await unlink(path);
+    } catch {
+      return false;
+    }
+
+    try {
+      const handle = await open(path, "wx");
+      try {
+        await handle.writeFile(
+          JSON.stringify({
+            pid: process.pid,
+            createdAt: Date.now(),
+            recovered: true,
+          }),
+        );
+      } finally {
+        await handle.close();
+      }
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/src/snapshot-cache.ts
+++ b/src/snapshot-cache.ts
@@ -1,4 +1,5 @@
-import { mkdir, open, stat, unlink } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { mkdir, open, rename, rm, stat, unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -32,6 +33,19 @@ export function snapshotRefreshLockFile(
   root = tmpdir(),
 ): string {
   return join(cacheDir(root), `snapshot-${enrichmentMode}-${showDead ? "dead" : "alive"}.lock`);
+}
+
+export async function writeCacheFileAtomically(path: string, value: string): Promise<void> {
+  const tempPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
+
+  try {
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(tempPath, value, "utf-8");
+    await rename(tempPath, path);
+  } catch (error) {
+    await rm(tempPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
 }
 
 export async function releaseSnapshotRefreshLock(

--- a/src/tmux/index.ts
+++ b/src/tmux/index.ts
@@ -1,5 +1,6 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+import { profileAsync } from "../perf.js";
 import type { AgentSession } from "../types.js";
 
 const execFileAsync = promisify(execFile);
@@ -16,6 +17,16 @@ export interface TmuxPane {
 export interface TmuxJumpTarget {
   pane: TmuxPane;
   match: "pid-tree" | "cwd";
+}
+
+export interface TmuxRuntimeSnapshot {
+  panes: TmuxPane[];
+  childMap: Map<number, number[]>;
+}
+
+interface TmuxRuntimeSnapshotLoaders {
+  listPanes?: () => Promise<TmuxPane[]>;
+  getProcessTree?: () => Promise<Map<number, number[]>>;
 }
 
 export interface TmuxJumpResult {
@@ -111,14 +122,18 @@ export function selectTmuxPaneForAgent(
   return undefined;
 }
 
+let tmuxRuntimeSnapshotPromise: Promise<TmuxRuntimeSnapshot> | undefined;
+
 export async function listTmuxPanes(): Promise<TmuxPane[]> {
   try {
-    const { stdout } = await execFileAsync("tmux", [
-      "list-panes",
-      "-a",
-      "-F",
-      "#{session_name}:#{window_index}.#{pane_index}\t#{pane_pid}\t#{pane_current_path}",
-    ]);
+    const { stdout } = await profileAsync("tmux", "list_panes", () =>
+      execFileAsync("tmux", [
+        "list-panes",
+        "-a",
+        "-F",
+        "#{session_name}:#{window_index}.#{pane_index}\t#{pane_pid}\t#{pane_current_path}",
+      ]),
+    );
     return parseTmuxPanes(stdout);
   } catch {
     return [];
@@ -127,18 +142,51 @@ export async function listTmuxPanes(): Promise<TmuxPane[]> {
 
 export async function getProcessTree(): Promise<Map<number, number[]>> {
   try {
-    const { stdout } = await execFileAsync("ps", ["-eo", "pid=,ppid="]);
+    const { stdout } = await profileAsync("tmux", "process_tree", () =>
+      execFileAsync("ps", ["-eo", "pid=,ppid="]),
+    );
     return parseProcessTree(stdout);
   } catch {
     return new Map();
   }
 }
 
+export async function getTmuxRuntimeSnapshot(
+  loaders: TmuxRuntimeSnapshotLoaders = {},
+): Promise<TmuxRuntimeSnapshot> {
+  if (tmuxRuntimeSnapshotPromise) {
+    return await tmuxRuntimeSnapshotPromise;
+  }
+
+  const loadPanes = loaders.listPanes ?? listTmuxPanes;
+  const loadProcessTree = loaders.getProcessTree ?? getProcessTree;
+  const snapshotPromise = profileAsync("tmux", "resolve_snapshot", async () => {
+    const [panes, childMap] = await Promise.all([loadPanes(), loadProcessTree()]);
+    return { panes, childMap };
+  });
+  tmuxRuntimeSnapshotPromise = snapshotPromise;
+
+  try {
+    return await snapshotPromise;
+  } finally {
+    if (tmuxRuntimeSnapshotPromise === snapshotPromise) {
+      tmuxRuntimeSnapshotPromise = undefined;
+    }
+  }
+}
+
+export function resetTmuxRuntimeSnapshotForTests(): void {
+  tmuxRuntimeSnapshotPromise = undefined;
+}
+
 export async function resolveTmuxJumpTarget(
   agent: Pick<AgentSession, "pid" | "cwd">,
+  loaders: TmuxRuntimeSnapshotLoaders = {},
 ): Promise<TmuxJumpTarget | undefined> {
   try {
-    const [panes, childMap] = await Promise.all([listTmuxPanes(), getProcessTree()]);
+    const { panes, childMap } = await profileAsync("tmux", "resolve_jump_target", () =>
+      getTmuxRuntimeSnapshot(loaders),
+    );
     return selectTmuxPaneForAgent(agent, panes, childMap);
   } catch {
     return undefined;
@@ -150,14 +198,9 @@ export async function captureTmuxPaneOutput(
   lines = 30,
 ): Promise<string | undefined> {
   try {
-    const { stdout } = await execFileAsync("tmux", [
-      "capture-pane",
-      "-p",
-      "-t",
-      target.pane.target,
-      "-S",
-      `-${lines}`,
-    ]);
+    const { stdout } = await profileAsync("tmux", "capture_pane", () =>
+      execFileAsync("tmux", ["capture-pane", "-p", "-t", target.pane.target, "-S", `-${lines}`]),
+    );
     return stdout;
   } catch {
     return undefined;
@@ -169,14 +212,24 @@ export async function jumpToTmuxPane(target: TmuxJumpTarget): Promise<boolean> {
 
   try {
     if (process.env.TMUX) {
-      await execFileAsync("tmux", ["switch-client", "-t", windowTarget]);
-      await execFileAsync("tmux", ["select-window", "-t", windowTarget]);
-      await execFileAsync("tmux", ["select-pane", "-t", target.pane.target]);
+      await profileAsync("tmux", "switch_client", () =>
+        execFileAsync("tmux", ["switch-client", "-t", windowTarget]),
+      );
+      await profileAsync("tmux", "select_window", () =>
+        execFileAsync("tmux", ["select-window", "-t", windowTarget]),
+      );
+      await profileAsync("tmux", "select_pane", () =>
+        execFileAsync("tmux", ["select-pane", "-t", target.pane.target]),
+      );
       return true;
     }
 
-    await execFileAsync("tmux", ["select-window", "-t", windowTarget]);
-    await execFileAsync("tmux", ["select-pane", "-t", target.pane.target]);
+    await profileAsync("tmux", "select_window", () =>
+      execFileAsync("tmux", ["select-window", "-t", windowTarget]),
+    );
+    await profileAsync("tmux", "select_pane", () =>
+      execFileAsync("tmux", ["select-pane", "-t", target.pane.target]),
+    );
     return true;
   } catch {
     return false;

--- a/tests/guard.test.mjs
+++ b/tests/guard.test.mjs
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
+import { dirname, join } from "node:path";
 import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { getDefaults } from "../dist/config/index.js";
 import {
@@ -11,6 +13,7 @@ import {
 } from "../dist/guard/index.js";
 
 const execFileAsync = promisify(execFile);
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 
 describe("parseHookEvent", () => {
   it("parses Claude hook payload", () => {
@@ -151,7 +154,7 @@ describe("formatGuardOutput", () => {
 describe("guard CLI fail-open", () => {
   it("returns allow for malformed stdin payload", async () => {
     const { stdout } = await execFileAsync("node", ["bin/marmonitor.js", "guard"], {
-      cwd: "/Users/macrent/Documents/mjjo/marmonitor",
+      cwd: repoRoot,
       input: "{not-json",
     });
     assert.equal(stdout.trim(), '{"decision":"allow"}');

--- a/tests/runtime-cache.test.mjs
+++ b/tests/runtime-cache.test.mjs
@@ -1,12 +1,22 @@
 import assert from "node:assert/strict";
-import { mkdtemp } from "node:fs/promises";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it } from "node:test";
 
 import { getDefaults } from "../dist/config/index.js";
-import { processCwdCache, stdoutHeuristicCache } from "../dist/scanner/cache.js";
+import {
+  claudePhaseCache,
+  claudeProjectDirCache,
+  claudeSessionRegistry,
+  codexPhaseCache,
+  processCwdCache,
+  stdoutHeuristicCache,
+} from "../dist/scanner/cache.js";
+import { detectClaudePhase, resolveClaudeSessionFile } from "../dist/scanner/claude.js";
+import { detectCodexPhase } from "../dist/scanner/codex.js";
 import { getProcessCwd } from "../dist/scanner/process.js";
+import { getPidUsageCached, listProcessesCached } from "../dist/scanner/runtime-snapshot.js";
 import { detectCliStdoutPhase } from "../dist/scanner/status.js";
 
 describe("shared stdout heuristic cache", () => {
@@ -162,5 +172,261 @@ describe("shared process cwd cache", () => {
 
     assert.equal(second, undefined);
     assert.equal(execCalls, 1);
+  });
+});
+
+describe("shared process runtime snapshots", () => {
+  it("reuses ps-list results across fresh calls", async () => {
+    const cacheRoot = await mkdtemp(join(tmpdir(), "marmonitor-process-list-cache-"));
+    let calls = 0;
+
+    const first = await listProcessesCached({
+      cacheRoot,
+      nowMs: 1_000,
+      psList: async () => {
+        calls += 1;
+        return [
+          {
+            pid: 101,
+            ppid: 1,
+            name: "codex",
+            cmd: "codex --sandbox",
+          },
+        ];
+      },
+    });
+
+    assert.deepEqual(first, [
+      {
+        pid: 101,
+        ppid: 1,
+        name: "codex",
+        cmd: "codex --sandbox",
+      },
+    ]);
+    assert.equal(calls, 1);
+
+    const second = await listProcessesCached({
+      cacheRoot,
+      nowMs: 1_500,
+      psList: async () => {
+        throw new Error("shared cache miss");
+      },
+    });
+
+    assert.deepEqual(second, first);
+    assert.equal(calls, 1);
+  });
+
+  it("reuses pidusage results across fresh calls", async () => {
+    const cacheRoot = await mkdtemp(join(tmpdir(), "marmonitor-pidusage-cache-"));
+    let calls = 0;
+
+    const first = await getPidUsageCached([101, 202], {
+      cacheRoot,
+      nowMs: 1_000,
+      pidusage: async () => {
+        calls += 1;
+        return {
+          101: { cpu: 12.3, memory: 456 },
+          202: { cpu: 4.5, memory: 789 },
+        };
+      },
+    });
+
+    assert.deepEqual(first, {
+      101: { cpu: 12.3, memory: 456 },
+      202: { cpu: 4.5, memory: 789 },
+    });
+    assert.equal(calls, 1);
+
+    const second = await getPidUsageCached([202, 101], {
+      cacheRoot,
+      nowMs: 1_500,
+      pidusage: async () => {
+        throw new Error("shared cache miss");
+      },
+    });
+
+    assert.deepEqual(second, first);
+    assert.equal(calls, 1);
+  });
+});
+
+describe("shared Claude caches", () => {
+  it("reuses resolved Claude session files across in-memory cache clears", async () => {
+    const cacheRoot = await mkdtemp(join(tmpdir(), "marmonitor-claude-session-cache-"));
+    const projectRoot = await mkdtemp(join(tmpdir(), "marmonitor-claude-projects-"));
+    const cwd = "/tmp/shared-claude-project";
+    const sessionId = "claude-session-shared";
+    const startedAt = 1_717_171_717;
+    const projectDirName = cwd.replace(/[/.]/g, "-");
+    const sessionDir = join(projectRoot, projectDirName);
+    const sessionFile = join(sessionDir, `${sessionId}.jsonl`);
+    const runtimePaths = {
+      claudeProjects: [projectRoot],
+      claudeSessions: [],
+      codexSessions: [],
+      extraRoots: [],
+    };
+
+    await mkdir(sessionDir, { recursive: true });
+    await writeFile(sessionFile, "", "utf8");
+
+    claudeSessionRegistry.clear();
+    claudeProjectDirCache.clear();
+
+    const first = await resolveClaudeSessionFile(
+      sessionId,
+      cwd,
+      startedAt,
+      undefined,
+      runtimePaths,
+      {
+        cacheRoot,
+        nowMs: 1_000,
+      },
+    );
+
+    assert.equal(first, sessionFile);
+
+    claudeSessionRegistry.clear();
+    claudeProjectDirCache.clear();
+
+    const second = await resolveClaudeSessionFile(
+      sessionId,
+      cwd,
+      startedAt,
+      undefined,
+      {
+        claudeProjects: [],
+        claudeSessions: [],
+        codexSessions: [],
+        extraRoots: [],
+      },
+      {
+        cacheRoot,
+        nowMs: 2_000,
+      },
+    );
+
+    assert.equal(second, sessionFile);
+  });
+
+  it("reuses Claude phase results across in-memory cache clears", async () => {
+    const cacheRoot = await mkdtemp(join(tmpdir(), "marmonitor-claude-phase-cache-"));
+    const projectRoot = await mkdtemp(join(tmpdir(), "marmonitor-claude-projects-"));
+    const cwd = "/tmp/shared-claude-phase";
+    const sessionId = "claude-phase-shared";
+    const startedAt = 1_717_171_717;
+    const projectDirName = cwd.replace(/[/.]/g, "-");
+    const sessionDir = join(projectRoot, projectDirName);
+    const sessionFile = join(sessionDir, `${sessionId}.jsonl`);
+    const runtimePaths = {
+      claudeProjects: [projectRoot],
+      claudeSessions: [],
+      codexSessions: [],
+      extraRoots: [],
+    };
+
+    await mkdir(sessionDir, { recursive: true });
+    await writeFile(
+      sessionFile,
+      `${[
+        JSON.stringify({
+          type: "assistant",
+          timestamp: "2026-03-31T10:00:00.000Z",
+          message: {
+            stop_reason: "end_turn",
+            content: [{ type: "text", text: "done" }],
+          },
+        }),
+      ].join("\n")}\n`,
+      "utf8",
+    );
+
+    claudeSessionRegistry.clear();
+    claudeProjectDirCache.clear();
+    claudePhaseCache.clear();
+
+    const first = await detectClaudePhase(sessionId, cwd, startedAt, undefined, runtimePaths, {
+      cacheRoot,
+      nowMs: 1_000,
+    });
+
+    assert.deepEqual(first, {
+      phase: "done",
+      lastResponseAt: new Date("2026-03-31T10:00:00.000Z").getTime() / 1000,
+      lastActivityAt: new Date("2026-03-31T10:00:00.000Z").getTime() / 1000,
+    });
+
+    claudeSessionRegistry.clear();
+    claudeProjectDirCache.clear();
+    claudePhaseCache.clear();
+
+    const second = await detectClaudePhase(sessionId, cwd, startedAt, undefined, runtimePaths, {
+      cacheRoot,
+      nowMs: 2_000,
+      openFile: async () => {
+        throw new Error("shared cache miss");
+      },
+    });
+
+    assert.deepEqual(second, first);
+  });
+});
+
+describe("shared Codex phase cache", () => {
+  it("reuses Codex phase results across in-memory cache clears", async () => {
+    const cacheRoot = await mkdtemp(join(tmpdir(), "marmonitor-codex-phase-cache-"));
+    const sessionsRoot = await mkdtemp(join(tmpdir(), "marmonitor-codex-sessions-"));
+    const now = new Date();
+    const yyyy = now.getFullYear().toString();
+    const mm = String(now.getMonth() + 1).padStart(2, "0");
+    const dd = String(now.getDate()).padStart(2, "0");
+    const dayDir = join(sessionsRoot, yyyy, mm, dd);
+    const sessionFile = join(dayDir, "codex-phase-shared.jsonl");
+
+    await mkdir(dayDir, { recursive: true });
+    await writeFile(
+      sessionFile,
+      `${[
+        JSON.stringify({
+          type: "session_meta",
+          payload: {
+            id: "codex-phase-shared",
+            cwd: "/tmp/shared-codex-phase",
+            timestamp: new Date("2026-03-31T10:00:00.000Z").toISOString(),
+            model_provider: "gpt-5.4",
+          },
+        }),
+        JSON.stringify({
+          type: "event_msg",
+          payload: {
+            type: "token_count",
+          },
+        }),
+      ].join("\n")}\n`,
+      "utf8",
+    );
+
+    codexPhaseCache.clear();
+    const first = await detectCodexPhase(sessionFile, undefined, {
+      cacheRoot,
+      nowMs: 1_000,
+    });
+
+    assert.equal(first, "done");
+
+    codexPhaseCache.clear();
+    const second = await detectCodexPhase(sessionFile, undefined, {
+      cacheRoot,
+      nowMs: 2_000,
+      openFile: async () => {
+        throw new Error("shared cache miss");
+      },
+    });
+
+    assert.equal(second, "done");
   });
 });

--- a/tests/runtime-cache.test.mjs
+++ b/tests/runtime-cache.test.mjs
@@ -1,0 +1,166 @@
+import assert from "node:assert/strict";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+
+import { getDefaults } from "../dist/config/index.js";
+import { processCwdCache, stdoutHeuristicCache } from "../dist/scanner/cache.js";
+import { getProcessCwd } from "../dist/scanner/process.js";
+import { detectCliStdoutPhase } from "../dist/scanner/status.js";
+
+describe("shared stdout heuristic cache", () => {
+  it("reuses stdout heuristic result across in-memory cache clears", async () => {
+    const cacheRoot = await mkdtemp(join(tmpdir(), "marmonitor-stdout-cache-"));
+    const config = getDefaults();
+    config.performance.stdoutHeuristicTtlMs = 10_000;
+    const agent = { pid: 91_001, cwd: "/repo/shared-stdout" };
+    let resolveCalls = 0;
+    let captureCalls = 0;
+
+    stdoutHeuristicCache.clear();
+    const first = await detectCliStdoutPhase(agent, config, {
+      cacheRoot,
+      nowMs: 1_000,
+      resolveTmuxJumpTarget: async () => {
+        resolveCalls += 1;
+        return {
+          pane: {
+            target: "0:1.1",
+            sessionName: "0",
+            windowIndex: 1,
+            paneIndex: 1,
+            panePid: 1,
+            cwd: agent.cwd,
+          },
+          match: "cwd",
+        };
+      },
+      captureTmuxPaneOutput: async () => {
+        captureCalls += 1;
+        return "Action required\n1. Allow once";
+      },
+    });
+
+    assert.equal(first, "permission");
+    assert.equal(resolveCalls, 1);
+    assert.equal(captureCalls, 1);
+
+    stdoutHeuristicCache.clear();
+    const second = await detectCliStdoutPhase(agent, config, {
+      cacheRoot,
+      nowMs: 2_000,
+      resolveTmuxJumpTarget: async () => {
+        throw new Error("shared cache miss");
+      },
+      captureTmuxPaneOutput: async () => {
+        throw new Error("shared cache miss");
+      },
+    });
+
+    assert.equal(second, "permission");
+    assert.equal(resolveCalls, 1);
+    assert.equal(captureCalls, 1);
+  });
+
+  it("reuses negative stdout heuristic result across in-memory cache clears", async () => {
+    const cacheRoot = await mkdtemp(join(tmpdir(), "marmonitor-stdout-negative-"));
+    const config = getDefaults();
+    config.performance.stdoutHeuristicTtlMs = 10_000;
+    const agent = { pid: 91_002, cwd: "/repo/shared-stdout-negative" };
+    let resolveCalls = 0;
+
+    stdoutHeuristicCache.clear();
+    const first = await detectCliStdoutPhase(agent, config, {
+      cacheRoot,
+      nowMs: 1_000,
+      resolveTmuxJumpTarget: async () => {
+        resolveCalls += 1;
+        return undefined;
+      },
+    });
+
+    assert.equal(first, undefined);
+    assert.equal(resolveCalls, 1);
+
+    stdoutHeuristicCache.clear();
+    const second = await detectCliStdoutPhase(agent, config, {
+      cacheRoot,
+      nowMs: 2_000,
+      resolveTmuxJumpTarget: async () => {
+        throw new Error("shared cache miss");
+      },
+      captureTmuxPaneOutput: async () => {
+        throw new Error("shared cache miss");
+      },
+    });
+
+    assert.equal(second, undefined);
+    assert.equal(resolveCalls, 1);
+  });
+});
+
+describe("shared process cwd cache", () => {
+  it("reuses cwd results across in-memory cache clears", async () => {
+    const cacheRoot = await mkdtemp(join(tmpdir(), "marmonitor-cwd-cache-"));
+    let execCalls = 0;
+
+    processCwdCache.clear();
+    const first = await getProcessCwd(88_001, {
+      cacheRoot,
+      nowMs: 1_000,
+      execFile: async () => {
+        execCalls += 1;
+        return {
+          stdout: "p88001\nn/repo/shared-cwd\n",
+          stderr: "",
+        };
+      },
+    });
+
+    assert.equal(first, "/repo/shared-cwd");
+    assert.equal(execCalls, 1);
+
+    processCwdCache.clear();
+    const second = await getProcessCwd(88_001, {
+      cacheRoot,
+      nowMs: 2_000,
+      execFile: async () => {
+        throw new Error("shared cache miss");
+      },
+    });
+
+    assert.equal(second, "/repo/shared-cwd");
+    assert.equal(execCalls, 1);
+  });
+
+  it("reuses negative cwd results across in-memory cache clears", async () => {
+    const cacheRoot = await mkdtemp(join(tmpdir(), "marmonitor-cwd-negative-"));
+    let execCalls = 0;
+
+    processCwdCache.clear();
+    const first = await getProcessCwd(88_002, {
+      cacheRoot,
+      nowMs: 1_000,
+      execFile: async () => {
+        execCalls += 1;
+        throw new Error("lsof failed");
+      },
+    });
+
+    assert.equal(first, undefined);
+    assert.equal(execCalls, 1);
+
+    processCwdCache.clear();
+    const second = await getProcessCwd(88_002, {
+      cacheRoot,
+      nowMs: 2_000,
+      execFile: async () => {
+        throw new Error("shared cache miss");
+      },
+    });
+
+    assert.equal(second, undefined);
+    assert.equal(execCalls, 1);
+  });
+});

--- a/tests/runtime-cache.test.mjs
+++ b/tests/runtime-cache.test.mjs
@@ -239,6 +239,43 @@ describe("shared process start cache", () => {
     assert.equal(second, undefined);
     assert.equal(execCalls, 1);
   });
+
+  it("partitions shared start-time cache by process identity key", async () => {
+    const cacheRoot = await mkdtemp(join(tmpdir(), "marmonitor-start-identity-"));
+    let execCalls = 0;
+
+    processStartCache.clear();
+    const first = await getProcessStartTime(88_005, {
+      cacheRoot,
+      nowMs: 1_000,
+      sharedKey: "88_005:parent-a:codex:a",
+      execFile: async () => {
+        execCalls += 1;
+        return {
+          stdout: "Mon Mar 31 10:00:00 2026\n",
+          stderr: "",
+        };
+      },
+    });
+
+    processStartCache.clear();
+    const second = await getProcessStartTime(88_005, {
+      cacheRoot,
+      nowMs: 2_000,
+      sharedKey: "88_005:parent-b:codex:b",
+      execFile: async () => {
+        execCalls += 1;
+        return {
+          stdout: "Mon Mar 31 11:00:00 2026\n",
+          stderr: "",
+        };
+      },
+    });
+
+    assert.equal(first, new Date("Mon Mar 31 10:00:00 2026").getTime() / 1000);
+    assert.equal(second, new Date("Mon Mar 31 11:00:00 2026").getTime() / 1000);
+    assert.equal(execCalls, 2);
+  });
 });
 
 describe("shared process runtime snapshots", () => {

--- a/tests/runtime-cache.test.mjs
+++ b/tests/runtime-cache.test.mjs
@@ -11,11 +11,12 @@ import {
   claudeSessionRegistry,
   codexPhaseCache,
   processCwdCache,
+  processStartCache,
   stdoutHeuristicCache,
 } from "../dist/scanner/cache.js";
 import { detectClaudePhase, resolveClaudeSessionFile } from "../dist/scanner/claude.js";
 import { detectCodexPhase } from "../dist/scanner/codex.js";
-import { getProcessCwd } from "../dist/scanner/process.js";
+import { getProcessCwd, getProcessStartTime } from "../dist/scanner/process.js";
 import { getPidUsageCached, listProcessesCached } from "../dist/scanner/runtime-snapshot.js";
 import { detectCliStdoutPhase } from "../dist/scanner/status.js";
 
@@ -163,6 +164,71 @@ describe("shared process cwd cache", () => {
 
     processCwdCache.clear();
     const second = await getProcessCwd(88_002, {
+      cacheRoot,
+      nowMs: 2_000,
+      execFile: async () => {
+        throw new Error("shared cache miss");
+      },
+    });
+
+    assert.equal(second, undefined);
+    assert.equal(execCalls, 1);
+  });
+});
+
+describe("shared process start cache", () => {
+  it("reuses start times across in-memory cache clears", async () => {
+    const cacheRoot = await mkdtemp(join(tmpdir(), "marmonitor-start-cache-"));
+    let execCalls = 0;
+
+    processStartCache.clear();
+    const first = await getProcessStartTime(88_003, {
+      cacheRoot,
+      nowMs: 1_000,
+      execFile: async () => {
+        execCalls += 1;
+        return {
+          stdout: "Mon Mar 31 10:00:00 2026\n",
+          stderr: "",
+        };
+      },
+    });
+
+    assert.equal(first, new Date("Mon Mar 31 10:00:00 2026").getTime() / 1000);
+    assert.equal(execCalls, 1);
+
+    processStartCache.clear();
+    const second = await getProcessStartTime(88_003, {
+      cacheRoot,
+      nowMs: 2_000,
+      execFile: async () => {
+        throw new Error("shared cache miss");
+      },
+    });
+
+    assert.equal(second, first);
+    assert.equal(execCalls, 1);
+  });
+
+  it("reuses negative start times across in-memory cache clears", async () => {
+    const cacheRoot = await mkdtemp(join(tmpdir(), "marmonitor-start-negative-"));
+    let execCalls = 0;
+
+    processStartCache.clear();
+    const first = await getProcessStartTime(88_004, {
+      cacheRoot,
+      nowMs: 1_000,
+      execFile: async () => {
+        execCalls += 1;
+        throw new Error("ps failed");
+      },
+    });
+
+    assert.equal(first, undefined);
+    assert.equal(execCalls, 1);
+
+    processStartCache.clear();
+    const second = await getProcessStartTime(88_004, {
       cacheRoot,
       nowMs: 2_000,
       execFile: async () => {

--- a/tests/scanner.test.mjs
+++ b/tests/scanner.test.mjs
@@ -1,11 +1,17 @@
 import assert from "node:assert/strict";
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it } from "node:test";
 import { getDefaults } from "../dist/config/index.js";
-import { setCodexIndexCache } from "../dist/scanner/cache.js";
+import {
+  codexIndexCache,
+  geminiProjectDirCache,
+  setCodexIndexCache,
+} from "../dist/scanner/cache.js";
+import { parseClaudeSession } from "../dist/scanner/claude.js";
 import { indexCodexSessions } from "../dist/scanner/codex.js";
+import { resolveGeminiProjectDir } from "../dist/scanner/gemini.js";
 import {
   detectAgentFromProcessSignature,
   parseGeminiSessionContent,
@@ -128,6 +134,137 @@ describe("parseGeminiSessionContent", () => {
       JSON.stringify({ messages: [{ type: "gemini" }, {}] }),
     );
     assert.ok(parsed.phase === "done" || parsed.phase === undefined);
+  });
+
+  it("can skip token extraction in light mode", () => {
+    const parsed = parseGeminiSessionContent(
+      JSON.stringify({
+        sessionId: "abc-123",
+        startTime: "2026-03-28T10:38:11.868Z",
+        messages: [
+          {
+            timestamp: "2026-03-28T10:38:15.504Z",
+            type: "gemini",
+            model: "gemini-3-flash-preview",
+            tokens: { input: 9426, output: 26, cached: 0, total: 9596 },
+          },
+        ],
+      }),
+      { includeTokenUsage: false },
+    );
+
+    assert.equal(parsed.model, undefined);
+    assert.equal(parsed.tokenUsage, undefined);
+    assert.equal(parsed.phase, "done");
+  });
+});
+
+describe("resolveGeminiProjectDir", () => {
+  it("caches a matching Gemini project directory", async () => {
+    const tmpRoot = await mkdtemp(join(tmpdir(), "marmonitor-gemini-cache-"));
+    const projectDir = join(tmpRoot, "project-a");
+    await mkdir(projectDir, { recursive: true });
+    await writeFile(join(projectDir, ".project_root"), "/repo/gemini-cache\n", "utf8");
+
+    geminiProjectDirCache.clear();
+    const resolved = await resolveGeminiProjectDir("/repo/gemini-cache", { tmpRoot });
+
+    assert.equal(resolved, projectDir);
+    assert.equal(geminiProjectDirCache.get(`${tmpRoot}::/repo/gemini-cache`), projectDir);
+  });
+
+  it("invalidates a stale Gemini project-dir cache entry and finds the new match", async () => {
+    const tmpRoot = await mkdtemp(join(tmpdir(), "marmonitor-gemini-stale-"));
+    const staleDir = join(tmpRoot, "project-stale");
+    const freshDir = join(tmpRoot, "project-fresh");
+    await mkdir(staleDir, { recursive: true });
+    await writeFile(join(staleDir, ".project_root"), "/repo/gemini-stale\n", "utf8");
+
+    geminiProjectDirCache.clear();
+    const firstResolved = await resolveGeminiProjectDir("/repo/gemini-stale", { tmpRoot });
+    assert.equal(firstResolved, staleDir);
+
+    await mkdir(freshDir, { recursive: true });
+    await writeFile(join(staleDir, ".project_root"), "/repo/other\n", "utf8");
+    await writeFile(join(freshDir, ".project_root"), "/repo/gemini-stale\n", "utf8");
+
+    const secondResolved = await resolveGeminiProjectDir("/repo/gemini-stale", { tmpRoot });
+    assert.equal(secondResolved, freshDir);
+    assert.equal(geminiProjectDirCache.get(`${tmpRoot}::/repo/gemini-stale`), freshDir);
+  });
+
+  it("skips non-matching Gemini directories and still finds the correct project", async () => {
+    const tmpRoot = await mkdtemp(join(tmpdir(), "marmonitor-gemini-mixed-"));
+    const ignoredDir = join(tmpRoot, "project-ignored");
+    const targetDir = join(tmpRoot, "project-target");
+    await mkdir(ignoredDir, { recursive: true });
+    await mkdir(targetDir, { recursive: true });
+    await writeFile(join(ignoredDir, ".project_root"), "/repo/other\n", "utf8");
+    await writeFile(join(targetDir, ".project_root"), "/repo/gemini-target\n", "utf8");
+
+    geminiProjectDirCache.clear();
+    const resolved = await resolveGeminiProjectDir("/repo/gemini-target", { tmpRoot });
+
+    assert.equal(resolved, targetDir);
+  });
+});
+
+describe("parseClaudeSession", () => {
+  it("skips token parsing when includeTokenUsage is false", async () => {
+    const pid = 42_424;
+    const root = await mkdtemp(join(tmpdir(), "marmonitor-claude-light-"));
+    const config = getDefaults();
+    config.paths.claudeSessions = [root];
+    await mkdir(root, { recursive: true });
+    await writeFile(
+      join(root, `${pid}.json`),
+      JSON.stringify({
+        cwd: "/repo/project",
+        sessionId: "sess-1",
+        startedAt: 1_710_000_000_000,
+      }),
+      "utf8",
+    );
+
+    const parsed = await parseClaudeSession(pid, config, { includeTokenUsage: false });
+
+    assert.equal(parsed.cwd, "/repo/project");
+    assert.equal(parsed.sessionId, "sess-1");
+    assert.equal(parsed.startedAt, 1_710_000_000);
+    assert.equal(parsed.sessionMatched, true);
+    assert.equal(parsed.tokenUsage, undefined);
+    assert.equal(parsed.model, undefined);
+  });
+
+  it("can use provided runtime paths for Claude session lookup", async () => {
+    const pid = 52_525;
+    const root = await mkdtemp(join(tmpdir(), "marmonitor-claude-runtime-paths-"));
+    const config = getDefaults();
+    await mkdir(root, { recursive: true });
+    await writeFile(
+      join(root, `${pid}.json`),
+      JSON.stringify({
+        cwd: "/repo/runtime-paths",
+        sessionId: "sess-runtime-paths",
+        startedAt: 1_710_000_000_000,
+      }),
+      "utf8",
+    );
+
+    const parsed = await parseClaudeSession(pid, config, {
+      includeTokenUsage: false,
+      runtimePaths: {
+        claudeProjects: [],
+        claudeSessions: [root],
+        codexSessions: [],
+        extraRoots: [],
+      },
+    });
+
+    assert.equal(parsed.cwd, "/repo/runtime-paths");
+    assert.equal(parsed.sessionId, "sess-runtime-paths");
+    assert.equal(parsed.startedAt, 1_710_000_000);
+    assert.equal(parsed.sessionMatched, true);
   });
 });
 
@@ -262,5 +399,197 @@ describe("indexCodexSessions", () => {
     assert.ok(matched);
     assert.ok(matched.lastActivityAt);
     assert.ok(Math.abs(matched.lastActivityAt - Date.now() / 1000) < 10);
+  });
+
+  it("can index Codex sessions without token usage in light mode", async () => {
+    const now = new Date();
+    const yyyy = now.getFullYear().toString();
+    const mm = String(now.getMonth() + 1).padStart(2, "0");
+    const dd = String(now.getDate()).padStart(2, "0");
+    const root = join(tmpdir(), `marmonitor-codex-light-${Date.now()}`);
+    const dayDir = join(root, yyyy, mm, dd);
+    await mkdir(dayDir, { recursive: true });
+    const filePath = join(dayDir, "session.jsonl");
+    await writeFile(
+      filePath,
+      [
+        JSON.stringify({
+          type: "session_meta",
+          payload: {
+            id: "codex-light-1",
+            cwd: "/tmp/light-project",
+            timestamp: new Date("2026-03-28T10:00:00.000Z").toISOString(),
+            model_provider: "gpt-5.4",
+          },
+        }),
+        JSON.stringify({
+          type: "event_msg",
+          payload: {
+            type: "token_count",
+            info: {
+              total_token_usage: {
+                input_tokens: 50,
+                cached_input_tokens: 10,
+                output_tokens: 5,
+                total_tokens: 55,
+              },
+            },
+          },
+        }),
+      ].join("\n"),
+      "utf8",
+    );
+
+    setCodexIndexCache(undefined);
+    const config = getDefaults();
+    config.paths.codexSessions = [root];
+    const sessions = await indexCodexSessions(config, { includeTokenUsage: false });
+    const matched = sessions.find((item) => item.filePath === filePath);
+
+    assert.ok(matched);
+    assert.equal(matched?.id, "codex-light-1");
+    assert.equal(matched?.cwd, "/tmp/light-project");
+    assert.equal(matched?.model, "gpt-5.4");
+    assert.equal(matched?.totalTokenUsage, undefined);
+  });
+
+  it("can use provided runtime paths for Codex indexing", async () => {
+    const now = new Date();
+    const yyyy = now.getFullYear().toString();
+    const mm = String(now.getMonth() + 1).padStart(2, "0");
+    const dd = String(now.getDate()).padStart(2, "0");
+    const root = join(tmpdir(), `marmonitor-codex-runtime-paths-${Date.now()}`);
+    const dayDir = join(root, yyyy, mm, dd);
+    await mkdir(dayDir, { recursive: true });
+    const filePath = join(dayDir, "session.jsonl");
+    await writeFile(
+      filePath,
+      [
+        JSON.stringify({
+          type: "session_meta",
+          payload: {
+            id: "codex-runtime-paths-1",
+            cwd: "/tmp/runtime-paths-project",
+            timestamp: new Date("2026-03-28T10:00:00.000Z").toISOString(),
+            model_provider: "gpt-5.4",
+          },
+        }),
+      ].join("\n"),
+      "utf8",
+    );
+
+    setCodexIndexCache(undefined);
+    const config = getDefaults();
+    const sessions = await indexCodexSessions(config, {
+      includeTokenUsage: false,
+      runtimePaths: {
+        claudeProjects: [],
+        claudeSessions: [],
+        codexSessions: [root],
+        extraRoots: [],
+      },
+    });
+    const matched = sessions.find((item) => item.filePath === filePath);
+
+    assert.ok(matched);
+    assert.equal(matched?.id, "codex-runtime-paths-1");
+    assert.equal(matched?.cwd, "/tmp/runtime-paths-project");
+  });
+
+  it("keeps light Codex indexing from poisoning later full indexing", async () => {
+    const now = new Date();
+    const yyyy = now.getFullYear().toString();
+    const mm = String(now.getMonth() + 1).padStart(2, "0");
+    const dd = String(now.getDate()).padStart(2, "0");
+    const root = join(tmpdir(), `marmonitor-codex-cache-${Date.now()}`);
+    const dayDir = join(root, yyyy, mm, dd);
+    await mkdir(dayDir, { recursive: true });
+    const filePath = join(dayDir, "session.jsonl");
+    await writeFile(
+      filePath,
+      [
+        JSON.stringify({
+          type: "session_meta",
+          payload: {
+            id: "codex-cache-1",
+            cwd: "/tmp/cache-project",
+            timestamp: new Date("2026-03-28T10:00:00.000Z").toISOString(),
+            model_provider: "gpt-5.4",
+          },
+        }),
+        JSON.stringify({
+          type: "event_msg",
+          payload: {
+            type: "token_count",
+            info: {
+              total_token_usage: {
+                input_tokens: 25,
+                cached_input_tokens: 5,
+                output_tokens: 7,
+                total_tokens: 32,
+              },
+            },
+          },
+        }),
+      ].join("\n"),
+      "utf8",
+    );
+
+    setCodexIndexCache(undefined);
+    const config = getDefaults();
+    config.paths.codexSessions = [root];
+
+    const lightSessions = await indexCodexSessions(config, { includeTokenUsage: false });
+    const lightMatched = lightSessions.find((item) => item.filePath === filePath);
+    assert.ok(lightMatched);
+    assert.equal(lightMatched?.totalTokenUsage, undefined);
+
+    const fullSessions = await indexCodexSessions(config);
+    const fullMatched = fullSessions.find((item) => item.filePath === filePath);
+    assert.ok(fullMatched);
+    assert.deepEqual(fullMatched?.totalTokenUsage, {
+      input_tokens: 25,
+      cached_input_tokens: 5,
+      output_tokens: 7,
+      total_tokens: 32,
+    });
+    assert.ok(codexIndexCache.full);
+    assert.ok(codexIndexCache.light);
+  });
+
+  it("skips missing Codex roots and still indexes the available root", async () => {
+    const now = new Date();
+    const yyyy = now.getFullYear().toString();
+    const mm = String(now.getMonth() + 1).padStart(2, "0");
+    const dd = String(now.getDate()).padStart(2, "0");
+    const missingRoot = join(tmpdir(), `marmonitor-codex-missing-${Date.now()}`);
+    const root = join(tmpdir(), `marmonitor-codex-available-${Date.now()}`);
+    const dayDir = join(root, yyyy, mm, dd);
+    await mkdir(dayDir, { recursive: true });
+    const filePath = join(dayDir, "session.jsonl");
+    await writeFile(
+      filePath,
+      JSON.stringify({
+        type: "session_meta",
+        payload: {
+          id: "codex-available-1",
+          cwd: "/tmp/available-project",
+          timestamp: new Date("2026-03-28T10:00:00.000Z").toISOString(),
+          model_provider: "gpt-5.4",
+        },
+      }),
+      "utf8",
+    );
+
+    setCodexIndexCache(undefined);
+    const config = getDefaults();
+    config.paths.codexSessions = [missingRoot, root];
+
+    const sessions = await indexCodexSessions(config, { includeTokenUsage: false });
+    const matched = sessions.find((item) => item.filePath === filePath);
+
+    assert.ok(matched);
+    assert.equal(matched?.id, "codex-available-1");
+    assert.equal(matched?.cwd, "/tmp/available-project");
   });
 });

--- a/tests/snapshot-cache.test.mjs
+++ b/tests/snapshot-cache.test.mjs
@@ -1,12 +1,13 @@
 import assert from "node:assert/strict";
-import { mkdtemp, stat } from "node:fs/promises";
+import { mkdtemp, readFile, readdir, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { describe, it } from "node:test";
 import {
   acquireSnapshotRefreshLock,
   releaseSnapshotRefreshLock,
   snapshotRefreshLockFile,
+  writeCacheFileAtomically,
 } from "../dist/snapshot-cache.js";
 
 describe("snapshot refresh lock", () => {
@@ -18,5 +19,19 @@ describe("snapshot refresh lock", () => {
     await stat(snapshotRefreshLockFile("light", false, root));
 
     await releaseSnapshotRefreshLock("light", false, root);
+  });
+
+  it("writes cache files atomically without leaving temp files behind", async () => {
+    const root = await mkdtemp(join(tmpdir(), "marmonitor-snapshot-write-"));
+    const path = join(root, "marmonitor", "statusline.txt");
+
+    await writeCacheFileAtomically(path, "first");
+    assert.equal(await readFile(path, "utf8"), "first");
+
+    await writeCacheFileAtomically(path, "second");
+    assert.equal(await readFile(path, "utf8"), "second");
+
+    const entries = await readdir(dirname(path));
+    assert.deepEqual(entries, ["statusline.txt"]);
   });
 });

--- a/tests/snapshot-cache.test.mjs
+++ b/tests/snapshot-cache.test.mjs
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { mkdtemp, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import {
+  acquireSnapshotRefreshLock,
+  releaseSnapshotRefreshLock,
+  snapshotRefreshLockFile,
+} from "../dist/snapshot-cache.js";
+
+describe("snapshot refresh lock", () => {
+  it("creates the lock parent directory on a fresh temp root", async () => {
+    const root = await mkdtemp(join(tmpdir(), "marmonitor-snapshot-lock-"));
+    const acquired = await acquireSnapshotRefreshLock("light", false, root);
+
+    assert.equal(acquired, true);
+    await stat(snapshotRefreshLockFile("light", false, root));
+
+    await releaseSnapshotRefreshLock("light", false, root);
+  });
+});

--- a/tests/tmux.test.mjs
+++ b/tests/tmux.test.mjs
@@ -1,11 +1,22 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  getTmuxRuntimeSnapshot,
   isPidInTree,
   parseProcessTree,
   parseTmuxPanes,
+  resetTmuxRuntimeSnapshotForTests,
+  resolveTmuxJumpTarget,
   selectTmuxPaneForAgent,
 } from "../dist/tmux/index.js";
+
+function createDeferred() {
+  let resolve;
+  const promise = new Promise((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
 
 describe("parseTmuxPanes", () => {
   it("parses tmux list-panes output", () => {
@@ -70,5 +81,120 @@ describe("selectTmuxPaneForAgent", () => {
     const result = selectTmuxPaneForAgent({ pid: 999, cwd: "/repo/b" }, panes, childMap);
     assert.equal(result?.pane.target, "mjjo:2.1");
     assert.equal(result?.match, "cwd");
+  });
+});
+
+describe("tmux runtime snapshot", () => {
+  it("shares in-flight tmux snapshot loads across concurrent callers", async () => {
+    resetTmuxRuntimeSnapshotForTests();
+    let paneLoads = 0;
+    let treeLoads = 0;
+    const panesDeferred = createDeferred();
+    const treeDeferred = createDeferred();
+    const loaders = {
+      listPanes: async () => {
+        paneLoads += 1;
+        return await panesDeferred.promise;
+      },
+      getProcessTree: async () => {
+        treeLoads += 1;
+        return await treeDeferred.promise;
+      },
+    };
+
+    const first = getTmuxRuntimeSnapshot(loaders);
+    const second = getTmuxRuntimeSnapshot(loaders);
+
+    assert.equal(paneLoads, 1);
+    assert.equal(treeLoads, 1);
+
+    panesDeferred.resolve([
+      {
+        target: "mjjo:1.2",
+        sessionName: "mjjo",
+        windowIndex: 1,
+        paneIndex: 2,
+        panePid: 100,
+        cwd: "/repo/a",
+      },
+    ]);
+    treeDeferred.resolve(new Map([[1, [100]]]));
+
+    const [firstSnapshot, secondSnapshot] = await Promise.all([first, second]);
+    assert.strictEqual(firstSnapshot, secondSnapshot);
+    assert.equal(firstSnapshot.panes[0].target, "mjjo:1.2");
+    assert.deepEqual(firstSnapshot.childMap.get(1), [100]);
+  });
+
+  it("rebuilds the tmux snapshot after the in-flight load finishes", async () => {
+    resetTmuxRuntimeSnapshotForTests();
+    let paneLoads = 0;
+    let treeLoads = 0;
+    const loaders = {
+      listPanes: async () => {
+        paneLoads += 1;
+        return [];
+      },
+      getProcessTree: async () => {
+        treeLoads += 1;
+        return new Map();
+      },
+    };
+
+    await getTmuxRuntimeSnapshot(loaders);
+    await getTmuxRuntimeSnapshot(loaders);
+
+    assert.equal(paneLoads, 2);
+    assert.equal(treeLoads, 2);
+  });
+
+  it("resolves concurrent jump targets from one shared tmux snapshot", async () => {
+    resetTmuxRuntimeSnapshotForTests();
+    let paneLoads = 0;
+    let treeLoads = 0;
+    const panesDeferred = createDeferred();
+    const treeDeferred = createDeferred();
+    const loaders = {
+      listPanes: async () => {
+        paneLoads += 1;
+        return await panesDeferred.promise;
+      },
+      getProcessTree: async () => {
+        treeLoads += 1;
+        return await treeDeferred.promise;
+      },
+    };
+
+    const first = resolveTmuxJumpTarget({ pid: 200, cwd: "/repo/a" }, loaders);
+    const second = resolveTmuxJumpTarget({ pid: 999, cwd: "/repo/b" }, loaders);
+
+    assert.equal(paneLoads, 1);
+    assert.equal(treeLoads, 1);
+
+    panesDeferred.resolve([
+      {
+        target: "mjjo:1.2",
+        sessionName: "mjjo",
+        windowIndex: 1,
+        paneIndex: 2,
+        panePid: 100,
+        cwd: "/repo/a",
+      },
+      {
+        target: "mjjo:2.1",
+        sessionName: "mjjo",
+        windowIndex: 2,
+        paneIndex: 1,
+        panePid: 500,
+        cwd: "/repo/b",
+      },
+    ]);
+    treeDeferred.resolve(parseProcessTree("100 1\n200 100\n"));
+
+    const [firstTarget, secondTarget] = await Promise.all([first, second]);
+    assert.equal(firstTarget?.pane.target, "mjjo:1.2");
+    assert.equal(firstTarget?.match, "pid-tree");
+    assert.equal(secondTarget?.pane.target, "mjjo:2.1");
+    assert.equal(secondTarget?.match, "cwd");
   });
 });


### PR DESCRIPTION
## Summary

Resolve #5

This PR reduces redundant work in `marmonitor`'s statusline path and adjacent status-oriented commands when tmux refreshes frequently while multiple AI sessions are running.

The scope of this PR is intentionally narrow:

- make statusline-oriented paths cheaper than full status scans
- prevent duplicate refresh work across closely spaced CLI invocations
- reuse tmux, process, and session-derived data where the result is still valid
- keep bounded-freshness tradeoffs constrained to the statusline path

This PR does **not** claim that all tmux typing lag is solved. The evidence in this PR supports better cache-hit / near-hit behavior and lower forced-miss overhead, while leaving the heaviest cold-path costs visible.

## Type

- `PERF` performance improvement
- Includes a small `REFACTOR` cleanup in `getAgentsSnapshot()` for readability

## Changes

- Added `MARMONITOR_PERF=1` timing instrumentation for statusline, scanner, tmux, and process-heavy paths.
- Split statusline-oriented commands onto light snapshots while preserving stdout heuristics for phase accuracy.
- Added snapshot refresh locking so concurrent refreshes do not repeat the same work.
- Fixed a bug where a fresh `TMPDIR` without the snapshot lock parent directory could cause repeated lock waits.
- Shared tmux pane and process-tree runtime state with in-flight single-flight so closely spaced calls reuse `tmux list-panes` and `ps -eo pid=,ppid=` results.
- Split Codex light/full caches so light paths do not contaminate full session metadata.
- Reused runtime path resolution across scan helpers instead of recalculating it per helper.
- Added a safe Gemini project-dir cache with stale-entry revalidation.
- Added shared cross-process caches for stdout heuristics and process cwd lookup.
- Added shared cross-process caches for Claude session-file resolution, Claude phase detection, and Codex phase detection.
- Added a shared cross-process cache for `getProcessStartTime`, but keyed it by `pid + ppid + name + cmd` and kept its shared TTL shorter than the in-memory TTL to reduce PID-reuse risk.
- Kept the `ps-list` / `pidusage` shared snapshots on a `1s` TTL, but narrowed them to the `--statusline` path so the bounded freshness tradeoff does not affect full status scans.
- Switched shared-cache writes and snapshot/statusline cache writes to temp-file + rename so concurrent writers fail open as cache misses rather than leaving partial files behind.
- Reduced `existsSync` preflight patterns and let `readdir` / `readFile` failures drive fallback behavior directly.
- Added reproducible benchmark scripts for synthetic Codex indexing and live statusline measurement, and documented the benchmark methodology.
- Added regression tests for cache, lock, runtime-sharing, identity-partitioned process-start reuse, and atomic cache-file writes.

## Validation

- `npm run build`: passing
- `npm run lint`: passing
- `npm test`: passing
- Current automated total: `189` tests passing
- README update is not required because this change is not user-facing.

## Benchmarks

Reproducible benchmarks now included in the repo

- `npm run bench:codex-index -- --json`
  - script: `scripts/bench-codex-index.mjs`
  - purpose: reproducible fixture-based Codex indexing benchmark
- `npm run bench:statusline-live -- --json`
  - script: `scripts/bench-statusline-live.mjs`
  - purpose: real `--statusline` benchmark against the current tmux/runtime environment
- methodology and interpretation: `docs/performance-benchmarking.md`

Sample benchmark outputs captured on measurement commit `b26bdf5ffcfae05f42a8bd6ec4f704a3b010949b`

- baseline commit: `6f04e60c4605db77586dc7a73a2e4bfe8814d8d6`
- host: `Apple M3 Max`, `14` logical CPU, `36GB RAM`
- synthetic Codex benchmark
  - `heavy / cold_empty_caches`: full avg `20.9ms`, light avg `4.6ms`
  - `compact / cold_empty_caches`: full avg `5.6ms`, light avg `3.4ms`
  - `warm_file_cache`: both paths around `1ms`
- live tmux benchmark environment
  - tmux sessions: `3`
  - tmux panes: `7`
  - agents: `37`
  - `snapshotTtlMs=10000`
  - `statuslineTtlMs=10000`
  - `stdoutHeuristicTtlMs=10000`
- live tmux benchmark results
  - `cold`: `1413.3ms`
  - `warm`: `66.1ms`
  - `forced-miss`: `550.1ms`
  - `forced-miss`: `118.4ms`

Interpretation

- cache-hit and near-hit paths improved significantly
- forced snapshot misses also improved when shared runtime/session state can be reused
- cold-path wall time is still not low enough to claim that typing lag is fully solved
- the remaining cold-path hotspots are still dominated by session building, stdout/tmux resolution, and `pidusage`

## Risk

Medium

- Statusline-oriented commands now use lighter scan paths, but phase/status/cwd/runtime behavior is intentionally preserved.
- Snapshot locking and tmux single-flight reduce duplicate work rather than changing command semantics.
- Shared stdout/cwd/session/phase caches reduce repeated work across closely spaced CLI invocations.
- Shared `getProcessStartTime` reuse is partitioned by stronger process identity and a shorter shared TTL to reduce PID-reuse risk.
- The `ps-list` / `pidusage` shared snapshots still introduce a very small bounded freshness window (`1s`), but that tradeoff is now limited to the `--statusline` path rather than all scan-based commands.
- Temp-file + rename cache writes are fail-open stability improvements; cache write failures still degrade to cache misses rather than scan failures.
- Cache-hit and near-hit behavior improved clearly, but major cold-path bottlenecks still remain.
- The main remaining risk is real tmux typing-lag improvement under `15s refresh > 10s TTL` conditions, where refreshes can still hit colder paths.
