### PR TITLE
[BUG] #12 Fix Codex session indexing — switch to SQLite-based discovery

### DIFF
--- a/src/scanner/codex-sqlite.ts
+++ b/src/scanner/codex-sqlite.ts
@@ -1,0 +1,56 @@
+/**
+ * Codex session indexing via SQLite threads table.
+ * Uses sqlite3 CLI (pre-installed on macOS/Linux) — no npm dependency.
+ * Falls back gracefully if sqlite3 is unavailable or DB is missing.
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { CodexSessionMeta } from "./cache.js";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Query Codex state SQLite for active (non-archived) threads.
+ * Returns CodexSessionMeta[] compatible with existing matchCodexSession().
+ */
+export async function indexCodexSessionsFromSqlite(dbPath: string): Promise<CodexSessionMeta[]> {
+  try {
+    const { stdout } = await execFileAsync("sqlite3", [
+      dbPath,
+      "-separator",
+      "\t",
+      "SELECT id, cwd, rollout_path, tokens_used, model, updated_at, created_at FROM threads WHERE archived = 0 ORDER BY updated_at DESC;",
+    ]);
+
+    const lines = stdout.trim().split("\n").filter(Boolean);
+    const sessions: CodexSessionMeta[] = [];
+
+    for (const line of lines) {
+      const [id, cwd, rolloutPath, tokensUsed, model, updatedAt, createdAt] = line.split("\t");
+      if (!id || !cwd) continue;
+
+      sessions.push({
+        filePath: rolloutPath ?? "",
+        id,
+        cwd,
+        timestamp: Number(createdAt) || 0,
+        lastActivityAt: Number(updatedAt) || undefined,
+        totalTokenUsage: tokensUsed
+          ? {
+              input_tokens: 0,
+              cached_input_tokens: 0,
+              output_tokens: 0,
+              total_tokens: Number(tokensUsed) || 0,
+            }
+          : undefined,
+        model: model || undefined,
+      });
+    }
+
+    return sessions;
+  } catch {
+    // sqlite3 not available, DB missing, or query failed — return empty
+    return [];
+  }
+}

--- a/src/scanner/codex.ts
+++ b/src/scanner/codex.ts
@@ -2,9 +2,11 @@
  * Codex session parsing, indexing, and phase detection.
  */
 
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import { open, readFile, readdir, stat } from "node:fs/promises";
+import { homedir } from "node:os";
 import { join } from "node:path";
+import { indexCodexSessionsFromSqlite } from "./codex-sqlite.js";
 
 import type { MarmonitorConfig } from "../config/index.js";
 import { resolveRuntimeDataPaths } from "../config/index.js";
@@ -138,12 +140,50 @@ export async function detectCodexPhase(
   }
 }
 
