### PR TITLE
[FIX] Claude 세션 감지를 JSONL 타임스탬프 기반 매칭으로 전환

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ npm-debug.log*
 
 # Test coverage
 coverage/
+
+# Worklog
+.worklog/

--- a/src/output/utils.ts
+++ b/src/output/utils.ts
@@ -44,12 +44,16 @@ export function formatTokens(n: number): string {
 }
 
 /** Compact directory label for dock/focus display.
- *  Shows last 2 path segments to avoid basename collisions.
- *  e.g. "/Users/macrent/.ai/projects/mjjo" → "projects/mjjo"
- *       "/Users/macrent/Documents/valueofspace/vos-data-service" → "valueofspace/vos-data-service"
+ *  Replaces $HOME with ~ first, then shows last 2 path segments.
+ *  e.g. "/Users/macrent" → "~"
+ *       "/Users/macrent/marmonitor" → "~/marmonitor"
+ *       "/Users/macrent/Documents/vos/vos-data-service" → "vos/vos-data-service"
  *       "/Users/macrent/.ai/projects/vos" → "projects/vos" */
 export function compactDirLabel(cwd: string): string {
-  const parts = cwd.split("/").filter(Boolean);
+  const home = process.env.HOME ?? "";
+  const shortened = home && cwd.startsWith(home) ? `~${cwd.slice(home.length)}` : cwd;
+  if (shortened === "~") return "~";
+  const parts = shortened.split("/").filter(Boolean);
   if (parts.length <= 1) return parts[0] || cwd;
   return parts.slice(-2).join("/");
 }

--- a/src/scanner/claude.ts
+++ b/src/scanner/claude.ts
@@ -473,41 +473,196 @@ export async function detectClaudePhase(
   }
 }
 
