### PR TITLE
[CICD] Fix npm publish — Upgrade Node 24

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,11 +42,14 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Use Node.js 20
+      - name: Use Node.js 24
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
+
+      - name: Check npm version
+        run: node -v && npm -v
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
npm trusted publishing은 Node 22.14.0+ / npm 11.5.1+ 필요. Node 20 → 24. npm 버전 확인 로그 추가.

<!-- PR title format: [TYPE] #{issue} description -->
<!-- Examples: [FEAT] #1 Add risk alert badges to statusline -->
<!--           [BUG] #5 Fix stalled permission excluded from attention -->
<!--           [HOTFIX] #8 Crash on startup with missing config -->

## Summary

<!-- What does this PR do? Link related issues with "Resolve #N" -->

Resolve #

## Type

- [ ] `[FEAT]` New feature
- [ ] `[BUG]` Bug fix
- [ ] `[HOTFIX]` Urgent fix
- [ ] `[PERF]` Performance improvement
- [ ] `[REFACTOR]` Code restructuring
- [ ] `[DOCS]` Documentation
- [ ] `[TEST]` Test coverage
- [x] `[CICD]` CI/CD or release
- [ ] `[CHORE]` Maintenance

## Changes

-

## Checklist

- [ ] `npm run build` passes
- [ ] `npm run lint` passes
- [ ] `npm test` passes (all tests green)
- [ ] New features have tests
- [ ] README updated (if user-facing changes)
- [ ] No hardcoded paths or environment-specific values

## Testing

<!-- How did you verify this works? Include commands or screenshots -->

## Risk

<!-- Low / Medium / High — what could break? -->
