### PR TITLE
[CICD] Release dev to main including tmux stale binding guidance

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -87,6 +87,20 @@ marmonitor setup tmux
 
 [marmonitor-tmux](https://github.com/mjjo16/marmonitor-tmux) 플러그인을 `~/.tmux.conf`에 추가합니다. tmux 안에서 `prefix + I`을 눌러 활성화하세요.
 
+`marmonitor`를 업그레이드한 뒤에는 다음 명령으로 tmux 연동 업데이트 경로를 확인하세요:
+
+```bash
+marmonitor update-integration
+```
+
+`prefix + U`로 TPM 플러그인을 업데이트했는데도 클릭 동작이나 팝업 키바인딩이 이전 버전처럼 남아 있다면, 실행 중인 tmux 서버에 플러그인을 다시 적용해야 합니다:
+
+```bash
+tmux run-shell ~/.tmux/plugins/marmonitor-tmux/marmonitor.tmux
+```
+
+이 증상은 주로 기존 tmux 세션에서 플러그인을 업그레이드할 때 발생합니다. 신규 설치에서 `prefix + I`로 처음 로드하는 경우에는 보통 바로 최신 바인딩이 적용됩니다.
+
 <details>
 <summary>직접 ~/.tmux.conf에 추가하기</summary>
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ marmonitor update-integration
 
 This checks whether your tmux integration also needs a TPM/plugin update.
 
+If you updated the TPM plugin with `prefix + U` but click actions or popup keybindings still behave like the old version, re-apply the plugin in the running tmux server:
+
+```bash
+tmux run-shell ~/.tmux/plugins/marmonitor-tmux/marmonitor.tmux
+```
+
+This mainly affects existing tmux sessions after a plugin upgrade. Fresh installs via `prefix + I` usually load the current bindings immediately.
+
 <details>
 <summary>Or add manually to ~/.tmux.conf</summary>
 

--- a/docs/issue-bug-tmux-plugin-upgrade-stale-bindings.md
+++ b/docs/issue-bug-tmux-plugin-upgrade-stale-bindings.md
@@ -1,0 +1,52 @@
+## Description
+
+After upgrading `marmonitor` and updating the `marmonitor-tmux` TPM plugin, the running tmux server can keep the old plugin bindings in memory. The status line may update, but click handling and popup keybindings can still use the previous behavior until the plugin is re-applied manually.
+
+## Steps to Reproduce
+
+1. Install `marmonitor`, set up tmux integration, and activate the TPM plugin.
+2. Upgrade `marmonitor` and update `marmonitor-tmux` with `prefix + U` or `git -C ~/.tmux/plugins/marmonitor-tmux pull --ff-only`.
+3. In the existing tmux session, try statusline click actions or `prefix + j`.
+
+## Expected Behavior
+
+After the TPM/plugin update, the running tmux session should use the latest plugin bindings immediately, including statusline click handling and the current popup keybindings.
+
+## Actual Behavior
+
+The plugin files on disk are updated, but the running tmux server still uses older bindings. In the reproduced case:
+
+- `status-format[1]` already pointed to `marmonitor-tmux/scripts/statusline.sh`
+- `MouseDown1Status` still resolved to the old default binding
+- `prefix + j` still resolved to `select-pane -D`
+- Running `tmux run-shell ~/.tmux/plugins/marmonitor-tmux/marmonitor.tmux` fixed the issue immediately
+
+## Environment
+
+- **OS**: macOS
+- **Node.js**: unknown
+- **marmonitor**: 0.2.0
+- **Terminal**: unknown
+- **tmux**: installed, existing server session active during upgrade
+
+## AI Agents Running
+
+- [ ] Claude Code
+- [x] Codex
+- [ ] Gemini CLI
+- [ ] Other: ___
+
+## Additional Context
+
+This appears to affect upgrade paths more than first-time installation. Fresh installs via `prefix + I` usually load the current bindings immediately because the plugin is being sourced for the first time. Existing users who update the TPM plugin while keeping the same tmux server alive are more likely to hit the stale-binding state.
+
+Suggested user-facing workaround:
+
+```bash
+tmux run-shell ~/.tmux/plugins/marmonitor-tmux/marmonitor.tmux
+```
+
+Suggested product improvement:
+
+- Make `marmonitor update-integration` print the explicit `tmux run-shell` recovery command
+- Add troubleshooting notes to the main README and `marmonitor-tmux` README

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1147,7 +1147,10 @@ program
       console.log("Update path:");
       console.log("  1. Press prefix+U in tmux");
       console.log(`  2. Or run: git -C ${pluginDir} pull --ff-only`);
-      console.log("  3. Reload tmux if keybindings or popup sizing changed");
+      console.log(
+        `  3. Re-apply the plugin in the running tmux server: tmux run-shell ${join(pluginDir, "marmonitor.tmux")}`,
+      );
+      console.log("  4. If the status bar still looks stale, reload tmux.conf or restart tmux");
     }
   });
 


### PR DESCRIPTION
## Summary

Release `dev` into `main`.
Includes the tmux stale binding recovery guidance merged via #22.

## Type

- [ ] `[FEAT]` New feature
- [ ] `[BUG]` Bug fix
- [ ] `[HOTFIX]` Urgent fix
- [ ] `[PERF]` Performance improvement
- [ ] `[REFACTOR]` Code restructuring
- [ ] `[DOCS]` Documentation
- [ ] `[TEST]` Test coverage
- [x] `[CICD]` CI/CD or release
- [ ] `[CHORE]` Maintenance

## Changes

- release current `dev` into `main`
- include the tmux stale binding recovery guidance merged in #22
- carry the pending unreleased `dev` changes into production

## Checklist

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (all tests green)
- [ ] New features have tests
- [x] README updated (if user-facing changes)
- [x] No hardcoded paths or environment-specific values

## Testing

- `npm run -s build`
- `npm run lint`
- `npm test`
- verified stale tmux binding recovery guidance on upgrade path

## Risk

Medium. This is a `dev` to `main` release PR, so it includes all unreleased `dev` changes.