### PR TITLE
[FIX] #8 Improve Claude session detection (follow-up to PR #7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,3 @@ npm-debug.log*
 
 # Test coverage
 coverage/
-
-# Worklog
-.worklog/

--- a/src/scanner/claude.ts
+++ b/src/scanner/claude.ts
@@ -480,16 +480,18 @@ export async function detectClaudePhase(
 async function readJsonlFirstLine(
   filePath: string,
 ): Promise<{ sessionId?: string; cwd?: string; timestamp?: string } | undefined> {
+  let fd: Awaited<ReturnType<typeof open>> | undefined;
   try {
-    const fd = await open(filePath, "r");
+    fd = await open(filePath, "r");
     const buf = Buffer.alloc(4096);
     await fd.read(buf, 0, 4096, 0);
-    await fd.close();
     const firstLine = buf.toString("utf-8").split("\n")[0];
     if (!firstLine) return undefined;
     return JSON.parse(firstLine);
   } catch {
     return undefined;
+  } finally {
+    await fd?.close().catch(() => {});
   }
 }
 


### PR DESCRIPTION
## Summary

Resolve #8

Follow-up improvements to PR #7 (Claude JSONL timestamp matching by @devbrother2024).

## Changes

- **fd leak fix**: `readJsonlFirstLine()` now wraps `fd.close()` in `try/finally` to prevent file descriptor leak on read error
- **Remove `.worklog/`**: Removed contributor-specific `.worklog/` from `.gitignore`

## Type

- [x] `[FIX]` Bug fix

## Checklist

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (166/166)
- [x] No hardcoded paths or environment-specific values

## Testing

- `npm run build && npm test && npm run lint` — all green
- fd leak scenario: if `fd.read()` throws, `fd.close()` is now guaranteed via `finally`

## Risk

Low — minimal change to existing logic, only adds safety around file descriptor cleanup.