### PR TITLE
[FEAT] #11 Improve tmux UX with badge themes, jump-back, pagination, and click actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,15 @@ The [marmonitor-tmux](https://github.com/mjjo16/marmonitor-tmux) plugin handles 
 
 All settings are customizable via `@marmonitor-*` options. See the [plugin README](https://github.com/mjjo16/marmonitor-tmux) for details.
 
+### Badge styles
+
+tmux badges and terminal text output can share one style via `integration.tmux.badgeStyle`.
+
+- `basic` — default colored pills
+- `basic-mono` — monochrome pills with Powerline borders
+- `text` — plain colored text, no filled background
+- `text-mono` — grayscale text only
+
 ## Configuration
 
 Config is loaded from (first found wins):
@@ -206,6 +215,7 @@ marmonitor settings-init --stdout
   },
   "integration": {
     "tmux": {
+      "badgeStyle": "basic",
       "keys": {
         "attentionPopup": "a",
         "jumpPopup": "j",

--- a/examples/tmux/README.md
+++ b/examples/tmux/README.md
@@ -101,6 +101,31 @@ bind-key -n M-5 run-shell -b "cd ~/Documents/mjjo/marmonitor && node bin/marmoni
 - on macOS this usually maps to `Option + 1..5`
 - `run-shell -b` + output redirection is intentional so tmux does not show a temporary `Jumped to ...` screen
 
+## Jump-back
+
+Return to the pane you were in before the current marmonitor jump chain:
+
+```bash
+node bin/marmonitor.js jump-back
+```
+
+Recommended tmux binding without prefix:
+
+```tmux
+bind-key -n M-6 run-shell -b "cd ~/Documents/mjjo/marmonitor && node bin/marmonitor.js jump-back >/dev/null 2>&1"
+```
+
+- current behavior keeps the **first pane before the jump chain**
+- repeated `Option+1..5` jumps do not overwrite that origin
+- after successful jump-back, the anchor is cleared
+
+## Statusline click interaction
+
+When using the tmux plugin, the second statusline row can be clicked:
+
+- click attention pills to jump to that session
+- click the `↩` pill to trigger jump-back
+
 ## Notes
 
 - `tmux-badges` is optimized for tmux status bar rendering

--- a/examples/tmux/README.md
+++ b/examples/tmux/README.md
@@ -43,13 +43,15 @@ bind-key A display-popup -E -w 70 -h 18 "cd ~/Documents/mjjo/marmonitor && node 
 Choose one attention item and jump directly from the popup:
 
 ```tmux
-bind-key A display-popup -E -w 120 -h 32 "cd ~/Documents/mjjo/marmonitor && node bin/marmonitor.js attention --interactive --limit 12"
+bind-key A display-popup -E -w 120 -h 42 "cd ~/Documents/mjjo/marmonitor && node bin/marmonitor.js attention --interactive --limit 12"
 ```
 
 - shows only jumpable items
 - by default follows `display.attentionLimit` from `settings.json`
-- press `1-9` once to jump
-- press `0` for item 10
+- when more than 10 items exist, use `←` / `→` to move pages
+- page indicator uses `< 1/2 >` style in the popup header
+- press `1-9` to jump
+- press `0` for `10`
 - press `q` to cancel
 
 ## Interactive jump popup
@@ -57,8 +59,13 @@ bind-key A display-popup -E -w 120 -h 32 "cd ~/Documents/mjjo/marmonitor && node
 Choose one attention item and jump to its existing pane:
 
 ```tmux
-bind-key J display-popup -E -w 120 -h 32 "cd ~/Documents/mjjo/marmonitor && node bin/marmonitor.js jump --attention"
+bind-key J display-popup -E -w 120 -h 42 "cd ~/Documents/mjjo/marmonitor && node bin/marmonitor.js jump --attention"
 ```
+
+- when more than 10 items exist, use `←` / `→` to move pages
+- press `1-9` to jump
+- press `0` for `10`
+- press `q` to cancel
 
 ## Jump to existing pane
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,7 @@ import {
 } from "./config/index.js";
 import { evaluateGuard, formatGuardOutput, parseHookEvent, readStdin } from "./guard/index.js";
 import {
+  applyTerminalStyle,
   printAttention,
   printAttentionJson,
   printCleanJson,
@@ -555,6 +556,7 @@ program
           opts.statuslineFormat,
           attentionLimit,
           width,
+          config.integration.tmux.badgeStyle,
         );
         await writeCachedStatusline(opts.statuslineFormat, attentionLimit, width, rendered);
         console.log(rendered);
@@ -571,8 +573,11 @@ program
   .command("status")
   .description("Show current AI agent status")
   .option("--json", "Output as JSON")
+  .option("--config <path>", "Path to settings.json")
   .action(async (opts) => {
     const agents = await requireDaemonSnapshot();
+    const config = await loadConfig(resolveConfigPath(opts));
+    applyTerminalStyle(config.integration.tmux.badgeStyle);
     if (opts.json) {
       await printStatusJson(agents);
     } else {
@@ -604,6 +609,7 @@ program
   .action(async (opts) => {
     const agents = await requireDaemonSnapshot();
     const config = await loadConfig(resolveConfigPath(opts));
+    applyTerminalStyle(config.integration.tmux.badgeStyle);
     const limit = resolveAttentionLimit(opts, config.display.attentionLimit);
     const interactiveLimit = resolveAttentionLimit(opts, config.display.attentionLimit, true);
     if (opts.interactive && opts.json) {
@@ -876,7 +882,10 @@ program
   .description("Compact persistent monitor for tmux pane")
   .option("--interval <sec>", "Refresh interval in seconds", "2")
   .option("--lines <n>", "Max display lines", "12")
+  .option("--config <path>", "Path to settings.json")
   .action(async (opts) => {
+    const config = await loadConfig(resolveConfigPath(opts));
+    applyTerminalStyle(config.integration.tmux.badgeStyle);
     const intervalMs = Math.max(Number(opts.interval) || 2, 2) * 1000;
     const maxLines = Number(opts.lines) || 12;
 
@@ -895,7 +904,10 @@ program
   .description("Refresh agent status in a long-lived loop")
   .option("--interval <sec>", "Refresh interval in seconds", "2")
   .option("--json", "Output as JSON")
+  .option("--config <path>", "Path to settings.json")
   .action(async (opts) => {
+    const config = await loadConfig(resolveConfigPath(opts));
+    applyTerminalStyle(config.integration.tmux.badgeStyle);
     const intervalSec = Number(opts.interval);
     const intervalMs = Number.isFinite(intervalSec) && intervalSec > 0 ? intervalSec * 1000 : 2_000;
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,10 +25,17 @@ import {
   printStatus,
   printStatusJson,
   printStatusline,
+  renderJumpAttentionChooser,
   renderStatusline,
   renderUnavailableStatusline,
 } from "./output/index.js";
-import { selectJumpAttentionItem, selectUnmatchedTargets } from "./output/utils.js";
+import {
+  buildJumpAttentionItems,
+  parseSelectionInput,
+  selectJumpAttentionItem,
+  selectJumpAttentionItemOnPage,
+  selectUnmatchedTargets,
+} from "./output/utils.js";
 import { TERMINAL_RESTORE_SEQUENCE, formatProcessFailure } from "./process-safety.js";
 import { detectClaudePhase } from "./scanner/claude.js";
 import { detectCodexPhase, indexCodexSessions, matchCodexSession } from "./scanner/codex.js";
@@ -37,6 +44,7 @@ import { parseGeminiSession } from "./scanner/gemini.js";
 import { scanAgents } from "./scanner/index.js";
 import { detectCliStdoutPhase } from "./scanner/status.js";
 import { captureTmuxPaneOutput, jumpToAgent, resolveTmuxJumpTarget } from "./tmux/index.js";
+import { getClientTty, jumpBack } from "./tmux/jump-anchor.js";
 import type { AgentSession } from "./types.js";
 import { VERSION } from "./version.js";
 
@@ -145,6 +153,12 @@ function buildHelpAppendix(): string {
     "  [Dead]      Session file exists but process gone",
     "  [Unmatched] AI process without matching session",
     "",
+    "Common settings:",
+    "  display.attentionLimit / display.statuslineAttentionLimit",
+    "  integration.tmux.badgeStyle",
+    "  integration.tmux.keys.*",
+    "  paths.* (runtime data path overrides)",
+    "",
     "Default tmux shortcuts:",
     "  Prefix+a      Attention popup",
     "  Prefix+j      Jump popup",
@@ -168,16 +182,24 @@ function clearScreen(): void {
   }
 }
 
-async function promptSelectionKey(maxChoice: number): Promise<number | undefined> {
+async function promptSelectionAction(
+  maxChoice: number,
+  currentPage = 1,
+  totalPages = 1,
+): Promise<ReturnType<typeof parseSelectionInput>> {
   if (!process.stdin.isTTY || maxChoice < 1) return undefined;
 
   const prompt =
-    maxChoice >= 10
-      ? "\nPress 1-9 to jump, 0 for item 10, q to cancel: "
-      : `\nPress 1-${maxChoice} to jump, q to cancel: `;
+    totalPages > 1
+      ? maxChoice >= 10
+        ? "\n←/→ page, 1-9 to jump, 0 for 10, q to cancel: "
+        : `\n←/→ page, 1-${maxChoice} to jump, q to cancel: `
+      : maxChoice >= 10
+        ? "\n1-9 to jump, 0 for 10, q to cancel: "
+        : `\n1-${maxChoice} to jump, q to cancel: `;
   process.stdout.write(prompt);
 
-  return await new Promise<number | undefined>((resolve) => {
+  return await new Promise<ReturnType<typeof parseSelectionInput>>((resolve) => {
     const stdin = process.stdin;
     const restoreRawMode = "setRawMode" in stdin && typeof stdin.setRawMode === "function";
 
@@ -194,24 +216,10 @@ async function promptSelectionKey(maxChoice: number): Promise<number | undefined
         cleanup();
         exitWithCleanup(130);
       }
-      if (input === "\u001b" || input === "q" || input === "Q") {
+      const action = parseSelectionInput(input, maxChoice, currentPage, totalPages);
+      if (action) {
         cleanup();
-        resolve(undefined);
-        return;
-      }
-
-      const trimmed = input.trim();
-      if (/^[1-9]$/.test(trimmed)) {
-        const selection = Number.parseInt(trimmed, 10);
-        if (selection <= maxChoice) {
-          cleanup();
-          resolve(selection);
-        }
-        return;
-      }
-      if (trimmed === "0" && maxChoice >= 10) {
-        cleanup();
-        resolve(10);
+        resolve(action);
       }
     };
 
@@ -293,6 +301,7 @@ function buildMinimalConfigSample(): string {
       },
       integration: {
         tmux: {
+          badgeStyle: "basic",
           keys: {
             attentionPopup: "a",
             jumpPopup: "j",
@@ -329,6 +338,7 @@ function buildAdvancedConfigSample(): string {
       },
       integration: {
         tmux: {
+          badgeStyle: "basic",
           keys: {
             attentionPopup: "a",
             jumpPopup: "j",
@@ -551,12 +561,26 @@ program
           console.log(renderUnavailableStatusline(opts.statuslineFormat));
           return;
         }
+        // Check jump-back anchor for indicator
+        let hasJumpAnchor = false;
+        if (opts.statuslineFormat === "tmux-badges") {
+          const { tmpdir: td } = await import("node:os");
+          const { join: pj } = await import("node:path");
+          const { loadJumpAnchor } = await import("./tmux/jump-anchor.js");
+          const tty = await getClientTty();
+          if (tty) {
+            hasJumpAnchor = Boolean(
+              await loadJumpAnchor(pj(td(), "marmonitor", "jump-anchors.json"), tty),
+            );
+          }
+        }
         const rendered = await renderStatusline(
           agents,
           opts.statuslineFormat,
           attentionLimit,
           width,
           config.integration.tmux.badgeStyle,
+          hasJumpAnchor,
         );
         await writeCachedStatusline(opts.statuslineFormat, attentionLimit, width, rendered);
         console.log(rendered);
@@ -621,12 +645,37 @@ program
         console.error("--interactive requires an interactive terminal.");
         process.exit(1);
       }
-      printJumpAttentionChooser(agents, interactiveLimit);
-      const selection = await promptSelectionKey(interactiveLimit);
-      if (selection === undefined) return;
-      const item = selectJumpAttentionItem(agents, selection);
+      const totalItems = buildJumpAttentionItems(agents).length;
+      const totalPages = Math.max(1, Math.ceil(totalItems / interactiveLimit));
+      let currentPage = 1;
+      let item: ReturnType<typeof selectJumpAttentionItemOnPage>;
+      while (true) {
+        clearScreen();
+        console.log(renderJumpAttentionChooser(agents, currentPage, interactiveLimit));
+        const pageItemCount = Math.min(
+          interactiveLimit,
+          Math.max(totalItems - (currentPage - 1) * interactiveLimit, 0),
+        );
+        const action = await promptSelectionAction(pageItemCount, currentPage, totalPages);
+        if (!action || action.kind === "cancel") return;
+        if (action.kind === "next") {
+          currentPage = Math.min(currentPage + 1, totalPages);
+          continue;
+        }
+        if (action.kind === "prev") {
+          currentPage = Math.max(currentPage - 1, 1);
+          continue;
+        }
+        item = selectJumpAttentionItemOnPage(
+          agents,
+          currentPage,
+          action.selection,
+          interactiveLimit,
+        );
+        break;
+      }
       if (!item) {
-        console.error(`Invalid selection: ${selection}`);
+        console.error("Invalid selection.");
         process.exit(1);
       }
       const agent = agents.find((candidate) => candidate.pid === item.pid);
@@ -822,12 +871,29 @@ program
         config.display.attentionLimit,
         true,
       );
-      printJumpAttentionChooser(agents, limit);
-      const selection = await promptSelectionKey(limit);
-      if (selection === undefined) return;
-      const item = selectJumpAttentionItem(agents, selection);
+      const totalItems = buildJumpAttentionItems(agents).length;
+      const totalPages = Math.max(1, Math.ceil(totalItems / limit));
+      let currentPage = 1;
+      let item: ReturnType<typeof selectJumpAttentionItemOnPage>;
+      while (true) {
+        clearScreen();
+        console.log(renderJumpAttentionChooser(agents, currentPage, limit));
+        const pageItemCount = Math.min(limit, Math.max(totalItems - (currentPage - 1) * limit, 0));
+        const action = await promptSelectionAction(pageItemCount, currentPage, totalPages);
+        if (!action || action.kind === "cancel") return;
+        if (action.kind === "next") {
+          currentPage = Math.min(currentPage + 1, totalPages);
+          continue;
+        }
+        if (action.kind === "prev") {
+          currentPage = Math.max(currentPage - 1, 1);
+          continue;
+        }
+        item = selectJumpAttentionItemOnPage(agents, currentPage, action.selection, limit);
+        break;
+      }
       if (!item) {
-        console.error(`Invalid selection: ${selection}`);
+        console.error("Invalid selection.");
         process.exit(1);
       }
       pid = item.pid;
@@ -875,6 +941,24 @@ program
       printJumpResult(result);
     }
     if (!result.found) process.exit(1);
+  });
+
+program
+  .command("jump-back")
+  .description("Return to the tmux pane you were in before the last jump")
+  .option("--client-tty <tty>", "Override client tty (auto-detected if omitted)")
+  .action(async (opts) => {
+    const { tmpdir: td } = await import("node:os");
+    const { join: pjoin } = await import("node:path");
+    const anchorPath = pjoin(td(), "marmonitor", "jump-anchors.json");
+    const tty = opts.clientTty ?? (await getClientTty());
+    if (!tty) {
+      console.error("Cannot detect tmux client. Are you inside tmux?");
+      process.exit(1);
+    }
+    const result = await jumpBack(anchorPath, tty);
+    console.log(result.message);
+    if (!result.success) process.exit(1);
   });
 
 program

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -45,6 +45,7 @@ import { scanAgents } from "./scanner/index.js";
 import { detectCliStdoutPhase } from "./scanner/status.js";
 import { captureTmuxPaneOutput, jumpToAgent, resolveTmuxJumpTarget } from "./tmux/index.js";
 import { getClientTty, jumpBack } from "./tmux/jump-anchor.js";
+import { findClickedAgent, parseStatusClickToken } from "./tmux/status-click.js";
 import type { AgentSession } from "./types.js";
 import { VERSION } from "./version.js";
 
@@ -959,6 +960,34 @@ program
     const result = await jumpBack(anchorPath, tty);
     console.log(result.message);
     if (!result.success) process.exit(1);
+  });
+
+program
+  .command("status-click")
+  .description("Internal tmux statusline click handler")
+  .argument("[token]", "tmux mouse status range token")
+  .option("--client-tty <tty>", "Override client tty (auto-detected if omitted)")
+  .action(async (token: string | undefined, opts) => {
+    const action = parseStatusClickToken(token);
+    if (!action) return;
+
+    if (action.kind === "jump-back") {
+      const { tmpdir: td } = await import("node:os");
+      const { join: pjoin } = await import("node:path");
+      const anchorPath = pjoin(td(), "marmonitor", "jump-anchors.json");
+      const tty = opts.clientTty ?? (await getClientTty());
+      if (!tty) process.exit(1);
+      const result = await jumpBack(anchorPath, tty);
+      if (!result.success) process.exit(1);
+      return;
+    }
+
+    const agents = await getAgentsSnapshot();
+    if (agents.length === 0) process.exit(1);
+    const agent = findClickedAgent(agents, action);
+    if (!agent) process.exit(1);
+    const result = await jumpToAgent(agent);
+    if (!result.executed) process.exit(1);
   });
 
 program

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -71,6 +71,7 @@ export interface MarmonitorConfig {
         dockToggle: string;
         directJump: string[];
       };
+      badgeStyle: "basic" | "basic-mono" | "text" | "text-mono";
     };
     wezterm: {
       enabled: boolean;
@@ -152,6 +153,7 @@ const DEFAULTS: MarmonitorConfig = {
         dockToggle: "m",
         directJump: ["M-1", "M-2", "M-3", "M-4", "M-5"],
       },
+      badgeStyle: "basic" as const,
     },
     wezterm: {
       enabled: false,

--- a/src/output/badge-themes.ts
+++ b/src/output/badge-themes.ts
@@ -11,6 +11,7 @@ export interface BadgeTheme {
   attention: string;
   focus: string;
   empty: string;
+  jumpBack: string;
 }
 
 export const BADGE_THEMES: Record<string, BadgeTheme> = {
@@ -20,6 +21,8 @@ export const BADGE_THEMES: Record<string, BadgeTheme> = {
       "#[fg={bg},bg=#1e1e2e]#[bold,fg=#11111b,bg={bg}] {index} #[fg=#313244,bg={bg}]#[fg=#cdd6f4,bg=#313244] {label} #[fg=#313244,bg=#1e1e2e]#[default]",
     focus: "#[fg=#bac2de,bg=#181825] {text} #[default]",
     empty: "#[fg=#cdd6f4,bg=#313244] no active #[fg=#313244,bg=#1e1e2e]#[default]",
+    jumpBack:
+      "#[fg=#45475a,bg=#1e1e2e]#[fg=#bac2de,bg=#45475a] ↩ #[fg=#45475a,bg=#1e1e2e]#[default]",
   },
   "basic-mono": {
     badge:
@@ -29,18 +32,22 @@ export const BADGE_THEMES: Record<string, BadgeTheme> = {
     focus: "#[fg=#6c7086,bg=#181825] {text} #[default]",
     empty:
       "#[fg=#313244,bg=#1e1e2e]#[fg=#6c7086,bg=#313244] no active #[fg=#313244,bg=#1e1e2e]#[default]",
+    jumpBack:
+      "#[fg=#313244,bg=#1e1e2e]#[fg=#6c7086,bg=#313244] ↩ #[fg=#313244,bg=#1e1e2e]#[default]",
   },
   text: {
     badge: "#[fg={bg}]{label}#[default]",
     attention: "#[fg={bg}]{index} {label}#[default]",
     focus: "{text}",
     empty: "no active",
+    jumpBack: "#[fg=#89b4fa]↩#[default]",
   },
   "text-mono": {
     badge: "#[fg=#cdd6f4]{label}#[default]",
     attention: "#[bold,fg=#cdd6f4]{index}#[default] #[fg=#6c7086]{label}#[default]",
     focus: "#[fg=#6c7086]{text}#[default]",
     empty: "#[fg=#6c7086]no active#[default]",
+    jumpBack: "#[fg=#6c7086]↩#[default]",
   },
 };
 

--- a/src/output/badge-themes.ts
+++ b/src/output/badge-themes.ts
@@ -1,0 +1,69 @@
+/**
+ * Badge theme definitions for tmux statusline rendering.
+ * Each theme defines template strings with placeholders:
+ *   {label}, {fg}, {bg} for badges
+ *   {index}, {label}, {bg} for attention segments
+ *   {text} for focus text
+ */
+
+export interface BadgeTheme {
+  badge: string;
+  attention: string;
+  focus: string;
+  empty: string;
+}
+
+export const BADGE_THEMES: Record<string, BadgeTheme> = {
+  basic: {
+    badge: "#[fg={bg},bg=#1e1e2e]#[bold,fg={fg},bg={bg}] {label} #[fg={bg},bg=#1e1e2e]#[default]",
+    attention:
+      "#[fg={bg},bg=#1e1e2e]#[bold,fg=#11111b,bg={bg}] {index} #[fg=#313244,bg={bg}]#[fg=#cdd6f4,bg=#313244] {label} #[fg=#313244,bg=#1e1e2e]#[default]",
+    focus: "#[fg=#bac2de,bg=#181825] {text} #[default]",
+    empty: "#[fg=#cdd6f4,bg=#313244] no active #[fg=#313244,bg=#1e1e2e]#[default]",
+  },
+  "basic-mono": {
+    badge:
+      "#[fg=#313244,bg=#1e1e2e]#[bold,fg=#cdd6f4,bg=#313244] {label} #[fg=#313244,bg=#1e1e2e]#[default]",
+    attention:
+      "#[fg=#313244,bg=#1e1e2e]#[bold,fg=#cdd6f4,bg=#313244] {index} #[fg=#1e1e2e,bg=#313244]#[fg=#6c7086,bg=#1e1e2e] {label} #[fg=#1e1e2e]#[default]",
+    focus: "#[fg=#6c7086,bg=#181825] {text} #[default]",
+    empty:
+      "#[fg=#313244,bg=#1e1e2e]#[fg=#6c7086,bg=#313244] no active #[fg=#313244,bg=#1e1e2e]#[default]",
+  },
+  text: {
+    badge: "#[fg={bg}]{label}#[default]",
+    attention: "#[fg={bg}]{index} {label}#[default]",
+    focus: "{text}",
+    empty: "no active",
+  },
+  "text-mono": {
+    badge: "#[fg=#cdd6f4]{label}#[default]",
+    attention: "#[bold,fg=#cdd6f4]{index}#[default] #[fg=#6c7086]{label}#[default]",
+    focus: "#[fg=#6c7086]{text}#[default]",
+    empty: "#[fg=#6c7086]no active#[default]",
+  },
+};
+
+export function renderBadge(theme: BadgeTheme, label: string, fg: string, bg: string): string {
+  return theme.badge.replaceAll("{label}", label).replaceAll("{fg}", fg).replaceAll("{bg}", bg);
+}
+
+export function renderAttention(
+  theme: BadgeTheme,
+  index: number,
+  label: string,
+  bg: string,
+): string {
+  return theme.attention
+    .replaceAll("{index}", String(index))
+    .replaceAll("{label}", label)
+    .replaceAll("{bg}", bg);
+}
+
+export function renderFocus(theme: BadgeTheme, text: string): string {
+  return theme.focus.replaceAll("{text}", text);
+}
+
+export function resolveTheme(style: string): BadgeTheme {
+  return BADGE_THEMES[style] ?? BADGE_THEMES.basic;
+}

--- a/src/output/index.ts
+++ b/src/output/index.ts
@@ -9,6 +9,7 @@ import type {
   WorkerProcess,
 } from "../types.js";
 import {
+  type BadgeStyle,
   type StatuslineFormat,
   buildAttentionFocusText,
   buildAttentionItems,
@@ -42,6 +43,13 @@ export async function getSystemInfo(): Promise<SystemInfo> {
 }
 
 // shortenPath, formatElapsed, formatTokens imported from ./utils.js
+
+/** Apply badge style to terminal chalk output: mono/plain disable colors */
+export function applyTerminalStyle(badgeStyle: BadgeStyle): void {
+  if (badgeStyle === "basic-mono" || badgeStyle === "text-mono") {
+    chalk.level = 0;
+  }
+}
 
 /** Agent name with distinct color */
 function agentLabel(name: string): string {
@@ -505,6 +513,7 @@ export async function renderStatusline(
   format: StatuslineFormat = "compact",
   attentionLimit = 5,
   width?: number,
+  badgeStyle: BadgeStyle = "basic",
 ): Promise<string> {
   const alive = agents.filter((a) => a.status !== "Dead" && a.status !== "Unmatched");
   const unmatched = agents.filter((a) => a.status === "Unmatched");
@@ -545,8 +554,9 @@ export async function renderStatusline(
       buildJumpAttentionItems(agents),
       attentionLimit,
       width,
+      badgeStyle,
     );
-    return buildTmuxBadgeBar(snapshot, focusText);
+    return buildTmuxBadgeBar(snapshot, focusText, badgeStyle);
   }
 
   if (format === "wezterm-pills") {

--- a/src/output/index.ts
+++ b/src/output/index.ts
@@ -374,6 +374,49 @@ function jumpAttentionLine(item: ReturnType<typeof buildJumpAttentionItems>[numb
   return `  ${status} ${agent} ${chalk.dim(path)}${runtime}${icon}\n             PID:${item.pid}  ${stats}${started}${activity}`;
 }
 
+function paginateJumpAttentionItems<T>(items: T[], page: number, pageSize = 10): T[] {
+  const normalizedPage = Number.isInteger(page) && page > 0 ? page : 1;
+  const normalizedSize = Number.isInteger(pageSize) && pageSize > 0 ? pageSize : 10;
+  const start = (normalizedPage - 1) * normalizedSize;
+  return items.slice(start, start + normalizedSize);
+}
+
+export function renderJumpAttentionChooser(
+  agents: AgentSession[],
+  page = 1,
+  pageSize = 10,
+): string {
+  const items = buildJumpAttentionItems(agents);
+  if (items.length === 0) {
+    return "No jumpable attention items.";
+  }
+
+  const shown = paginateJumpAttentionItems(items, page, pageSize);
+  if (shown.length === 0) {
+    return "No jumpable attention items.";
+  }
+
+  const totalPages = Math.max(1, Math.ceil(items.length / pageSize));
+  const lines = [
+    `Select session to jump to (${items.length}) — ${totalPages > 1 ? `< ${page}/${totalPages} >` : "< 1/1 >"}:`,
+  ];
+
+  shown.forEach((item, index) => {
+    const [firstLine, ...restLines] = jumpAttentionLine(item).split("\n");
+    const displayNumber = index + 1;
+    const indexLabel = `${displayNumber})`.padStart(displayNumber === 10 ? 4 : 3);
+    lines.push(`${indexLabel} ${firstLine.trimStart()}`);
+    for (const line of restLines) {
+      lines.push(`    ${line.trimStart()}`);
+    }
+    if (index < shown.length - 1) {
+      lines.push(chalk.dim("    ───────────────────────────────────────────────────────────"));
+    }
+  });
+
+  return lines.join("\n");
+}
+
 export function printAttention(agents: AgentSession[], limit = 12): void {
   const items = buildAttentionItems(agents);
   if (items.length === 0) {
@@ -422,26 +465,8 @@ export function printAttentionChooser(agents: AgentSession[], limit = 12): void 
   });
 }
 
-export function printJumpAttentionChooser(agents: AgentSession[], limit = 12): void {
-  const items = buildJumpAttentionItems(agents).slice(0, limit);
-  if (items.length === 0) {
-    console.log("No jumpable attention items.");
-    return;
-  }
-
-  console.log(`Select session to jump to (${items.length}):`);
-  items.forEach((item, index) => {
-    const [firstLine, ...restLines] = jumpAttentionLine(item).split("\n");
-    const indexLabel = `${index + 1})`.padStart(3);
-    console.log(`${indexLabel} ${firstLine.trimStart()}`);
-    for (const line of restLines) {
-      console.log(`    ${line.trimStart()}`);
-    }
-    if (index < items.length - 1) {
-      console.log(chalk.dim("    ───────────────────────────────────────────────────────────"));
-    }
-  });
-  console.log(chalk.dim("\nPress 1-9 to jump, 0 for item 10, q to cancel."));
+export function printJumpAttentionChooser(agents: AgentSession[], limit = 10): void {
+  console.log(renderJumpAttentionChooser(agents, 1, limit));
 }
 
 export function printJumpResult(result: TmuxJumpResult): void {
@@ -536,6 +561,7 @@ export async function renderStatusline(
   attentionLimit = 5,
   width?: number,
   badgeStyle: BadgeStyle = "basic",
+  hasJumpAnchor = false,
 ): Promise<string> {
   const alive = agents.filter((a) => a.status !== "Dead" && a.status !== "Unmatched");
   const unmatched = agents.filter((a) => a.status === "Unmatched");
@@ -578,7 +604,7 @@ export async function renderStatusline(
       width,
       badgeStyle,
     );
-    return buildTmuxBadgeBar(snapshot, focusText, badgeStyle);
+    return buildTmuxBadgeBar(snapshot, focusText, badgeStyle, hasJumpAnchor);
   }
 
   if (format === "wezterm-pills") {

--- a/src/output/index.ts
+++ b/src/output/index.ts
@@ -44,15 +44,17 @@ export async function getSystemInfo(): Promise<SystemInfo> {
 
 // shortenPath, formatElapsed, formatTokens imported from ./utils.js
 
-/** Apply badge style to terminal chalk output: mono/plain disable colors */
+let monoMode = false;
+
+/** Apply badge style to terminal chalk output: mono uses bold/dim only */
 export function applyTerminalStyle(badgeStyle: BadgeStyle): void {
-  if (badgeStyle === "basic-mono" || badgeStyle === "text-mono") {
-    chalk.level = 0;
-  }
+  monoMode = badgeStyle === "basic-mono" || badgeStyle === "text-mono";
 }
 
 /** Agent name with distinct color */
 function agentLabel(name: string): string {
+  const label = name === "Claude Code" ? "Claude" : name;
+  if (monoMode) return chalk.bold.white(label);
   switch (name) {
     case "Claude Code":
       return chalk.hex("#D97706")("Claude"); // amber/orange
@@ -67,6 +69,20 @@ function agentLabel(name: string): string {
 
 /** Status icon/color */
 function statusLabel(status: AgentSession["status"]): string {
+  if (monoMode) {
+    switch (status) {
+      case "Active":
+        return chalk.white("[Active]   ");
+      case "Idle":
+        return chalk.gray("[Idle]     ");
+      case "Stalled":
+        return chalk.dim("[Stalled]  ");
+      case "Unmatched":
+        return chalk.dim("[Unmatched]");
+      case "Dead":
+        return chalk.dim("[Dead]     ");
+    }
+  }
   switch (status) {
     case "Active":
       return chalk.green("[Active]   ");
@@ -82,6 +98,12 @@ function statusLabel(status: AgentSession["status"]): string {
 }
 
 function displayStatusLabel(status: AgentSession["status"], phase?: SessionPhase): string {
+  if (monoMode) {
+    if (phase === "permission") return chalk.bold.white("[Allow]   ");
+    if (phase === "tool") return chalk.white("[Tool]    ");
+    if (phase === "thinking") return chalk.white("[Think]   ");
+    return statusLabel(status);
+  }
   if (phase === "permission") return chalk.red("[Allow]   ");
   if (phase === "tool") return chalk.green("[Tool]    ");
   if (phase === "thinking") return chalk.magenta("[Think]   ");

--- a/src/output/utils.ts
+++ b/src/output/utils.ts
@@ -423,12 +423,6 @@ function agentShortName(agentName: string): string {
   return agentName;
 }
 
-function attentionPriority(agent: AgentSession): number | undefined {
-  if (agent.phase === "permission") return 0;
-  if (agent.phase === "thinking") return 1;
-  return undefined;
-}
-
 function attentionKind(agent: AgentSession): AttentionKind | undefined {
   if (agent.phase === "permission") return "permission";
   if (agent.phase === "thinking") return "thinking";
@@ -445,21 +439,28 @@ function attentionActivityTime(
   return agent.lastActivityAt ?? agent.lastResponseAt ?? agent.startedAt ?? 0;
 }
 
+const STALE_ATTENTION_PHASE_SEC = 10 * 60;
+
+function attentionPriority(
+  agent: Pick<AgentSession, "phase" | "lastActivityAt" | "lastResponseAt" | "startedAt">,
+  nowSec = Date.now() / 1000,
+): number | undefined {
+  if (agent.phase === "permission") return 0;
+
+  const activityTime = attentionActivityTime(agent);
+  if (activityTime <= 0) return undefined;
+  const elapsedSec = Math.max(0, nowSec - activityTime);
+  const isFresh = elapsedSec <= STALE_ATTENTION_PHASE_SEC;
+
+  if (agent.phase === "thinking" && isFresh) return 1;
+  if (agent.phase === "tool" && isFresh) return 2;
+  return undefined;
+}
+
 function orderedAttentionItems(items: AttentionItem[]): AttentionItem[] {
-  const tier1Order: Partial<Record<AttentionKind, number>> = {
-    permission: 0,
-    thinking: 1,
-  };
-
   return [...items].sort((a, b) => {
-    const aTier1 = tier1Order[a.kind];
-    const bTier1 = tier1Order[b.kind];
-
-    if (aTier1 !== undefined || bTier1 !== undefined) {
-      if (aTier1 === undefined) return 1;
-      if (bTier1 === undefined) return -1;
-      if (aTier1 !== bTier1) return aTier1 - bTier1;
-      return attentionActivityTime(b) - attentionActivityTime(a);
+    if (a.priority !== b.priority) {
+      return a.priority - b.priority;
     }
 
     return attentionActivityTime(b) - attentionActivityTime(a);
@@ -467,8 +468,11 @@ function orderedAttentionItems(items: AttentionItem[]): AttentionItem[] {
 }
 
 /** Build prioritized attention list for popup/jump UX.
- * Order: permission -> thinking -> recently active alive sessions. */
-export function buildAttentionItems(agents: AgentSession[]): AttentionItem[] {
+ * Order: permission -> fresh thinking/tool -> recent alive sessions -> stale thinking/tool. */
+export function buildAttentionItems(
+  agents: AgentSession[],
+  nowSec = Date.now() / 1000,
+): AttentionItem[] {
   const alive = agents.filter(
     (agent) =>
       agent.status !== "Dead" && agent.status !== "Unmatched" && agent.status !== "Stalled",
@@ -495,22 +499,26 @@ export function buildAttentionItems(agents: AgentSession[]): AttentionItem[] {
   });
 
   const tier1 = alive
-    .filter((agent) => attentionPriority(agent) !== undefined)
+    .filter((agent) => attentionPriority(agent, nowSec) !== undefined)
     .sort((a, b) => {
-      const aPriority = attentionPriority(a) ?? Number.MAX_SAFE_INTEGER;
-      const bPriority = attentionPriority(b) ?? Number.MAX_SAFE_INTEGER;
+      const aPriority = attentionPriority(a, nowSec) ?? Number.MAX_SAFE_INTEGER;
+      const bPriority = attentionPriority(b, nowSec) ?? Number.MAX_SAFE_INTEGER;
       if (aPriority !== bPriority) return aPriority - bPriority;
       return attentionActivityTime(b) - attentionActivityTime(a);
     })
     .map((agent) =>
-      toAttentionItem(agent, attentionPriority(agent) ?? 0, attentionKind(agent) ?? "active"),
+      toAttentionItem(
+        agent,
+        attentionPriority(agent, nowSec) ?? 0,
+        attentionKind(agent) ?? "active",
+      ),
     );
 
   const tier1Pids = new Set(tier1.map((item) => item.pid));
   const tier2 = alive
     .filter((agent) => !tier1Pids.has(agent.pid))
     .sort((a, b) => attentionActivityTime(b) - attentionActivityTime(a))
-    .map((agent) => toAttentionItem(agent, 2, attentionKind(agent) ?? "active"));
+    .map((agent) => toAttentionItem(agent, 3, attentionKind(agent) ?? "active"));
 
   return [...tier1, ...tier2];
 }
@@ -525,8 +533,11 @@ export function selectAttentionItem(
 
 /** Build jumpable attention items for interactive navigation.
  *  Statusline/jump share the same top-of-mind ordering. */
-export function buildJumpAttentionItems(agents: AgentSession[]): AttentionItem[] {
-  return orderedAttentionItems(buildAttentionItems(agents));
+export function buildJumpAttentionItems(
+  agents: AgentSession[],
+  nowSec = Date.now() / 1000,
+): AttentionItem[] {
+  return orderedAttentionItems(buildAttentionItems(agents, nowSec));
 }
 
 export function selectJumpAttentionItem(

--- a/src/output/utils.ts
+++ b/src/output/utils.ts
@@ -1,4 +1,5 @@
 import type { AgentSession, SessionPhase } from "../types.js";
+import { renderAttention, renderBadge, renderFocus, resolveTheme } from "./badge-themes.js";
 
 /**
  * Pure utility functions for marmonitor.
@@ -697,13 +698,7 @@ export function buildStatuslineSummary(
   return standardParts.join(" | ");
 }
 
-function tmuxPill(label: string, fg: string, bg: string): string {
-  return `#[fg=${bg},bg=#1e1e2e]#[bold,fg=${fg},bg=${bg}] ${label} #[fg=${bg},bg=#1e1e2e]#[default]`;
-}
-
-function tmuxDetailBlock(label: string): string {
-  return `#[fg=#cdd6f4,bg=#313244] ${label} #[fg=#313244,bg=#1e1e2e]#[default]`;
-}
+export type BadgeStyle = "basic" | "basic-mono" | "text" | "text-mono";
 
 function attentionBg(kind: Exclude<AttentionKind, "unmatched">): string {
   if (kind === "permission") return "#f38ba8";
@@ -722,11 +717,16 @@ function tmuxAttentionSegment(
   return `#[fg=${bg},bg=#1e1e2e]#[bold,fg=#11111b,bg=${bg}] ${index} #[fg=#313244,bg=${bg}]#[fg=#cdd6f4,bg=#313244] ${label} #[fg=#313244,bg=#1e1e2e]#[default]`;
 }
 
-export function buildTmuxBadgeBar(snapshot: StatuslineSnapshot, focusText?: string): string {
+export function buildTmuxBadgeBar(
+  snapshot: StatuslineSnapshot,
+  focusText?: string,
+  badgeStyle: BadgeStyle = "basic",
+): string {
+  const theme = resolveTheme(badgeStyle);
   const { agents, alerts } = buildStatusPills(snapshot);
-  const agentPills = agents.map((pill) => tmuxPill(pill.label, pill.fg, pill.bg));
-  const alertPills = alerts.map((pill) => tmuxPill(pill.label, pill.fg, pill.bg));
-  const focus = focusText ? `#[fg=#bac2de,bg=#181825] ${focusText} #[default]` : "";
+  const agentPills = agents.map((pill) => renderBadge(theme, pill.label, pill.fg, pill.bg));
+  const alertPills = alerts.map((pill) => renderBadge(theme, pill.label, pill.fg, pill.bg));
+  const focus = focusText ? renderFocus(theme, focusText) : "";
   return [agentPills.join(" "), alertPills.join(" "), focus].filter(Boolean).join("  ");
 }
 
@@ -734,6 +734,7 @@ export function buildTmuxAttentionPills(
   items: AttentionItem[],
   maxCount = 5,
   width?: number,
+  badgeStyle: BadgeStyle = "basic",
 ): string | undefined {
   if (maxCount <= 0) return undefined;
   const layout = resolveStatuslineDetailLayout(width, maxCount);
@@ -744,8 +745,10 @@ export function buildTmuxAttentionPills(
     )
     .slice(0, layout.itemCount);
 
+  const theme = resolveTheme(badgeStyle);
+
   if (jumpItems.length === 0) {
-    return tmuxDetailBlock("no active");
+    return theme.empty;
   }
 
   const segments = jumpItems.map((item, index) => {
@@ -770,7 +773,7 @@ export function buildTmuxAttentionPills(
               : time
                 ? `⚠${agent} ${path} ${time}`
                 : `⚠${agent} ${path}`;
-    return tmuxAttentionSegment(index + 1, item.kind, label);
+    return renderAttention(theme, index + 1, label, attentionBg(item.kind));
   });
 
   return segments.join("  ");

--- a/src/output/utils.ts
+++ b/src/output/utils.ts
@@ -766,6 +766,10 @@ function tmuxAttentionSegment(
   return `#[fg=${bg},bg=#1e1e2e]#[bold,fg=#11111b,bg=${bg}] ${index} #[fg=#313244,bg=${bg}]#[fg=#cdd6f4,bg=#313244] ${label} #[fg=#313244,bg=#1e1e2e]#[default]`;
 }
 
+function tmuxUserRange(value: string, content: string): string {
+  return `#[range=user|${value}]${content}#[norange]`;
+}
+
 export function buildTmuxBadgeBar(
   snapshot: StatuslineSnapshot,
   focusText?: string,
@@ -776,7 +780,7 @@ export function buildTmuxBadgeBar(
   const { agents, alerts } = buildStatusPills(snapshot);
   const agentPills = agents.map((pill) => renderBadge(theme, pill.label, pill.fg, pill.bg));
   const alertPills = alerts.map((pill) => renderBadge(theme, pill.label, pill.fg, pill.bg));
-  const jumpBack = hasJumpAnchor ? theme.jumpBack : "";
+  const jumpBack = hasJumpAnchor ? tmuxUserRange("jump-back", theme.jumpBack) : "";
   const focus = focusText ? renderFocus(theme, focusText) : "";
   return [agentPills.join(" "), alertPills.join(" "), jumpBack, focus].filter(Boolean).join("  ");
 }
@@ -824,7 +828,10 @@ export function buildTmuxAttentionPills(
               : time
                 ? `⚠${agent} ${path} ${time}`
                 : `⚠${agent} ${path}`;
-    return renderAttention(theme, index + 1, label, attentionBg(item.kind));
+    return tmuxUserRange(
+      `pid:${item.pid}`,
+      renderAttention(theme, index + 1, label, attentionBg(item.kind)),
+    );
   });
 
   return segments.join("  ");

--- a/src/output/utils.ts
+++ b/src/output/utils.ts
@@ -537,6 +537,55 @@ export function selectJumpAttentionItem(
   return buildJumpAttentionItems(agents)[selection - 1];
 }
 
+export function selectJumpAttentionItemOnPage(
+  agents: AgentSession[],
+  page: number,
+  selection: number,
+  pageSize = 10,
+): AttentionItem | undefined {
+  if (!Number.isInteger(selection) || selection < 1) return undefined;
+  if (!Number.isInteger(page) || page < 1) return undefined;
+  if (!Number.isInteger(pageSize) || pageSize < 1) return undefined;
+  const start = (page - 1) * pageSize;
+  return buildJumpAttentionItems(agents)[start + selection - 1];
+}
+
+export type SelectionAction =
+  | { kind: "cancel" }
+  | { kind: "next" }
+  | { kind: "prev" }
+  | { kind: "select"; selection: number };
+
+export function parseSelectionInput(
+  input: string,
+  maxChoice: number,
+  currentPage = 1,
+  totalPages = 1,
+): SelectionAction | undefined {
+  if (input === "\u001b" || input === "q" || input === "Q") {
+    return { kind: "cancel" };
+  }
+  if (input === "\u001b[C" && currentPage < totalPages) {
+    return { kind: "next" };
+  }
+  if (input === "\u001b[D" && currentPage > 1) {
+    return { kind: "prev" };
+  }
+
+  const trimmed = input.trim();
+  if (/^[1-9]$/.test(trimmed)) {
+    const selection = Number.parseInt(trimmed, 10);
+    if (selection <= maxChoice) {
+      return { kind: "select", selection };
+    }
+    return undefined;
+  }
+  if (trimmed === "0" && maxChoice >= 10) {
+    return { kind: "select", selection: 10 };
+  }
+  return undefined;
+}
+
 export function buildAttentionFocusText(
   items: AttentionItem[],
   maxCount = 3,
@@ -721,13 +770,15 @@ export function buildTmuxBadgeBar(
   snapshot: StatuslineSnapshot,
   focusText?: string,
   badgeStyle: BadgeStyle = "basic",
+  hasJumpAnchor = false,
 ): string {
   const theme = resolveTheme(badgeStyle);
   const { agents, alerts } = buildStatusPills(snapshot);
   const agentPills = agents.map((pill) => renderBadge(theme, pill.label, pill.fg, pill.bg));
   const alertPills = alerts.map((pill) => renderBadge(theme, pill.label, pill.fg, pill.bg));
+  const jumpBack = hasJumpAnchor ? theme.jumpBack : "";
   const focus = focusText ? renderFocus(theme, focusText) : "";
-  return [agentPills.join(" "), alertPills.join(" "), focus].filter(Boolean).join("  ");
+  return [agentPills.join(" "), alertPills.join(" "), jumpBack, focus].filter(Boolean).join("  ");
 }
 
 export function buildTmuxAttentionPills(

--- a/src/tmux/index.ts
+++ b/src/tmux/index.ts
@@ -1,6 +1,9 @@
 import { execFile } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { promisify } from "node:util";
 import type { AgentSession } from "../types.js";
+import { getClientTty, getCurrentTmuxLocation, saveJumpAnchorIfMissing } from "./jump-anchor.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -183,9 +186,19 @@ export async function jumpToTmuxPane(target: TmuxJumpTarget): Promise<boolean> {
   }
 }
 
+const ANCHOR_PATH = join(tmpdir(), "marmonitor", "jump-anchors.json");
+
 export async function jumpToAgent(
   agent: Pick<AgentSession, "pid" | "cwd">,
 ): Promise<TmuxJumpResult> {
+  // Save current location as jump-back anchor before jumping
+  if (process.env.TMUX) {
+    const [tty, location] = await Promise.all([getClientTty(), getCurrentTmuxLocation()]);
+    if (tty && location) {
+      await saveJumpAnchorIfMissing(ANCHOR_PATH, tty, location).catch(() => {});
+    }
+  }
+
   const target = await resolveTmuxJumpTarget(agent);
   if (!target) {
     return {

--- a/src/tmux/jump-anchor.ts
+++ b/src/tmux/jump-anchor.ts
@@ -1,0 +1,131 @@
+/**
+ * Jump-back anchor management.
+ * Saves the current tmux pane location before jumping, so the user can return.
+ */
+
+import { execFile } from "node:child_process";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export interface JumpAnchorLocation {
+  session: string;
+  window: string;
+  pane: string;
+}
+
+export interface JumpAnchor extends JumpAnchorLocation {
+  savedAt: number;
+}
+
+async function readAnchors(anchorPath: string): Promise<Record<string, JumpAnchor>> {
+  try {
+    const raw = await readFile(anchorPath, "utf-8");
+    return JSON.parse(raw);
+  } catch {
+    return {};
+  }
+}
+
+async function writeAnchors(
+  anchorPath: string,
+  anchors: Record<string, JumpAnchor>,
+): Promise<void> {
+  await mkdir(dirname(anchorPath), { recursive: true });
+  await writeFile(anchorPath, JSON.stringify(anchors, null, 2), "utf-8");
+}
+
+export async function saveJumpAnchor(
+  anchorPath: string,
+  clientTty: string,
+  location: JumpAnchorLocation,
+): Promise<void> {
+  const anchors = await readAnchors(anchorPath);
+  anchors[clientTty] = { ...location, savedAt: Date.now() };
+  await writeAnchors(anchorPath, anchors);
+}
+
+export async function saveJumpAnchorIfMissing(
+  anchorPath: string,
+  clientTty: string,
+  location: JumpAnchorLocation,
+): Promise<boolean> {
+  const anchors = await readAnchors(anchorPath);
+  if (anchors[clientTty]) return false;
+  anchors[clientTty] = { ...location, savedAt: Date.now() };
+  await writeAnchors(anchorPath, anchors);
+  return true;
+}
+
+export async function loadJumpAnchor(
+  anchorPath: string,
+  clientTty: string,
+): Promise<JumpAnchor | undefined> {
+  try {
+    const anchors = await readAnchors(anchorPath);
+    return anchors[clientTty] ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function clearJumpAnchor(anchorPath: string, clientTty: string): Promise<boolean> {
+  const anchors = await readAnchors(anchorPath);
+  if (!anchors[clientTty]) return false;
+  delete anchors[clientTty];
+  await writeAnchors(anchorPath, anchors);
+  return true;
+}
+
+/** Get the current tmux pane location for the active client */
+export async function getCurrentTmuxLocation(): Promise<JumpAnchorLocation | undefined> {
+  try {
+    const { stdout } = await execFileAsync("tmux", [
+      "display-message",
+      "-p",
+      "#{session_name}\t#{window_index}\t#{session_name}:#{window_index}.#{pane_index}",
+    ]);
+    const [session, window, pane] = stdout.trim().split("\t");
+    if (session && window && pane) return { session, window, pane };
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Get the client tty of the current tmux client */
+export async function getClientTty(): Promise<string | undefined> {
+  try {
+    const { stdout } = await execFileAsync("tmux", ["display-message", "-p", "#{client_tty}"]);
+    const tty = stdout.trim();
+    return tty || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Jump back to a saved anchor location */
+export async function jumpBack(
+  anchorPath: string,
+  clientTty: string,
+): Promise<{ success: boolean; message: string }> {
+  const anchor = await loadJumpAnchor(anchorPath, clientTty);
+  if (!anchor) {
+    return { success: false, message: "No jump-back anchor found." };
+  }
+
+  try {
+    const windowTarget = `${anchor.session}:${anchor.window}`;
+    if (process.env.TMUX) {
+      await execFileAsync("tmux", ["switch-client", "-t", windowTarget]);
+    }
+    await execFileAsync("tmux", ["select-window", "-t", windowTarget]);
+    await execFileAsync("tmux", ["select-pane", "-t", anchor.pane]);
+    await clearJumpAnchor(anchorPath, clientTty).catch(() => {});
+    return { success: true, message: `Jumped back to ${anchor.pane}.` };
+  } catch {
+    return { success: false, message: `Failed to jump back to ${anchor.pane}.` };
+  }
+}

--- a/src/tmux/status-click.ts
+++ b/src/tmux/status-click.ts
@@ -1,0 +1,24 @@
+import type { AgentSession } from "../types.js";
+
+export type StatusClickAction = { kind: "jump"; pid: number } | { kind: "jump-back" };
+
+export function parseStatusClickToken(token?: string): StatusClickAction | undefined {
+  if (!token) return undefined;
+  const trimmed = token.trim();
+  if (trimmed === "jump-back") return { kind: "jump-back" };
+
+  const pidMatch = /^pid:(\d+)$/.exec(trimmed);
+  if (!pidMatch) return undefined;
+
+  const pid = Number.parseInt(pidMatch[1] ?? "", 10);
+  if (!Number.isFinite(pid)) return undefined;
+  return { kind: "jump", pid };
+}
+
+export function findClickedAgent(
+  sessions: AgentSession[],
+  action: StatusClickAction,
+): AgentSession | undefined {
+  if (action.kind !== "jump") return undefined;
+  return sessions.find((session) => session.pid === action.pid);
+}

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -3,6 +3,8 @@ import { execFileSync } from "node:child_process";
 import { dirname, join } from "node:path";
 import { describe, it } from "node:test";
 import { fileURLToPath } from "node:url";
+import { renderJumpAttentionChooser } from "../dist/output/index.js";
+import { parseSelectionInput, selectJumpAttentionItemOnPage } from "../dist/output/utils.js";
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 const cliPath = join(repoRoot, "bin", "marmonitor.js");
@@ -82,5 +84,81 @@ describe("postinstall/preuninstall scripts", () => {
     });
     // Should not throw. Output may be empty if no tmux.conf plugin line.
     assert.equal(typeof output, "string");
+  });
+});
+
+describe("jump attention chooser", () => {
+  it("renders first page with 1-10 numbering", () => {
+    const now = Math.floor(Date.now() / 1000);
+    const agents = Array.from({ length: 12 }, (_, index) => ({
+      agentName: "Claude Code",
+      pid: 1000 + index,
+      cwd: `/tmp/project-${index + 1}`,
+      cpuPercent: 1,
+      memoryMb: 100,
+      status: "Active",
+      sessionMatched: true,
+      phase: "thinking",
+      startedAt: now - 60,
+      lastActivityAt: now - index,
+      runtimeSource: "cli",
+    }));
+
+    const text = renderJumpAttentionChooser(agents, 1, 10);
+    assert.match(text, / 1\)/);
+    assert.match(text, /10\)/);
+    assert.doesNotMatch(text, /11\)/);
+    assert.match(text, /< 1\/2 >/);
+  });
+
+  it("renders second page with 1-based page-local numbering", () => {
+    const now = Math.floor(Date.now() / 1000);
+    const agents = Array.from({ length: 12 }, (_, index) => ({
+      agentName: "Codex",
+      pid: 2000 + index,
+      cwd: `/tmp/project-${index + 1}`,
+      cpuPercent: 1,
+      memoryMb: 100,
+      status: "Active",
+      sessionMatched: true,
+      phase: "thinking",
+      startedAt: now - 60,
+      lastActivityAt: now - index,
+      runtimeSource: "cli",
+    }));
+
+    const text = renderJumpAttentionChooser(agents, 2, 10);
+    assert.match(text, /< 2\/2 >/);
+    assert.match(text, / 1\)/);
+    assert.match(text, / 2\)/);
+    assert.doesNotMatch(text, /10\)/);
+  });
+
+  it("maps page-local selections back to the correct global item", () => {
+    const now = Math.floor(Date.now() / 1000);
+    const agents = Array.from({ length: 12 }, (_, index) => ({
+      agentName: "Claude Code",
+      pid: 3000 + index,
+      cwd: `/tmp/project-${index + 1}`,
+      cpuPercent: 1,
+      memoryMb: 100,
+      status: "Active",
+      sessionMatched: true,
+      phase: "thinking",
+      startedAt: now - 60,
+      lastActivityAt: now - index,
+      runtimeSource: "cli",
+    }));
+
+    const item = selectJumpAttentionItemOnPage(agents, 2, 1, 10);
+    assert.equal(item?.pid, 3010);
+  });
+
+  it("parses arrow-key page navigation and page-local selection input", () => {
+    assert.deepEqual(parseSelectionInput("\u001b[C", 10, 1, 2), { kind: "next" });
+    assert.deepEqual(parseSelectionInput("\u001b[D", 2, 2, 2), { kind: "prev" });
+    assert.deepEqual(parseSelectionInput("0", 10, 1, 2), { kind: "select", selection: 10 });
+    assert.deepEqual(parseSelectionInput("2", 2, 2, 2), { kind: "select", selection: 2 });
+    assert.deepEqual(parseSelectionInput("q", 2, 1, 2), { kind: "cancel" });
   });
 });

--- a/tests/jump-anchor.test.mjs
+++ b/tests/jump-anchor.test.mjs
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { mkdir, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import {
+  clearJumpAnchor,
+  loadJumpAnchor,
+  saveJumpAnchor,
+  saveJumpAnchorIfMissing,
+} from "../dist/tmux/jump-anchor.js";
+
+describe("jump anchor", () => {
+  it("saves and loads an anchor by client tty", async () => {
+    const dir = await mkdir(join(tmpdir(), `marmonitor-anchor-test-${Date.now()}`), {
+      recursive: true,
+    });
+    const anchorPath = join(dir, "jump-anchors.json");
+    try {
+      await saveJumpAnchor(anchorPath, "/dev/ttys001", {
+        session: "main",
+        window: "0",
+        pane: "main:0.1",
+      });
+      const anchor = await loadJumpAnchor(anchorPath, "/dev/ttys001");
+      assert.ok(anchor);
+      assert.equal(anchor.session, "main");
+      assert.equal(anchor.window, "0");
+      assert.equal(anchor.pane, "main:0.1");
+      assert.ok(anchor.savedAt > 0);
+    } finally {
+      await rm(dir, { recursive: true });
+    }
+  });
+
+  it("returns undefined when no anchor exists for client", async () => {
+    const dir = await mkdir(join(tmpdir(), `marmonitor-anchor-test-${Date.now()}`), {
+      recursive: true,
+    });
+    const anchorPath = join(dir, "jump-anchors.json");
+    try {
+      await saveJumpAnchor(anchorPath, "/dev/ttys001", {
+        session: "main",
+        window: "0",
+        pane: "main:0.1",
+      });
+      const anchor = await loadJumpAnchor(anchorPath, "/dev/ttys999");
+      assert.equal(anchor, undefined);
+    } finally {
+      await rm(dir, { recursive: true });
+    }
+  });
+
+  it("returns undefined when anchor file does not exist", async () => {
+    const anchor = await loadJumpAnchor("/tmp/nonexistent-anchors-12345.json", "/dev/ttys001");
+    assert.equal(anchor, undefined);
+  });
+
+  it("overwrites previous anchor for same client", async () => {
+    const dir = await mkdir(join(tmpdir(), `marmonitor-anchor-test-${Date.now()}`), {
+      recursive: true,
+    });
+    const anchorPath = join(dir, "jump-anchors.json");
+    try {
+      await saveJumpAnchor(anchorPath, "/dev/ttys001", {
+        session: "main",
+        window: "0",
+        pane: "main:0.1",
+      });
+      await saveJumpAnchor(anchorPath, "/dev/ttys001", {
+        session: "work",
+        window: "2",
+        pane: "work:2.0",
+      });
+      const anchor = await loadJumpAnchor(anchorPath, "/dev/ttys001");
+      assert.ok(anchor);
+      assert.equal(anchor.session, "work");
+      assert.equal(anchor.pane, "work:2.0");
+    } finally {
+      await rm(dir, { recursive: true });
+    }
+  });
+
+  it("preserves the first anchor when save-if-missing is used repeatedly", async () => {
+    const dir = await mkdir(join(tmpdir(), `marmonitor-anchor-test-${Date.now()}`), {
+      recursive: true,
+    });
+    const anchorPath = join(dir, "jump-anchors.json");
+    try {
+      const firstSaved = await saveJumpAnchorIfMissing(anchorPath, "/dev/ttys001", {
+        session: "main",
+        window: "0",
+        pane: "main:0.1",
+      });
+      const secondSaved = await saveJumpAnchorIfMissing(anchorPath, "/dev/ttys001", {
+        session: "work",
+        window: "2",
+        pane: "work:2.0",
+      });
+      const anchor = await loadJumpAnchor(anchorPath, "/dev/ttys001");
+      assert.equal(firstSaved, true);
+      assert.equal(secondSaved, false);
+      assert.ok(anchor);
+      assert.equal(anchor.session, "main");
+      assert.equal(anchor.pane, "main:0.1");
+    } finally {
+      await rm(dir, { recursive: true });
+    }
+  });
+
+  it("clears the anchor after jump-back success path cleanup", async () => {
+    const dir = await mkdir(join(tmpdir(), `marmonitor-anchor-test-${Date.now()}`), {
+      recursive: true,
+    });
+    const anchorPath = join(dir, "jump-anchors.json");
+    try {
+      await saveJumpAnchor(anchorPath, "/dev/ttys001", {
+        session: "main",
+        window: "0",
+        pane: "main:0.1",
+      });
+      const removed = await clearJumpAnchor(anchorPath, "/dev/ttys001");
+      const anchor = await loadJumpAnchor(anchorPath, "/dev/ttys001");
+      assert.equal(removed, true);
+      assert.equal(anchor, undefined);
+    } finally {
+      await rm(dir, { recursive: true });
+    }
+  });
+});

--- a/tests/status-click.test.mjs
+++ b/tests/status-click.test.mjs
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { buildTmuxAttentionPills, buildTmuxBadgeBar } from "../dist/output/utils.js";
+import { findClickedAgent, parseStatusClickToken } from "../dist/tmux/status-click.js";
+
+describe("status click parsing", () => {
+  it("parses pid click tokens", () => {
+    assert.deepEqual(parseStatusClickToken("pid:123"), { kind: "jump", pid: 123 });
+  });
+
+  it("parses jump-back click tokens", () => {
+    assert.deepEqual(parseStatusClickToken("jump-back"), { kind: "jump-back" });
+  });
+
+  it("returns undefined for unsupported tokens", () => {
+    assert.equal(parseStatusClickToken(undefined), undefined);
+    assert.equal(parseStatusClickToken(""), undefined);
+    assert.equal(parseStatusClickToken("focus"), undefined);
+  });
+
+  it("finds the clicked agent by pid", () => {
+    const agents = [
+      { pid: 11, cwd: "/tmp/a" },
+      { pid: 22, cwd: "/tmp/b" },
+    ];
+
+    const found = findClickedAgent(agents, { kind: "jump", pid: 22 });
+    assert.equal(found?.pid, 22);
+  });
+});
+
+describe("tmux statusline click ranges", () => {
+  it("wraps attention pills in tmux user ranges", () => {
+    const text = buildTmuxAttentionPills(
+      [
+        {
+          kind: "permission",
+          priority: 1,
+          pid: 30,
+          agentName: "Claude Code",
+          cwd: "/Users/macrent/.ai/projects/mjjo",
+          status: "Active",
+          phase: "permission",
+        },
+      ],
+      5,
+    );
+
+    assert.match(text, /#\[range=user\|pid:30\]/);
+    assert.match(text, /#\[norange\]/);
+  });
+
+  it("wraps jump-back indicator in a tmux user range", () => {
+    const text = buildTmuxBadgeBar(
+      {
+        aliveCount: 1,
+        waitingCount: 0,
+        riskCount: 0,
+        stalledCount: 0,
+        unmatchedCount: 0,
+        activeCount: 1,
+        highCpuCount: 0,
+      },
+      undefined,
+      "basic",
+      true,
+    );
+
+    assert.match(text, /#\[range=user\|jump-back\]/);
+    assert.match(text, /↩/);
+  });
+});

--- a/tests/utils.test.mjs
+++ b/tests/utils.test.mjs
@@ -622,6 +622,66 @@ describe("buildStatuslineSummary", () => {
     assert.match(text, /#\[fg=/);
   });
 
+  it("renders text badge style with fg color only", () => {
+    const snapshot = {
+      aliveCount: 3,
+      waitingCount: 0,
+      riskCount: 0,
+      stalledCount: 0,
+      unmatchedCount: 0,
+      activeCount: 2,
+      highCpuCount: 0,
+      thinkingCount: 0,
+      toolCount: 0,
+      claudeCount: 3,
+      codexCount: 0,
+      geminiCount: 0,
+    };
+    const text = buildTmuxBadgeBar(snapshot, undefined, "text");
+    assert.match(text, /Cl 3/);
+    assert.match(text, /#\[fg=/);
+  });
+
+  it("renders text-mono badge style in grayscale", () => {
+    const snapshot = {
+      aliveCount: 2,
+      waitingCount: 1,
+      riskCount: 0,
+      stalledCount: 0,
+      unmatchedCount: 0,
+      activeCount: 1,
+      highCpuCount: 0,
+      thinkingCount: 0,
+      toolCount: 0,
+      claudeCount: 2,
+      codexCount: 0,
+      geminiCount: 0,
+    };
+    const text = buildTmuxBadgeBar(snapshot, undefined, "text-mono");
+    assert.match(text, /Cl 2/);
+    assert.match(text, /#cdd6f4/);
+  });
+
+  it("defaults to basic style when badgeStyle not specified", () => {
+    const snapshot = {
+      aliveCount: 1,
+      waitingCount: 0,
+      riskCount: 0,
+      stalledCount: 0,
+      unmatchedCount: 0,
+      activeCount: 1,
+      highCpuCount: 0,
+      thinkingCount: 0,
+      toolCount: 0,
+      claudeCount: 1,
+      codexCount: 0,
+      geminiCount: 0,
+    };
+    const withoutStyle = buildTmuxBadgeBar(snapshot);
+    const withBasic = buildTmuxBadgeBar(snapshot, undefined, "basic");
+    assert.equal(withoutStyle, withBasic);
+  });
+
   it("builds shared status pills for terminal adapters", () => {
     const { agents, alerts } = buildStatusPills({
       aliveCount: 16,

--- a/tests/utils.test.mjs
+++ b/tests/utils.test.mjs
@@ -736,11 +736,19 @@ describe("buildStatuslineSummary", () => {
 });
 
 describe("buildAttentionItems", () => {
-  it("selects only attention-worthy agents in priority order", () => {
+  it("selects fresh permission/thinking/tool items before recent active sessions", () => {
+    const now = 5_000;
     const agents = [
       { pid: 10, agentName: "Claude Code", cwd: "/repo/a", status: "Idle", lastActivityAt: 3000 },
       { pid: 20, agentName: "Codex", cwd: "/repo/b", status: "Unmatched", runtimeSource: "vscode" },
-      { pid: 30, agentName: "Claude Code", cwd: "/repo/c", status: "Active", phase: "permission" },
+      {
+        pid: 30,
+        agentName: "Claude Code",
+        cwd: "/repo/c",
+        status: "Active",
+        phase: "permission",
+        lastActivityAt: 2500,
+      },
       { pid: 40, agentName: "Claude Code", cwd: "/repo/d", status: "Stalled" },
       {
         pid: 50,
@@ -748,7 +756,7 @@ describe("buildAttentionItems", () => {
         cwd: "/repo/e",
         status: "Active",
         phase: "thinking",
-        lastActivityAt: 2000,
+        lastActivityAt: 4_500,
       },
       {
         pid: 60,
@@ -756,22 +764,23 @@ describe("buildAttentionItems", () => {
         cwd: "/repo/f",
         status: "Active",
         phase: "tool",
-        lastActivityAt: 1000,
+        lastActivityAt: 4500,
       },
     ];
 
     assert.deepEqual(
-      buildAttentionItems(agents).map((item) => [item.kind, item.pid]),
+      buildAttentionItems(agents, now).map((item) => [item.kind, item.pid]),
       [
         ["permission", 30],
         ["thinking", 50],
-        ["active", 10],
         ["tool", 60],
+        ["active", 10],
       ],
     );
   });
 
   it("sorts same-priority items by newest activity first", () => {
+    const now = 5_000;
     const agents = [
       {
         pid: 100,
@@ -792,8 +801,64 @@ describe("buildAttentionItems", () => {
     ];
 
     assert.deepEqual(
-      buildAttentionItems(agents).map((item) => item.pid),
+      buildAttentionItems(agents, now).map((item) => item.pid),
       [200, 100],
+    );
+  });
+
+  it("demotes stale thinking/tool items below more recent active sessions", () => {
+    const now = 5_000;
+    const agents = [
+      {
+        pid: 10,
+        agentName: "Claude Code",
+        cwd: "/repo/thinking",
+        status: "Active",
+        phase: "thinking",
+        lastActivityAt: 4_500,
+      },
+      {
+        pid: 20,
+        agentName: "Codex",
+        cwd: "/repo/tool",
+        status: "Active",
+        phase: "tool",
+        lastActivityAt: 4_450,
+      },
+      {
+        pid: 30,
+        agentName: "Claude Code",
+        cwd: "/repo/stale-thinking",
+        status: "Active",
+        phase: "thinking",
+        lastActivityAt: 4_399,
+      },
+      {
+        pid: 40,
+        agentName: "Codex",
+        cwd: "/repo/stale-tool",
+        status: "Active",
+        phase: "tool",
+        lastActivityAt: 4_200,
+      },
+      {
+        pid: 50,
+        agentName: "Claude Code",
+        cwd: "/repo/active",
+        status: "Idle",
+        lastActivityAt: 4_500,
+      },
+    ];
+
+    assert.deepEqual(
+      buildAttentionItems(agents, now).map((item) => [item.kind, item.pid]),
+      [
+        ["thinking", 10],
+        ["tool", 20],
+        ["active", 50],
+        ["thinking", 30],
+        ["tool", 40],
+      ],
     );
   });
 
@@ -810,6 +875,7 @@ describe("buildAttentionItems", () => {
   });
 
   it("builds jump attention items with permission/thinking first, then recent alive sessions", () => {
+    const now = 5_000;
     const agents = [
       { pid: 20, agentName: "Codex", cwd: "/repo/b", status: "Unmatched" },
       {
@@ -826,7 +892,7 @@ describe("buildAttentionItems", () => {
         cwd: "/repo/t",
         status: "Active",
         phase: "thinking",
-        lastActivityAt: 2000,
+        lastActivityAt: 4_400,
       },
       { pid: 40, agentName: "Codex", cwd: "/repo/d", status: "Stalled" },
       {
@@ -835,18 +901,18 @@ describe("buildAttentionItems", () => {
         cwd: "/repo/e",
         status: "Active",
         phase: "tool",
-        lastActivityAt: 1500,
+        lastActivityAt: 4_500,
       },
       { pid: 60, agentName: "Claude Code", cwd: "/repo/f", status: "Idle", lastActivityAt: 2500 },
     ];
 
     assert.deepEqual(
-      buildJumpAttentionItems(agents).map((item) => [item.kind, item.pid]),
+      buildJumpAttentionItems(agents, now).map((item) => [item.kind, item.pid]),
       [
         ["permission", 30],
         ["thinking", 35],
-        ["active", 60],
         ["tool", 50],
+        ["active", 60],
       ],
     );
   });
@@ -941,7 +1007,7 @@ describe("buildAttentionItems", () => {
       [
         {
           kind: "permission",
-          priority: 1,
+          priority: 0,
           pid: 30,
           agentName: "Claude Code",
           cwd: "/Users/macrent/.ai/projects/mjjo",
@@ -1011,7 +1077,7 @@ describe("buildAttentionItems", () => {
       [
         {
           kind: "permission",
-          priority: 1,
+          priority: 0,
           pid: 30,
           agentName: "Claude Code",
           cwd: "/Users/macrent/.ai/projects/mjjo",
@@ -1087,7 +1153,7 @@ describe("buildAttentionItems", () => {
       [
         {
           kind: "permission",
-          priority: 1,
+          priority: 0,
           pid: 30,
           agentName: "Claude Code",
           cwd: "/Users/macrent/.ai/projects/mjjo",


### PR DESCRIPTION
## Summary

Resolve #11

Improve tmux UX across statusline and popup flows:

- add badge theme variants (`basic`, `basic-mono`, `text`, `text-mono`)
- add jump-back support with anchor preservation across chained jumps
- add paginated tmux jump popup with arrow-key navigation
- add clickable statusline attention pills and clickable jump-back indicator
- add stale attention aging so old `thinking/tool` sessions fall below more recent active sessions

<details>
<summary>Korean</summary>

tmux statusline과 popup UX를 전반적으로 개선했습니다.

- badge 스타일 4종(`basic`, `basic-mono`, `text`, `text-mono`) 추가
- jump-back 기능 추가 및 연속 점프 시 최초 출발 위치 유지
- jump popup 페이지네이션 추가
- statusline attention pill / jump-back pill 클릭 인터랙션 추가
- 오래된 `thinking/tool` 세션이 attention 상단을 계속 점유하지 않도록 stale aging 추가

</details>

## Type

- [x] `[FEAT]` New feature
- [ ] `[BUG]` Bug fix
- [ ] `[HOTFIX]` Urgent fix
- [ ] `[PERF]` Performance improvement
- [ ] `[REFACTOR]` Code restructuring
- [ ] `[DOCS]` Documentation
- [ ] `[TEST]` Test coverage
- [ ] `[CICD]` CI/CD or release
- [ ] `[CHORE]` Maintenance

## Changes

- add theme-based badge renderer for tmux statusline and terminal outputs
- expose `integration.tmux.badgeStyle` in config and config samples
- add jump-back command and anchor lifecycle
- preserve the initial origin during chained `jump --attention-index` flows
- add jump popup pagination with `< page/total >`, `←/→`, `1-9`, `0`, `q`
- add `status-click` routing for clickable attention pills and jump-back pill
- add stale attention aging so only recent `thinking/tool` stay in the hot bucket
- add tests for badge rendering, pagination, jump-back anchor behavior, click routing, and stale attention ordering

<details>
<summary>Korean</summary>

- tmux statusline과 터미널 출력에 공통 badge theme renderer 적용
- `integration.tmux.badgeStyle` 설정 추가 및 설정 샘플 반영
- jump-back 명령과 anchor 저장/정리 흐름 추가
- `jump --attention-index` 연속 실행 시 마지막 위치가 아니라 최초 출발 위치로 복귀하도록 수정
- jump popup에 `< 현재/전체 페이지 >`, `←/→`, `1-9`, `0`, `q` 입력 모델 추가
- clickable attention pill / jump-back pill을 위한 `status-click` 라우팅 추가
- 최근 활동이 없는 `thinking/tool` 세션은 recent active 아래로 내려가도록 attention 정렬 보정
- badge 스타일, 페이지네이션, jump-back, click interaction, stale aging 관련 테스트 추가

</details>

## Checklist

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (all tests green)
- [x] New features have tests
- [x] README updated (if user-facing changes)
- [x] No hardcoded paths or environment-specific values

## Testing

- `npm run build`
- `npm run lint`
- `npm test`
- manually verified tmux jump popup pagination
- manually verified jump-back via keybinding and clickable `↩` pill
- manually verified clickable attention pills in tmux statusline

<details>
<summary>Korean</summary>

- `npm run build`
- `npm run lint`
- `npm test`
- tmux jump popup 페이지네이션 수동 확인
- keybinding 및 clickable `↩` pill 기반 jump-back 수동 확인
- tmux statusline attention pill 클릭 이동 수동 확인

</details>

## Risk

Medium

This PR changes tmux-facing navigation UX and statusline interaction paths. The main risks are terminal/tmux differences in mouse and meta-key behavior.

<details>
<summary>Korean</summary>

tmux 상태바와 이동 UX 경로를 직접 건드리는 변경이라, 터미널/tmux 환경별로 마우스 처리나 Meta 키 입력 차이가 있을 수 있습니다.

</details>