-/** Parse Claude Code session file for enriched data */
-export async function parseClaudeSession(
-  pid: number,
-  config?: MarmonitorConfig,
-): Promise<Partial<AgentSession>> {
-  const sessionFile = getClaudeSessionRoots(config)
-    .map((root) => join(root, `${pid}.json`))
-    .find((candidate) => existsSync(candidate));
-  if (!sessionFile) return {};
+/**
+ * Read the first line of a JSONL file to extract session metadata.
+ * Returns undefined if the file can't be read or parsed.
+ */
+async function readJsonlFirstLine(
+  filePath: string,
+): Promise<{ sessionId?: string; cwd?: string; timestamp?: string } | undefined> {
   try {
-    const fileStat = await stat(sessionFile);
-    const raw = await readFile(sessionFile, "utf-8");
-    const data = JSON.parse(raw);
+    const fd = await open(filePath, "r");
+    const buf = Buffer.alloc(4096);
+    await fd.read(buf, 0, 4096, 0);
+    await fd.close();
+    const firstLine = buf.toString("utf-8").split("\n")[0];
+    if (!firstLine) return undefined;
+    return JSON.parse(firstLine);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Match a Claude session by scanning JSONL files in the project directory.
+ * When processStartedAt is available, matches by JSONL creation timestamp
+ * (first-line timestamp) proximity to process start time.
+ * Falls back to the most recently modified JSONL when no start time is available.
+ */
+export async function matchClaudeSessionByMtime(
+  cwd: string,
+  processStartedAt: number | undefined,
+  config?: MarmonitorConfig,
+): Promise<Partial<AgentSession> | undefined> {
+  const projectDirName = await findClaudeProjectDir(cwd, undefined, config);
+  if (!projectDirName) return undefined;
+
+  const projectRoots = getClaudeProjectRoots(config);
+  const candidates: Array<{ path: string; mtimeMs: number }> = [];
+
+  for (const projectsDir of projectRoots) {
+    const projectDir = join(projectsDir, projectDirName);
+    if (!existsSync(projectDir)) continue;
+    try {
+      const files = await readdir(projectDir);
+      for (const file of files) {
+        if (!file.endsWith(".jsonl")) continue;
+        try {
+          const filePath = join(projectDir, file);
+          const fileStat = await stat(filePath);
+          candidates.push({ path: filePath, mtimeMs: fileStat.mtimeMs });
+        } catch {
+          // skip
+        }
+      }
+    } catch {
+      // skip
+    }
+  }
+
+  if (candidates.length === 0) return undefined;
+
+  let bestPath: string | undefined;
+
+  if (processStartedAt) {
+    const startMs = processStartedAt * 1000;
+    // Pre-filter: only consider JSONL files modified after process start (with tolerance)
+    const active = candidates.filter(
+      (c) => c.mtimeMs >= startMs - CLAUDE_SESSION_MTIME_MATCH_SEC * 1000,
+    );
+    const pool = active.length > 0 ? active : candidates;
+
+    // Read first lines to get creation timestamps and match by proximity
+    const scored: Array<{ path: string; deltaSec: number; mtimeMs: number }> = [];
+    for (const c of pool) {
+      const firstLine = await readJsonlFirstLine(c.path);
+      if (!firstLine?.timestamp) continue;
+      const createdAt = new Date(firstLine.timestamp).getTime() / 1000;
+      scored.push({
+        path: c.path,
+        deltaSec: Math.abs(createdAt - processStartedAt),
+        mtimeMs: c.mtimeMs,
+      });
+    }
+
+    if (scored.length > 0) {
+      // Pick the JSONL whose creation time is closest to process start
+      scored.sort((a, b) => a.deltaSec - b.deltaSec);
+      // Only accept if within reasonable tolerance (5 minutes)
+      if (scored[0].deltaSec <= 300) {
+        bestPath = scored[0].path;
+      }
+    }
+
+    // Fallback: most recently modified
+    if (!bestPath) {
+      pool.sort((a, b) => b.mtimeMs - a.mtimeMs);
+      bestPath = pool[0].path;
+    }
+  } else {
+    // No process start time — pick most recently modified
+    candidates.sort((a, b) => b.mtimeMs - a.mtimeMs);
+    bestPath = candidates[0].path;
+  }
+
+  // Read first line for session metadata
+  const entry = await readJsonlFirstLine(bestPath);
+  if (!entry?.sessionId) return undefined;
+
+  try {
+    const fileStat = await stat(bestPath);
+    const sessionCwd = entry.cwd ?? cwd;
 
     const result: Partial<AgentSession> = {
-      cwd: data.cwd,
-      sessionId: data.sessionId,
-      startedAt: data.startedAt ? data.startedAt / 1000 : undefined,
+      cwd: sessionCwd,
+      sessionId: entry.sessionId,
+      startedAt: entry.timestamp ? new Date(entry.timestamp).getTime() / 1000 : undefined,
       lastActivityAt: fileStat.mtimeMs / 1000,
       sessionMatched: true,
     };
 
-    if (data.sessionId && data.cwd) {
-      const tokenData = await parseClaudeTokens(
-        data.sessionId,
-        data.cwd,
-        data.startedAt ? data.startedAt / 1000 : undefined,
-        config,
-      );
-      result.tokenUsage = tokenData.tokenUsage;
-      result.model = tokenData.model;
-    }
+    // Register in session registry for subsequent lookups
+    upsertSessionRegistryEntry(claudeSessionRegistry, {
+      filePath: bestPath,
+      sessionId: entry.sessionId,
+      cwd: sessionCwd,
+      firstSeenOffset: 0,
+      startedAt: result.startedAt,
+      source: "claude",
+    });
+
+    const tokenData = await parseClaudeTokens(
+      entry.sessionId,
+      sessionCwd,
+      result.startedAt,
+      config,
+    );
+    result.tokenUsage = tokenData.tokenUsage;
+    result.model = tokenData.model;
 
     return result;
   } catch {
-    return {};
+    return undefined;
   }
+}
+
+/** Parse Claude Code session file for enriched data */
+export async function parseClaudeSession(
+  pid: number,
+  cwd?: string,
+  processStartedAt?: number,
+  config?: MarmonitorConfig,
+): Promise<Partial<AgentSession>> {
+  // 1st: try legacy sessions/{pid}.json
+  const sessionFile = getClaudeSessionRoots(config)
+    .map((root) => join(root, `${pid}.json`))
+    .find((candidate) => existsSync(candidate));
+  if (sessionFile) {
+    try {
+      const fileStat = await stat(sessionFile);
+      const raw = await readFile(sessionFile, "utf-8");
+      const data = JSON.parse(raw);
+
+      const result: Partial<AgentSession> = {
+        cwd: data.cwd,
+        sessionId: data.sessionId,
+        startedAt: data.startedAt ? data.startedAt / 1000 : undefined,
+        lastActivityAt: fileStat.mtimeMs / 1000,
+        sessionMatched: true,
+      };
+
+      if (data.sessionId && data.cwd) {
+        const tokenData = await parseClaudeTokens(
+          data.sessionId,
+          data.cwd,
+          data.startedAt ? data.startedAt / 1000 : undefined,
+          config,
+        );
+        result.tokenUsage = tokenData.tokenUsage;
+        result.model = tokenData.model;
+      }
+
+      return result;
+    } catch {
+      // fall through to mtime-based matching
+    }
+  }
+
+  // 2nd: match by JSONL mtime in project directory
+  if (cwd && cwd !== "unknown") {
+    const matched = await matchClaudeSessionByMtime(cwd, processStartedAt, config);
+    if (matched) return matched;
+  }
+
+  return {};
 }

--- a/src/scanner/index.ts
+++ b/src/scanner/index.ts
@@ -113,11 +113,14 @@ export async function scanAgents(
       lastResponseAt = cachedEnrichment.lastResponseAt;
       lastActivityAt = cachedEnrichment.lastActivityAt;
     } else if (agentName === "Claude Code") {
-      const claudeData = await parseClaudeSession(proc.pid, config);
+      // Get cwd and start time early so mtime-based matching can use them
+      const processCwd = (await getProcessCwd(proc.pid)) ?? undefined;
+      const processStartTime = await getProcessStartTime(proc.pid);
+      const claudeData = await parseClaudeSession(proc.pid, processCwd, processStartTime, config);
       if (claudeData.cwd) cwd = claudeData.cwd;
-      if (cwd === "unknown") cwd = (await getProcessCwd(proc.pid)) ?? "unknown";
+      if (cwd === "unknown") cwd = processCwd ?? "unknown";
       sessionId = claudeData.sessionId;
-      startedAt = claudeData.startedAt;
+      startedAt = claudeData.startedAt ?? processStartTime;
       tokenUsage = claudeData.tokenUsage;
       model = claudeData.model;
       sessionMatched = claudeData.sessionMatched ?? false;


### PR DESCRIPTION
## Summary
- `sessions/{pid}.json`이 없을 때 JSONL 첫 줄 타임스탬프와 프로세스 시작 시간 근접도로 세션을 매칭하여 Unmatched 문제 해결 (10개 → 1개)
- 같은 cwd의 여러 프로세스가 각각 올바른 세션 JSONL에 매칭되도록 creation timestamp 기반 매칭 적용
- tmux 상태바 `compactDirLabel`에서 홈 경로를 `~`로 치환하여 중복 경로 표시 개선

## Test plan
- [x] `marmonitor status`에서 Unmatched 세션이 매칭된 세션으로 표시되는지 확인
- [x] 같은 cwd의 다른 세션 프로세스가 서로 다른 토큰 수를 표시하는지 확인
- [x] 기존 테스트 161/162 통과 (1 fail은 기존 guard.test node path 이슈)
- [ ] tmux 상태바에서 경로가 `~`로 축약되어 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)