-/** Build index of recent Codex sessions (last 7 days) */
+/** Find the latest Codex state SQLite DB path */
+function findCodexStateDb(): string | undefined {
+  const codexDir = join(homedir(), ".codex");
+  try {
+    const files = readdirSync(codexDir)
+      .filter((f) => f.startsWith("state_") && f.endsWith(".sqlite"))
+      .sort()
+      .reverse();
+    return files.length > 0 ? join(codexDir, files[0]) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Build index of Codex sessions (SQLite primary, JSONL fallback) */
 export async function indexCodexSessions(config?: MarmonitorConfig): Promise<CodexSessionMeta[]> {
   if (codexIndexCache && Date.now() - codexIndexCache.builtAt < CODEX_INDEX_TTL_MS) {
     return codexIndexCache.sessions;
   }
 
+  // Primary: SQLite threads table
+  const dbPath = findCodexStateDb();
+  if (dbPath) {
+    const sqliteSessions = await indexCodexSessionsFromSqlite(dbPath);
+    if (sqliteSessions.length > 0) {
+      // Register sessions for phase detection and cwd lookup
+      for (const s of sqliteSessions) {
+        codexSessionFileCache.set(s.filePath, { ...s, mtimeMs: undefined, size: undefined });
+        upsertSessionRegistryEntry(codexSessionRegistry, {
+          filePath: s.filePath,
+          sessionId: s.id,
+          cwd: s.cwd,
+          firstSeenOffset: 0,
+          startedAt: s.timestamp,
+          model: s.model,
+          source: "codex",
+        });
+      }
+      setCodexIndexCache({ builtAt: Date.now(), sessions: sqliteSessions });
+      return sqliteSessions;
+    }
+  }
+
+  // Fallback: JSONL directory scan (last 7 days)
   const sessionRoots = getCodexSessionRoots(config);
   if (!sessionRoots.some((sessionsDir) => existsSync(sessionsDir))) return [];
 

--- a/tests/codex-sqlite.test.mjs
+++ b/tests/codex-sqlite.test.mjs
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import { execSync } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { indexCodexSessionsFromSqlite } from "../dist/scanner/codex-sqlite.js";
+
+describe("codex sqlite indexing", () => {
+  it("indexes active threads from sqlite", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "marmonitor-codex-sqlite-"));
+    const dbPath = join(dir, "state.sqlite");
+    const jsonlPath = join(dir, "rollout.jsonl");
+    try {
+      // Create a minimal SQLite DB with threads table
+      execSync(`sqlite3 "${dbPath}" "
+        CREATE TABLE threads (
+          id TEXT PRIMARY KEY,
+          rollout_path TEXT NOT NULL,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL,
+          source TEXT NOT NULL DEFAULT 'cli',
+          model_provider TEXT NOT NULL DEFAULT 'openai',
+          cwd TEXT NOT NULL,
+          title TEXT NOT NULL DEFAULT '',
+          sandbox_policy TEXT NOT NULL DEFAULT '{}',
+          approval_mode TEXT NOT NULL DEFAULT 'on-request',
+          tokens_used INTEGER NOT NULL DEFAULT 0,
+          archived INTEGER NOT NULL DEFAULT 0,
+          model TEXT,
+          cli_version TEXT NOT NULL DEFAULT ''
+        );
+        INSERT INTO threads (id, rollout_path, created_at, updated_at, cwd, tokens_used, archived, model)
+        VALUES ('test-session-1', '${jsonlPath}', 1774000000, 1775000000, '/projects/test', 12345, 0, 'gpt-5.4');
+        INSERT INTO threads (id, rollout_path, created_at, updated_at, cwd, tokens_used, archived, model)
+        VALUES ('test-session-2', '/nonexistent.jsonl', 1774000000, 1774500000, '/projects/other', 999, 1, 'gpt-5.4');
+      "`);
+
+      // Create a dummy JSONL file
+      await writeFile(jsonlPath, '{"type":"session_meta"}\n', "utf-8");
+
+      const sessions = await indexCodexSessionsFromSqlite(dbPath);
+
+      // Should only return non-archived sessions
+      assert.equal(sessions.length, 1);
+      assert.equal(sessions[0].id, "test-session-1");
+      assert.equal(sessions[0].cwd, "/projects/test");
+      assert.equal(sessions[0].filePath, jsonlPath);
+      assert.equal(sessions[0].model, "gpt-5.4");
+      assert.ok(sessions[0].timestamp > 0);
+      assert.ok(sessions[0].lastActivityAt > 0);
+    } finally {
+      await rm(dir, { recursive: true });
+    }
+  });
+
+  it("returns empty array when sqlite3 is not available or DB missing", async () => {
+    const sessions = await indexCodexSessionsFromSqlite("/nonexistent/path/state.sqlite");
+    assert.equal(sessions.length, 0);
+  });
+
+  it("includes tokens_used as totalTokenUsage", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "marmonitor-codex-sqlite-"));
+    const dbPath = join(dir, "state.sqlite");
+    try {
+      execSync(`sqlite3 "${dbPath}" "
+        CREATE TABLE threads (
+          id TEXT PRIMARY KEY,
+          rollout_path TEXT NOT NULL,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL,
+          source TEXT NOT NULL DEFAULT 'cli',
+          model_provider TEXT NOT NULL DEFAULT 'openai',
+          cwd TEXT NOT NULL,
+          title TEXT NOT NULL DEFAULT '',
+          sandbox_policy TEXT NOT NULL DEFAULT '{}',
+          approval_mode TEXT NOT NULL DEFAULT 'on-request',
+          tokens_used INTEGER NOT NULL DEFAULT 0,
+          archived INTEGER NOT NULL DEFAULT 0,
+          model TEXT,
+          cli_version TEXT NOT NULL DEFAULT ''
+        );
+        INSERT INTO threads (id, rollout_path, created_at, updated_at, cwd, tokens_used, archived, model)
+        VALUES ('tok-test', '/tmp/rollout.jsonl', 1774000000, 1775000000, '/test', 500000, 0, 'gpt-5.4');
+      "`);
+
+      const sessions = await indexCodexSessionsFromSqlite(dbPath);
+      assert.equal(sessions.length, 1);
+      assert.ok(sessions[0].totalTokenUsage);
+      assert.equal(sessions[0].totalTokenUsage.total_tokens, 500000);
+    } finally {
+      await rm(dir, { recursive: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Resolve #12

Codex CLI 0.117+ reuses sessions for weeks. JSONL files reside in date-based directories (`sessions/YYYY/MM/DD/`) based on creation date, but `indexCodexSessions()` only scans the last 7 days → active sessions become Unmatched.

Switched to SQLite `threads` table as primary index source with JSONL fallback.

## Type

- [x] `[BUG]` Bug fix

## Changes

- `src/scanner/codex-sqlite.ts` (new): Query `~/.codex/state_*.sqlite` `threads` table via sqlite3 CLI. Zero npm dependencies.
- `src/scanner/codex.ts`: SQLite-first → JSONL fallback in `indexCodexSessions()`
- `tests/codex-sqlite.test.mjs`: 3 tests for SQLite indexing

**Hybrid architecture:**
- SQLite = session discovery + path resolution + token totals
- JSONL = phase detection + detailed token breakdown (input/output/cache)

## Before / After

| | Before | After |
|---|---|---|
| Indexed sessions | 2/49 (7-day window) | **49/49** (all active) |
| mjjo Codex match | ❌ Unmatched | ✅ Matched |
| Index method | Directory scan + JSONL parse (~20ms) | SQLite query (~6ms) |
| Fallback | — | JSONL scan (if sqlite3 unavailable) |

## Checklist

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] New features have tests (3 tests)
- [ ] README updated (if user-facing changes)
- [x] No hardcoded paths or environment-specific values

## Testing

```bash
# SQLite indexing
node -e "(async()=>{const {indexCodexSessions}=await import('./dist/scanner/codex.js');const s=await indexCodexSessions();console.log('Sessions:',s.length);})()"
# → Sessions: 49 (was: 2)

# Status check
marmonitor status  # Codex sessions now matched instead of Unmatched
```

## Risk

Low — Falls back to existing JSONL directory scan if sqlite3 CLI is unavailable or DB is missing/locked. No impact on existing behavior.

<details>
<summary><h2>🇰🇷 한국어 버전</h2></summary>

## 개요

Resolve #12

Codex CLI 0.117+에서 세션을 장기 재사용하면 JSONL 파일이 7일 이상 된 디렉토리에 위치하여 인덱스에서 누락 → Unmatched. SQLite `threads` 테이블 기반 인덱싱으로 전환하여 모든 활성 세션을 추적.

## 변경사항

- `src/scanner/codex-sqlite.ts` (신규): sqlite3 CLI로 threads 쿼리. npm 의존성 없음
- `src/scanner/codex.ts`: SQLite 우선 → JSONL fallback
- `tests/codex-sqlite.test.mjs`: 테스트 3개

**Hybrid 구조:** SQLite = 세션 발견/경로/토큰 총량, JSONL = phase 감지/토큰 상세

## 위험도

Low — sqlite3 실패 시 기존 JSONL 스캔으로 자동 fallback.

</details>