### PR TITLE
[CICD] Fix npm publish — switch to OIDC Trusted Publisher

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,6 +34,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     permissions:
       contents: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -58,14 +59,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Bump version and publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish to npm
         run: |
-          npm version patch --no-git-tag-version
           VERSION=$(node -p "require('./package.json').version")
-          git add package.json package-lock.json
-          git commit -m "chore: release v${VERSION}"
-          git tag "v${VERSION}"
-          git push origin main --tags
-          npm publish
+          git tag "v${VERSION}" || true
+          git push origin --tags || true
+          npm publish --provenance --access public

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,18 @@
 {
   "name": "marmonitor",
-  "version": "0.2.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "marmonitor",
-      "version": "0.2.1",
+      "version": "0.2.0",
+      "hasInstallScript": true,
       "license": "MIT",
+      "os": [
+        "darwin",
+        "linux"
+      ],
       "dependencies": {
         "chalk": "^5.3",
         "commander": "^12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marmonitor",
-  "version": "0.2.1",
+  "version": "0.2.0",
   "author": "MJ JO <mjjo16@gmail.com>",
   "description": "tmux status bar monitor for AI coding agents — track Claude Code, Codex, Gemini sessions, tokens, and phases in real time",
   "type": "module",


### PR DESCRIPTION
## Summary

Fix failed v0.2.0 publish (EOTP error). Switch from NPM_TOKEN to OIDC Trusted Publisher.

## Changes

- `publish.yml`: Add `id-token: write`, remove `NPM_TOKEN`, use `--provenance --access public`
- Remove automatic `npm version patch` (version managed manually)
- Revert 0.2.1 → 0.2.0 (0.2.1 was never published to npm)

## Risk

Low — only affects CI/CD pipeline.