### PR TITLE
[FEAT] #14 Add tmux integration sync inspection and guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ marmonitor setup tmux
 
 This adds the [marmonitor-tmux](https://github.com/mjjo16/marmonitor-tmux) plugin to your `~/.tmux.conf`. Then press `prefix + I` inside tmux to activate.
 
+After upgrading `marmonitor`, run:
+
+```bash
+marmonitor update-integration
+```
+
+This checks whether your tmux integration also needs a TPM/plugin update.
+
 <details>
 <summary>Or add manually to ~/.tmux.conf</summary>
 

--- a/bin/postinstall.cjs
+++ b/bin/postinstall.cjs
@@ -11,6 +11,7 @@
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
+const { execFileSync } = require("child_process");
 
 // Restart daemon if it was running (picks up new version)
 const pidPath = path.join(os.tmpdir(), "marmonitor", "daemon.pid");
@@ -26,21 +27,26 @@ try {
 }
 
 if (daemonWasRunning) {
-  // Brief delay then start new daemon
-  setTimeout(() => {
-    try {
-      const { fork } = require("child_process");
-      const daemonScript = path.join(__dirname, "..", "dist", "scanner", "daemon-entry.js");
-      // Only restart if the compiled entry exists (dist may not exist in dev)
-      if (fs.existsSync(daemonScript)) {
-        const child = fork(path.join(__dirname, "daemon.js"), [], { detached: true, stdio: "ignore" });
-        child.unref();
-        process.stderr.write(`  marmonitor: daemon restarted (PID: ${child.pid})\n`);
-      }
-    } catch {
-      process.stderr.write("  marmonitor: daemon restart failed — run: marmonitor start\n");
+  try {
+    const { fork } = require("child_process");
+    const daemonScript = path.join(__dirname, "..", "dist", "scanner", "daemon-entry.js");
+    // Only restart if the compiled entry exists (dist may not exist in dev)
+    if (fs.existsSync(daemonScript)) {
+      const child = fork(path.join(__dirname, "daemon.js"), [], { detached: true, stdio: "ignore" });
+      child.unref();
+      process.stderr.write(`  marmonitor: daemon restarted (PID: ${child.pid})\n`);
     }
-  }, 500);
+  } catch {
+    process.stderr.write("  marmonitor: daemon restart failed — run: marmonitor start\n");
+  }
+}
+
+try {
+  execFileSync(process.execPath, [path.join(__dirname, "marmonitor.js"), "update-integration", "--quiet"], {
+    stdio: "ignore",
+  });
+} catch {
+  // best-effort only — npm install should not fail if tmux/plugin state cannot be checked
 }
 
 const msg = `
@@ -51,6 +57,8 @@ const msg = `
     $ marmonitor start            Start background daemon
     $ marmonitor setup tmux       Add tmux plugin to ~/.tmux.conf
     Then press prefix+I in tmux to activate.
+    $ marmonitor update-integration
+                                Check whether the tmux plugin also needs sync
 
   Commands:
     $ marmonitor status           Show all AI sessions
@@ -64,3 +72,4 @@ const msg = `
 `;
 
 process.stderr.write(msg + "\n");
+process.exit(0);

--- a/src/banner/index.ts
+++ b/src/banner/index.ts
@@ -221,6 +221,8 @@ export function renderInstallInfo(): string {
     "Setup:",
     "  $ marmonitor setup tmux    - Add tmux plugin to ~/.tmux.conf",
     "  Then press prefix+I in tmux to activate.",
+    "  $ marmonitor update-integration",
+    "                           - Check whether the tmux plugin also needs sync",
     "",
     "Commands:",
     "  $ marmonitor status        - Show active AI sessions",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1100,6 +1100,58 @@ program
   });
 
 program
+  .command("update-integration")
+  .description("Check how to sync the installed tmux integration")
+  .option("--quiet", "Suppress non-essential output")
+  .action(async (opts: { quiet?: boolean }) => {
+    const { detectTmuxIntegrationMode, getMarmonitorPluginDir } = await import("./tmux/setup.js");
+    const { homedir } = await import("node:os");
+    const { join } = await import("node:path");
+    const confPath = join(homedir(), ".tmux.conf");
+    const pluginDir = getMarmonitorPluginDir();
+    const mode = await detectTmuxIntegrationMode(confPath, pluginDir);
+
+    if (mode === "local") {
+      if (!opts.quiet) {
+        console.log("Local marmonitor-tmux run-shell detected.");
+        console.log("Your local repo changes are already active after tmux reload.");
+      }
+      return;
+    }
+
+    if (!mode) {
+      if (!opts.quiet) {
+        console.log("tmux integration is not configured. Run: marmonitor setup tmux");
+      }
+      return;
+    }
+
+    if (mode === "missing") {
+      if (!opts.quiet) {
+        console.log("tmux integration is configured, but marmonitor-tmux is not installed yet.");
+        console.log("Press prefix+I in tmux to install the plugin.");
+      }
+      return;
+    }
+
+    if (mode === "not_git") {
+      if (!opts.quiet) {
+        console.log("marmonitor-tmux exists but is not a git checkout.");
+        console.log(`Reinstall the plugin or update it manually: ${pluginDir}`);
+      }
+      return;
+    }
+
+    if (!opts.quiet) {
+      console.log("marmonitor-tmux TPM plugin detected.");
+      console.log("Update path:");
+      console.log("  1. Press prefix+U in tmux");
+      console.log(`  2. Or run: git -C ${pluginDir} pull --ff-only`);
+      console.log("  3. Reload tmux if keybindings or popup sizing changed");
+    }
+  });
+
+program
   .command("uninstall-integration")
   .description("Remove marmonitor settings from tmux.conf")
   .action(async () => {

--- a/src/scanner/codex.ts
+++ b/src/scanner/codex.ts
@@ -160,8 +160,10 @@ export async function indexCodexSessions(config?: MarmonitorConfig): Promise<Cod
     return codexIndexCache.sessions;
   }
 
+  const hasExplicitSessionRoots = Boolean(config?.paths.codexSessions?.length);
+
   // Primary: SQLite threads table
-  const dbPath = findCodexStateDb();
+  const dbPath = hasExplicitSessionRoots ? undefined : findCodexStateDb();
   if (dbPath) {
     const sqliteSessions = await indexCodexSessionsFromSqlite(dbPath);
     if (sqliteSessions.length > 0) {

--- a/src/tmux/setup.ts
+++ b/src/tmux/setup.ts
@@ -3,12 +3,58 @@
  * Adds/removes the marmonitor-tmux tpm plugin line.
  */
 
-import { readFile, writeFile } from "node:fs/promises";
+import { constants } from "node:fs";
+import { access, readFile, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
 const PLUGIN_LINE = "set -g @plugin 'mjjo16/marmonitor-tmux'";
 
+export type TmuxIntegrationMode = "local" | "tpm" | "missing" | "not_git";
+
 function matchesPluginLine(line: string): boolean {
   return line.trim() === PLUGIN_LINE;
+}
+
+export function getMarmonitorPluginDir(home: string = homedir()): string {
+  return join(home, ".tmux", "plugins", "marmonitor-tmux");
+}
+
+export async function hasInstalledMarmonitorPlugin(pluginDir: string): Promise<boolean> {
+  try {
+    await access(join(pluginDir, "marmonitor.tmux"), constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function detectTmuxIntegrationMode(
+  confPath: string,
+  pluginDir: string,
+): Promise<TmuxIntegrationMode | undefined> {
+  let content = "";
+  if (!(await hasInstalledMarmonitorPlugin(pluginDir))) {
+    try {
+      content = await readFile(confPath, "utf-8");
+    } catch {
+      return undefined;
+    }
+    if (content.includes("marmonitor-tmux/marmonitor.tmux")) {
+      return "local";
+    }
+    if (content.split("\n").some(matchesPluginLine)) {
+      return "missing";
+    }
+    return undefined;
+  }
+
+  try {
+    await access(join(pluginDir, ".git"), constants.F_OK);
+    return "tpm";
+  } catch {
+    return "not_git";
+  }
 }
 
 export async function hasMarmonitorPlugin(confPath: string): Promise<boolean> {

--- a/tests/banner.test.mjs
+++ b/tests/banner.test.mjs
@@ -21,6 +21,7 @@ describe("renderInstallInfo", () => {
     const text = renderInstallInfo();
     assert.match(text, /marmonitor v\d+\.\d+\.\d+/);
     assert.match(text, /marmonitor setup tmux/);
+    assert.match(text, /marmonitor update-integration/);
     assert.match(text, /marmonitor status/);
     assert.match(text, /uninstall-integration/);
     assert.match(text, /github\.com\/mjjo16\/marmonitor/);

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -49,6 +49,11 @@ describe("config CLI helpers", () => {
     assert.match(output, /debug-phase \[options\]/);
   });
 
+  it("includes update-integration in help output", () => {
+    const output = runCli(["--help"]);
+    assert.match(output, /update-integration/);
+  });
+
   it("includes phase icon legend in help output", () => {
     const output = runCli(["--help"]);
     assert.match(output, /permission/);
@@ -74,6 +79,7 @@ describe("postinstall/preuninstall scripts", () => {
     );
     assert.match(merged, /marmonitor.*installed/);
     assert.match(merged, /marmonitor setup tmux/);
+    assert.match(merged, /marmonitor update-integration/);
     assert.match(merged, /marmonitor status/);
     assert.match(merged, /uninstall-integration/);
   });

--- a/tests/scanner.test.mjs
+++ b/tests/scanner.test.mjs
@@ -263,4 +263,35 @@ describe("indexCodexSessions", () => {
     assert.ok(matched.lastActivityAt);
     assert.ok(Math.abs(matched.lastActivityAt - Date.now() / 1000) < 10);
   });
+
+  it("prefers explicit codex session roots over the global sqlite index", async () => {
+    const now = new Date();
+    const yyyy = now.getFullYear().toString();
+    const mm = String(now.getMonth() + 1).padStart(2, "0");
+    const dd = String(now.getDate()).padStart(2, "0");
+    const root = join(tmpdir(), `marmonitor-codex-explicit-${Date.now()}`);
+    const dayDir = join(root, yyyy, mm, dd);
+    await mkdir(dayDir, { recursive: true });
+    const filePath = join(dayDir, "explicit.jsonl");
+    await writeFile(
+      filePath,
+      JSON.stringify({
+        type: "session_meta",
+        payload: {
+          id: "codex-explicit",
+          cwd: "/tmp/explicit-project",
+          timestamp: new Date("2026-03-28T10:00:00.000Z").toISOString(),
+          model_provider: "gpt-5.4",
+        },
+      }),
+      "utf8",
+    );
+
+    setCodexIndexCache(undefined);
+    const config = getDefaults();
+    config.paths.codexSessions = [root];
+    const sessions = await indexCodexSessions(config);
+
+    assert.ok(sessions.some((item) => item.filePath === filePath));
+  });
 });

--- a/tests/tmux-setup.test.mjs
+++ b/tests/tmux-setup.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it } from "node:test";
@@ -8,6 +8,9 @@ import { describe, it } from "node:test";
 // Import will work after build.
 import {
   addMarmonitorPlugin,
+  detectTmuxIntegrationMode,
+  getMarmonitorPluginDir,
+  hasInstalledMarmonitorPlugin,
   hasMarmonitorPlugin,
   removeMarmonitorPlugin,
 } from "../dist/tmux/setup.js";
@@ -148,5 +151,66 @@ describe("removeMarmonitorPlugin", () => {
       assert.ok(!after.includes("marmonitor-tmux"));
       assert.ok(after.includes("set -g status on"));
     });
+  });
+});
+
+describe("tmux integration inspection", () => {
+  it("returns the default plugin directory under ~/.tmux/plugins", () => {
+    assert.equal(
+      getMarmonitorPluginDir("/Users/tester"),
+      "/Users/tester/.tmux/plugins/marmonitor-tmux",
+    );
+  });
+
+  it("detects a local run-shell integration", async () => {
+    await withTmpConf(
+      "run-shell ~/Documents/mjjo/marmonitor-tmux/marmonitor.tmux\n",
+      async (confPath) => {
+        const mode = await detectTmuxIntegrationMode(
+          confPath,
+          "/tmp/nonexistent-marmonitor-plugin",
+        );
+        assert.equal(mode, "local");
+      },
+    );
+  });
+
+  it("detects a configured-but-missing TPM plugin", async () => {
+    await withTmpConf("set -g @plugin 'mjjo16/marmonitor-tmux'\n", async (confPath) => {
+      const mode = await detectTmuxIntegrationMode(confPath, "/tmp/nonexistent-marmonitor-plugin");
+      assert.equal(mode, "missing");
+    });
+  });
+
+  it("detects a TPM checkout with git metadata", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "marmonitor-plugin-"));
+    const pluginDir = join(dir, "marmonitor-tmux");
+    await mkdir(pluginDir, { recursive: true });
+    await writeFile(join(dir, ".tmux.conf"), "set -g @plugin 'mjjo16/marmonitor-tmux'\n", "utf-8");
+    await writeFile(join(pluginDir, "marmonitor.tmux"), "#!/usr/bin/env bash\n", "utf-8");
+    try {
+      await writeFile(join(pluginDir, ".git"), "", "utf-8");
+      const confPath = join(dir, ".tmux.conf");
+      const mode = await detectTmuxIntegrationMode(confPath, pluginDir);
+      assert.equal(mode, "tpm");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("detects a non-git plugin directory", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "marmonitor-plugin-"));
+    const pluginDir = join(dir, "marmonitor-tmux");
+    const confPath = join(dir, ".tmux.conf");
+    await mkdir(pluginDir, { recursive: true });
+    await writeFile(confPath, "set -g @plugin 'mjjo16/marmonitor-tmux'\n", "utf-8");
+    await writeFile(join(pluginDir, "marmonitor.tmux"), "#!/usr/bin/env bash\n", "utf-8");
+    try {
+      const mode = await detectTmuxIntegrationMode(confPath, pluginDir);
+      assert.equal(mode, "not_git");
+      assert.equal(await hasInstalledMarmonitorPlugin(pluginDir), true);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

Resolve #14
Fix #12

Add a canonical `update-integration` path so users can tell whether their tmux integration also needs syncing after upgrading `marmonitor`.

- add `marmonitor update-integration`
- detect local run-shell vs TPM plugin vs missing/non-git install states
- update install banner, postinstall output, and README guidance
- fix Codex indexing so explicit `config.paths.codexSessions` overrides take precedence over the global SQLite index

<details>
<summary>Korean</summary>

`marmonitor` 업데이트 후 tmux integration도 같이 갱신이 필요한지 확인할 수 있도록 canonical 경로를 추가했습니다.

- `marmonitor update-integration` 추가
- local run-shell / TPM plugin / 미설치 / non-git 설치 상태 판별
- install banner, postinstall 출력, README 안내 갱신
- Codex 인덱싱에서 explicit `config.paths.codexSessions` override가 global SQLite index보다 우선하도록 수정

</details>

## Type

- [x] `[FEAT]` New feature
- [ ] `[BUG]` Bug fix
- [ ] `[HOTFIX]` Urgent fix
- [ ] `[PERF]` Performance improvement
- [ ] `[REFACTOR]` Code restructuring
- [ ] `[DOCS]` Documentation
- [ ] `[TEST]` Test coverage
- [ ] `[CICD]` CI/CD or release
- [ ] `[CHORE]` Maintenance

## Changes

- add tmux integration mode inspection helpers in `src/tmux/setup.ts`
- add `update-integration` command in `src/cli.ts`
- wire best-effort `update-integration --quiet` into `postinstall`
- update banner/README/install guidance to mention integration sync
- add tests for tmux integration inspection and install guidance output
- fix Codex explicit session root precedence over the global SQLite index

<details>
<summary>Korean</summary>

- `src/tmux/setup.ts`에 tmux integration 설치 형태 판별 helper 추가
- `src/cli.ts`에 `update-integration` 명령 추가
- `postinstall`에 `update-integration --quiet` best-effort 연결
- banner/README/install 안내에 integration sync 경로 추가
- tmux integration inspection / install 안내 출력 테스트 추가
- Codex explicit session root가 global SQLite index보다 우선하도록 수정

</details>

## Checklist

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (all tests green)
- [x] New features have tests
- [x] README updated (if user-facing changes)
- [x] No hardcoded paths or environment-specific values

## Testing

- `npm run build`
- `npm run lint`
- `npm test`
- `node --test tests/banner.test.mjs tests/cli.test.mjs tests/tmux-setup.test.mjs`
- `node --test tests/scanner.test.mjs tests/codex-sqlite.test.mjs`
- manually verified `node bin/marmonitor.js update-integration`

<details>
<summary>Korean</summary>

- `npm run build`
- `npm run lint`
- `npm test`
- `node --test tests/banner.test.mjs tests/cli.test.mjs tests/tmux-setup.test.mjs`
- `node --test tests/scanner.test.mjs tests/codex-sqlite.test.mjs`
- `node bin/marmonitor.js update-integration` 수동 확인

</details>

## Risk

Medium

This changes install/update guidance and tmux integration lifecycle UX. The main risk is user confusion if their plugin installation method is unusual or partially broken, but the command is intentionally advisory rather than destructive.

<details>
<summary>Korean</summary>

설치/업데이트 안내와 tmux integration lifecycle UX를 바꾸는 변경입니다. 설치 방식이 특이하거나 중간 상태인 사용자는 혼동이 있을 수 있지만, 명령은 파괴적 작업 대신 안내 중심으로만 동작하도록 설계했습니다.

</details>
