### PR TITLE
[FEAT] #25 Codex binding registry and SQLite enrichment optimization

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -817,7 +817,33 @@ program
           }
         : null,
       paneOutput: paneOutput?.trimEnd() ?? null,
+      codexBinding: null as null | Record<string, unknown>,
     };
+
+    // Codex binding diagnostics
+    if (agent.agentName === "Codex") {
+      const { loadCodexBindingRegistryFromFile, buildCodexBindingKey } = await import(
+        "./scanner/codex-binding-registry.js"
+      );
+      const { getConfigDir } = await import("./config/index.js");
+      const { join: pj } = await import("node:path");
+      const bindingRegistry = new Map();
+      await loadCodexBindingRegistryFromFile(
+        pj(getConfigDir(), "codex-binding-registry.json"),
+        bindingRegistry,
+      );
+      const binding = bindingRegistry.get(buildCodexBindingKey(agent.pid, agent.startedAt));
+      if (binding) {
+        payload.codexBinding = {
+          threadId: binding.threadId,
+          rolloutPath: binding.rolloutPath,
+          confidence: binding.confidence,
+          unstableCount: binding.unstableCount,
+          lastVerifiedAt: binding.lastVerifiedAt,
+          deadAt: binding.deadAt ?? null,
+        };
+      }
+    }
 
     if (opts.json) {
       console.log(JSON.stringify(payload, null, 2));
@@ -836,6 +862,13 @@ program
     console.log(
       `tmux target: ${payload.tmuxTarget ? `${payload.tmuxTarget.pane} (${payload.tmuxTarget.match})` : "(none)"}`,
     );
+    if (payload.codexBinding) {
+      const b = payload.codexBinding;
+      console.log(
+        `Codex binding: thread=${b.threadId} confidence=${b.confidence} unstable=${b.unstableCount}`,
+      );
+      console.log(`  rollout: ${b.rolloutPath}`);
+    }
     console.log("Pane capture:");
     console.log(payload.paneOutput ?? "(none)");
   });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -779,7 +779,7 @@ program
       sessionLastActivityAt = gemini.lastActivityAt;
       sessionLastResponseAt = gemini.lastResponseAt;
     } else if (agent.agentName === "Codex") {
-      const codexSessions = await indexCodexSessions(config);
+      const codexSessions = await indexCodexSessions(config, { activeCwds: [agent.cwd] });
       const matched = matchCodexSession(agent.cwd, agent.startedAt, codexSessions);
       sessionPhase = await detectCodexPhase(matched?.filePath, config);
       sessionSourceFile = matched?.filePath;

--- a/src/output/utils.ts
+++ b/src/output/utils.ts
@@ -125,12 +125,20 @@ export function determineStatus(
   stalledAfterMin: number,
   phase?: SessionPhase,
   recentActivityActiveSec = 180,
+  agentName?: string,
 ): "Active" | "Idle" | "Stalled" | "Unmatched" | "Dead" {
   if (!sessionMatched) return "Unmatched";
   if (cpuPercent > activeCpuThreshold) return "Active";
   if (
     (phase === "thinking" || phase === "tool" || phase === "permission") &&
     (elapsedSec === undefined || elapsedSec <= recentActivityActiveSec)
+  ) {
+    return "Active";
+  }
+  if (
+    agentName === "Codex" &&
+    elapsedSec !== undefined &&
+    elapsedSec <= Math.min(60, recentActivityActiveSec)
   ) {
     return "Active";
   }

--- a/src/scanner/codex-binding-registry.ts
+++ b/src/scanner/codex-binding-registry.ts
@@ -1,0 +1,148 @@
+/**
+ * Codex binding registry — persists PID/process bindings to Codex thread/jsonl.
+ * 1차는 schema + load/save + prune만 제공한다.
+ */
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import type { SessionPhase } from "../types.js";
+import type { CodexSessionMeta } from "./cache.js";
+
+export interface CodexBindingRecord {
+  pid: number;
+  processStartedAt?: number;
+  cwd: string;
+  threadId: string;
+  rolloutPath: string;
+  threadCreatedAt?: number;
+  threadUpdatedAt?: number;
+  lastActivityAt?: number;
+  lastPhase?: SessionPhase;
+  lastVerifiedAt: number;
+  confidence: "high" | "medium" | "low";
+  unstableCount: number;
+  deadAt?: number;
+}
+
+export type CodexBindingRegistry = Map<string, CodexBindingRecord>;
+
+export function buildCodexBindingKey(pid: number, processStartedAt?: number): string {
+  return `${pid}:${processStartedAt ?? 0}`;
+}
+
+export function selectCodexBindingSession(
+  registry: CodexBindingRegistry,
+  pid: number,
+  processStartedAt: number | undefined,
+  cwd: string,
+  sessions: CodexSessionMeta[],
+): CodexSessionMeta | undefined {
+  const binding = registry.get(buildCodexBindingKey(pid, processStartedAt));
+  if (!binding || binding.deadAt !== undefined) return undefined;
+  if (binding.cwd !== cwd) return undefined;
+
+  const matched = sessions.find(
+    (session) =>
+      session.id === binding.threadId &&
+      session.filePath === binding.rolloutPath &&
+      session.cwd === cwd,
+  );
+  return matched;
+}
+
+export function upsertCodexBindingRecord(
+  registry: CodexBindingRegistry,
+  params: {
+    pid: number;
+    processStartedAt?: number;
+    cwd: string;
+    matched: CodexSessionMeta;
+    phase?: SessionPhase;
+    confidence?: CodexBindingRecord["confidence"];
+  },
+): void {
+  const { pid, processStartedAt, cwd, matched, phase, confidence = "high" } = params;
+  const key = buildCodexBindingKey(pid, processStartedAt);
+  const previous = registry.get(key);
+  const now = Math.floor(Date.now() / 1000);
+  const isChanged =
+    previous !== undefined &&
+    (previous.threadId !== matched.id || previous.rolloutPath !== matched.filePath);
+
+  registry.set(key, {
+    pid,
+    processStartedAt,
+    cwd,
+    threadId: matched.id,
+    rolloutPath: matched.filePath,
+    threadCreatedAt: matched.timestamp,
+    threadUpdatedAt: matched.lastActivityAt,
+    lastActivityAt: matched.lastActivityAt,
+    lastPhase: phase,
+    lastVerifiedAt: now,
+    confidence,
+    unstableCount: isChanged ? (previous?.unstableCount ?? 0) + 1 : (previous?.unstableCount ?? 0),
+    deadAt: undefined,
+  });
+}
+
+export function markMissingCodexBindingsDead(
+  registry: CodexBindingRegistry,
+  aliveKeys: Set<string>,
+): number {
+  const now = Math.floor(Date.now() / 1000);
+  let updated = 0;
+  for (const [key, record] of registry) {
+    if (aliveKeys.has(key)) continue;
+    if (record.deadAt === undefined) {
+      registry.set(key, { ...record, deadAt: now });
+      updated++;
+    }
+  }
+  return updated;
+}
+
+export function pruneCodexBindingRegistry(
+  registry: CodexBindingRegistry,
+  maxAgeDays: number,
+): number {
+  const cutoff = Math.floor(Date.now() / 1000) - maxAgeDays * 86400;
+  let pruned = 0;
+  for (const [key, record] of registry) {
+    if (record.deadAt !== undefined && record.deadAt < cutoff) {
+      registry.delete(key);
+      pruned++;
+    }
+  }
+  return pruned;
+}
+
+export async function saveCodexBindingRegistryToFile(
+  filePath: string,
+  registry: CodexBindingRegistry,
+): Promise<void> {
+  try {
+    await mkdir(dirname(filePath), { recursive: true });
+    const data = Object.fromEntries(registry.entries());
+    await writeFile(filePath, JSON.stringify(data, null, 2), "utf-8");
+  } catch {
+    // registry save failures must never crash the daemon
+  }
+}
+
+export async function loadCodexBindingRegistryFromFile(
+  filePath: string,
+  registry: CodexBindingRegistry,
+): Promise<void> {
+  try {
+    const raw = await readFile(filePath, "utf-8");
+    const data = JSON.parse(raw);
+    if (typeof data === "object" && data !== null && !Array.isArray(data)) {
+      for (const [key, value] of Object.entries(data)) {
+        registry.set(key, value as CodexBindingRecord);
+      }
+    }
+  } catch {
+    // missing or malformed file — start with empty registry
+  }
+}

--- a/src/scanner/codex-sqlite.ts
+++ b/src/scanner/codex-sqlite.ts
@@ -10,18 +10,50 @@ import type { CodexSessionMeta } from "./cache.js";
 
 const execFileAsync = promisify(execFile);
 
+export interface CodexSqliteIndexOptions {
+  recentUpdatedAfter?: number;
+  includeCwds?: string[];
+}
+
+function escapeSqlString(value: string): string {
+  return value.replaceAll("'", "''");
+}
+
+export function buildCodexThreadsQuery(options: CodexSqliteIndexOptions = {}): string {
+  const filters = ["archived = 0"];
+
+  const includeCwds = [...new Set((options.includeCwds ?? []).filter(Boolean))];
+  if (options.recentUpdatedAfter && includeCwds.length > 0) {
+    const inClause = includeCwds.map((cwd) => `'${escapeSqlString(cwd)}'`).join(", ");
+    filters.push(
+      `(updated_at >= ${Math.floor(options.recentUpdatedAfter)} OR cwd IN (${inClause}))`,
+    );
+  } else if (options.recentUpdatedAfter) {
+    filters.push(`updated_at >= ${Math.floor(options.recentUpdatedAfter)}`);
+  } else if (includeCwds.length > 0) {
+    const inClause = includeCwds.map((cwd) => `'${escapeSqlString(cwd)}'`).join(", ");
+    filters.push(`cwd IN (${inClause})`);
+  }
+
+  return [
+    "SELECT id, cwd, rollout_path, tokens_used, model, updated_at, created_at",
+    "FROM threads",
+    `WHERE ${filters.join(" AND ")}`,
+    "ORDER BY updated_at DESC;",
+  ].join(" ");
+}
+
 /**
  * Query Codex state SQLite for active (non-archived) threads.
  * Returns CodexSessionMeta[] compatible with existing matchCodexSession().
  */
-export async function indexCodexSessionsFromSqlite(dbPath: string): Promise<CodexSessionMeta[]> {
+export async function indexCodexSessionsFromSqlite(
+  dbPath: string,
+  options: CodexSqliteIndexOptions = {},
+): Promise<CodexSessionMeta[]> {
   try {
-    const { stdout } = await execFileAsync("sqlite3", [
-      dbPath,
-      "-separator",
-      "\t",
-      "SELECT id, cwd, rollout_path, tokens_used, model, updated_at, created_at FROM threads WHERE archived = 0 ORDER BY updated_at DESC;",
-    ]);
+    const query = buildCodexThreadsQuery(options);
+    const { stdout } = await execFileAsync("sqlite3", [dbPath, "-separator", "\t", query]);
 
     const lines = stdout.trim().split("\n").filter(Boolean);
     const sessions: CodexSessionMeta[] = [];

--- a/src/scanner/codex.ts
+++ b/src/scanner/codex.ts
@@ -33,6 +33,8 @@ import type { CodexSessionMeta } from "./cache.js";
 
 export type { CodexSessionMeta } from "./cache.js";
 
+const CODEX_SQLITE_RECENT_DAYS = 7;
+
 export function getCodexSessionRoots(config?: MarmonitorConfig): string[] {
   return config
     ? resolveRuntimeDataPaths(config).codexSessions
@@ -155,8 +157,18 @@ function findCodexStateDb(): string | undefined {
 }
 
 /** Build index of Codex sessions (SQLite primary, JSONL fallback) */
-export async function indexCodexSessions(config?: MarmonitorConfig): Promise<CodexSessionMeta[]> {
-  if (codexIndexCache && Date.now() - codexIndexCache.builtAt < CODEX_INDEX_TTL_MS) {
+export async function indexCodexSessions(
+  config?: MarmonitorConfig,
+  options?: { activeCwds?: string[] },
+): Promise<CodexSessionMeta[]> {
+  const activeCwds = [...new Set((options?.activeCwds ?? []).filter(Boolean))];
+  const hasTargetedFilter = activeCwds.length > 0;
+
+  if (
+    !hasTargetedFilter &&
+    codexIndexCache &&
+    Date.now() - codexIndexCache.builtAt < CODEX_INDEX_TTL_MS
+  ) {
     return codexIndexCache.sessions;
   }
 
@@ -165,7 +177,10 @@ export async function indexCodexSessions(config?: MarmonitorConfig): Promise<Cod
   // Primary: SQLite threads table
   const dbPath = hasExplicitSessionRoots ? undefined : findCodexStateDb();
   if (dbPath) {
-    const sqliteSessions = await indexCodexSessionsFromSqlite(dbPath);
+    const sqliteSessions = await indexCodexSessionsFromSqlite(dbPath, {
+      recentUpdatedAfter: Math.floor(Date.now() / 1000) - CODEX_SQLITE_RECENT_DAYS * 86400,
+      includeCwds: activeCwds,
+    });
     if (sqliteSessions.length > 0) {
       // Register sessions for phase detection and cwd lookup
       for (const s of sqliteSessions) {
@@ -180,7 +195,9 @@ export async function indexCodexSessions(config?: MarmonitorConfig): Promise<Cod
           source: "codex",
         });
       }
-      setCodexIndexCache({ builtAt: Date.now(), sessions: sqliteSessions });
+      if (!hasTargetedFilter) {
+        setCodexIndexCache({ builtAt: Date.now(), sessions: sqliteSessions });
+      }
       return sqliteSessions;
     }
   }

--- a/src/scanner/daemon-entry.ts
+++ b/src/scanner/daemon-entry.ts
@@ -23,6 +23,7 @@ async function main(): Promise<void> {
     snapshotPath: join(DAEMON_DIR, "daemon-snapshot.json"),
     pidPath: join(DAEMON_DIR, "daemon.pid"),
     registryPath: join(CONFIG_DIR, "session-registry.json"),
+    codexBindingRegistryPath: join(CONFIG_DIR, "codex-binding-registry.json"),
   });
 }
 

--- a/src/scanner/daemon-loop.ts
+++ b/src/scanner/daemon-loop.ts
@@ -5,6 +5,12 @@
 
 import { unlink } from "node:fs/promises";
 import type { MarmonitorConfig } from "../config/index.js";
+import {
+  type CodexBindingRegistry,
+  loadCodexBindingRegistryFromFile,
+  pruneCodexBindingRegistry,
+  saveCodexBindingRegistryToFile,
+} from "./codex-binding-registry.js";
 import { writeDaemonPid, writeDaemonSnapshot } from "./daemon-utils.js";
 import { scanAgents } from "./index.js";
 import { perfEnd, perfStart } from "./perf.js";
@@ -22,6 +28,7 @@ export interface DaemonOptions {
   snapshotPath: string;
   pidPath: string;
   registryPath: string;
+  codexBindingRegistryPath: string;
 }
 
 function sleep(ms: number): Promise<void> {
@@ -32,11 +39,19 @@ export async function runDaemonLoop(
   config: MarmonitorConfig,
   options: DaemonOptions,
 ): Promise<void> {
-  const { intervalMs, detailIntervalMs, snapshotPath, pidPath, registryPath } = options;
+  const {
+    intervalMs,
+    detailIntervalMs,
+    snapshotPath,
+    pidPath,
+    registryPath,
+    codexBindingRegistryPath,
+  } = options;
 
   await writeDaemonPid(pidPath, process.pid);
 
   const registry = new Map<string, SessionRegistryRecord>();
+  const codexBindingRegistry: CodexBindingRegistry = new Map();
 
   // Restore registry if saved recently (within 10 minutes)
   try {
@@ -49,6 +64,7 @@ export async function runDaemonLoop(
   } catch {
     // file missing or inaccessible — start fresh
   }
+  await loadCodexBindingRegistryFromFile(codexBindingRegistryPath, codexBindingRegistry);
 
   let lastHeavyAt = 0;
   let running = true;
@@ -58,6 +74,7 @@ export async function runDaemonLoop(
     running = false;
     // Save registry before exit
     await saveRegistryToFile(registryPath, registry);
+    await saveCodexBindingRegistryToFile(codexBindingRegistryPath, codexBindingRegistry);
     await unlink(pidPath).catch(() => {});
     process.exit(0);
   };
@@ -76,7 +93,10 @@ export async function runDaemonLoop(
 
     perfStart("daemon-scan");
     try {
-      const agents = await scanAgents(config, { enrichmentMode });
+      const agents = await scanAgents(config, {
+        enrichmentMode,
+        codexBindingRegistry,
+      });
       if (needsHeavy) lastHeavyAt = now;
 
       // Update session registry
@@ -89,6 +109,8 @@ export async function runDaemonLoop(
       if (needsHeavy) {
         pruneRegistry(registry, 30);
         await saveRegistryToFile(registryPath, registry);
+        pruneCodexBindingRegistry(codexBindingRegistry, 7);
+        await saveCodexBindingRegistryToFile(codexBindingRegistryPath, codexBindingRegistry);
       }
     } catch (err) {
       // scan failures must never crash the daemon

--- a/src/scanner/index.ts
+++ b/src/scanner/index.ts
@@ -30,6 +30,12 @@ import {
   parseClaudeSession,
   parseClaudeTokens,
 } from "./claude.js";
+import {
+  buildCodexBindingKey,
+  markMissingCodexBindingsDead,
+  selectCodexBindingSession,
+  upsertCodexBindingRecord,
+} from "./codex-binding-registry.js";
 import { detectCodexPhase, indexCodexSessions, matchCodexSession } from "./codex.js";
 import { promiseAllLimited } from "./concurrency.js";
 import { parseGeminiSession } from "./gemini.js";
@@ -55,6 +61,7 @@ export async function scanAgents(
 ): Promise<AgentSession[]> {
   const enrichmentMode = options.enrichmentMode ?? "full";
   const isFullEnrichment = enrichmentMode === "full";
+  const codexBindingRegistry = options.codexBindingRegistry;
   const seenPids = new Set<number>();
 
   perfStart("scanAgents");
@@ -86,8 +93,30 @@ export async function scanAgents(
   perfEnd("pidusage");
 
   // 3. Pre-index Codex sessions (once, shared across all Codex processes)
+  const codexCwdEntries = isFullEnrichment
+    ? await promiseAllLimited(
+        agentProcesses
+          .filter((item) => item.agentName === "Codex")
+          .map((item) => async () => ({
+            pid: item.proc.pid,
+            cwd: (await getProcessCwd(item.proc.pid)) ?? undefined,
+          })),
+        4,
+      )
+    : [];
+  const resolvedCodexCwds = codexCwdEntries.flatMap((entry) => (entry ? [entry] : []));
+  const activeCodexCwds = [
+    ...new Set(
+      resolvedCodexCwds.map((entry) => entry.cwd).filter((cwd): cwd is string => Boolean(cwd)),
+    ),
+  ];
+  const codexCwdByPid = new Map(
+    resolvedCodexCwds.filter((entry) => entry.cwd).map((entry) => [entry.pid, entry.cwd as string]),
+  );
   perfStart("codex-index");
-  const codexSessions = isFullEnrichment ? await indexCodexSessions(config) : [];
+  const codexSessions = isFullEnrichment
+    ? await indexCodexSessions(config, { activeCwds: activeCodexCwds })
+    : [];
   perfEnd("codex-index");
 
   // 4. Build sessions with enrichment (concurrency limited)
@@ -102,6 +131,7 @@ export async function scanAgents(
     let cwd = "unknown";
     let sessionId: string | undefined;
     let startedAt: number | undefined;
+    let processStartedAt: number | undefined;
     let tokenUsage: TokenUsage | undefined;
     let model: string | undefined;
     let sessionMatched = false;
@@ -147,6 +177,7 @@ export async function scanAgents(
       if (cachedEnrichment.cwd) cwd = cachedEnrichment.cwd;
       sessionId = cachedEnrichment.sessionId;
       startedAt = cachedEnrichment.startedAt;
+      processStartedAt = cachedEnrichment.processStartedAt;
       tokenUsage = cachedEnrichment.tokenUsage;
       model = cachedEnrichment.model;
       sessionMatched = cachedEnrichment.sessionMatched ?? false;
@@ -177,10 +208,23 @@ export async function scanAgents(
         lastActivityAt = phaseResult.lastActivityAt ?? lastActivityAt;
       }
     } else if (agentName === "Codex") {
-      cwd = cachedEnrichment?.cwd ?? (await getProcessCwd(proc.pid)) ?? "unknown";
-      const processStartTime = await getProcessStartTime(proc.pid);
+      cwd =
+        cachedEnrichment?.cwd ??
+        codexCwdByPid.get(proc.pid) ??
+        (await getProcessCwd(proc.pid)) ??
+        "unknown";
+      processStartedAt = await getProcessStartTime(proc.pid);
 
-      const matched = matchCodexSession(cwd, processStartTime, codexSessions);
+      const matched =
+        (codexBindingRegistry
+          ? selectCodexBindingSession(
+              codexBindingRegistry,
+              proc.pid,
+              processStartedAt,
+              cwd,
+              codexSessions,
+            )
+          : undefined) ?? matchCodexSession(cwd, processStartedAt, codexSessions);
       if (matched) {
         sessionMatched = true;
         sessionId = matched.id;
@@ -204,6 +248,16 @@ export async function scanAgents(
       if (phase !== "permission" && runtimeSource === "cli") {
         phase = (await detectCliStdoutPhase({ pid: proc.pid, cwd }, config)) ?? phase;
       }
+
+      if (codexBindingRegistry && matched) {
+        upsertCodexBindingRecord(codexBindingRegistry, {
+          pid: proc.pid,
+          processStartedAt,
+          cwd,
+          matched,
+          phase,
+        });
+      }
     } else if (agentName === "Gemini") {
       cwd = cachedEnrichment?.cwd ?? (await getProcessCwd(proc.pid)) ?? "unknown";
       const geminiData = await parseGeminiSession(cwd);
@@ -226,7 +280,7 @@ export async function scanAgents(
 
     const statusBaseAt = lastActivityAt ?? lastResponseAt ?? startedAt;
     const elapsed = statusBaseAt ? Date.now() / 1000 - statusBaseAt : undefined;
-    const status = determineStatus(cpuPercent, elapsed, sessionMatched, phase, config);
+    const status = determineStatus(cpuPercent, elapsed, sessionMatched, phase, config, agentName);
 
     const session = {
       agentName,
@@ -237,6 +291,7 @@ export async function scanAgents(
       memoryMb,
       status,
       startedAt,
+      processStartedAt,
       sessionId,
       tokenUsage,
       model,
@@ -252,6 +307,7 @@ export async function scanAgents(
         cwd: session.cwd,
         sessionId: session.sessionId,
         startedAt: session.startedAt,
+        processStartedAt: session.processStartedAt,
         tokenUsage: session.tokenUsage,
         model: session.model,
         sessionMatched: session.sessionMatched,
@@ -268,6 +324,15 @@ export async function scanAgents(
   const concurrencyLimit = isFullEnrichment ? 8 : 4;
   const results = await promiseAllLimited(sessionPromises, concurrencyLimit);
   const sessions: AgentSession[] = results.filter((s): s is AgentSession => s !== null);
+
+  if (codexBindingRegistry) {
+    const aliveCodexKeys = new Set(
+      sessions
+        .filter((session) => session.agentName === "Codex")
+        .map((session) => buildCodexBindingKey(session.pid, session.processStartedAt)),
+    );
+    markMissingCodexBindingsDead(codexBindingRegistry, aliveCodexKeys);
+  }
 
   // 5. Check for dead sessions (Claude: session file exists but process gone)
   if (config.display.showDead) {

--- a/src/scanner/status.ts
+++ b/src/scanner/status.ts
@@ -15,6 +15,7 @@ export function determineStatus(
   sessionMatched: boolean,
   phase: SessionPhase | undefined,
   config: MarmonitorConfig,
+  agentName?: string,
 ): SessionStatus {
   // Zombie: process exists but no matching session
   if (!sessionMatched) return "Unmatched";
@@ -22,11 +23,21 @@ export function determineStatus(
   // Active: CPU above threshold
   if (cpuPercent > config.status.activeCpuThreshold) return "Active";
 
-  // Permission/thinking override: these phases require user attention
-  // regardless of how long the process has been running
-  if (phase === "permission" || phase === "thinking") return "Idle";
+  // Recent active phases stay active briefly even after CPU bursts end.
+  if (
+    (phase === "permission" || phase === "thinking" || phase === "tool") &&
+    (elapsedSec === undefined || elapsedSec <= RECENT_ACTIVITY_ACTIVE_SEC)
+  ) {
+    return "Active";
+  }
 
-  if (phase === "tool" && (elapsedSec === undefined || elapsedSec <= RECENT_ACTIVITY_ACTIVE_SEC)) {
+  // Codex often drops to ~0% CPU immediately after a burst.
+  // Keep it active for a short recent-activity grace window even without a strong phase.
+  if (
+    agentName === "Codex" &&
+    elapsedSec !== undefined &&
+    elapsedSec <= Math.min(60, RECENT_ACTIVITY_ACTIVE_SEC)
+  ) {
     return "Active";
   }
 

--- a/src/scanner/types.ts
+++ b/src/scanner/types.ts
@@ -2,6 +2,9 @@
  * Public types for the scanner module.
  */
 
+import type { CodexBindingRegistry } from "./codex-binding-registry.js";
+
 export interface ScanOptions {
   enrichmentMode?: "full" | "light";
+  codexBindingRegistry?: CodexBindingRegistry;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,7 @@ export interface AgentSession {
   memoryMb: number;
   status: SessionStatus;
   startedAt?: number; // epoch seconds
+  processStartedAt?: number; // epoch seconds — OS process start time
   sessionId?: string;
   lastActivity?: string;
   tokenUsage?: TokenUsage;

--- a/tests/codex-binding-registry.test.mjs
+++ b/tests/codex-binding-registry.test.mjs
@@ -1,0 +1,151 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import {
+  buildCodexBindingKey,
+  loadCodexBindingRegistryFromFile,
+  markMissingCodexBindingsDead,
+  pruneCodexBindingRegistry,
+  saveCodexBindingRegistryToFile,
+  selectCodexBindingSession,
+  upsertCodexBindingRecord,
+} from "../dist/scanner/codex-binding-registry.js";
+
+describe("codex binding registry", () => {
+  it("builds a stable key from pid and process start time", () => {
+    assert.equal(buildCodexBindingKey(19077, 1775000000), "19077:1775000000");
+    assert.equal(buildCodexBindingKey(19077, undefined), "19077:0");
+  });
+
+  it("saves and loads registry records from file", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "marmonitor-codex-binding-"));
+    const filePath = join(dir, "codex-binding-registry.json");
+
+    try {
+      const registry = new Map([
+        [
+          "19077:1775000000",
+          {
+            pid: 19077,
+            processStartedAt: 1775000000,
+            cwd: "/Users/macrent/.ai/projects/mjjo",
+            threadId: "019d1f7f",
+            rolloutPath: "/tmp/rollout.jsonl",
+            threadCreatedAt: 1774349925,
+            threadUpdatedAt: 1775180138,
+            lastActivityAt: 1775180138,
+            lastPhase: "tool",
+            lastVerifiedAt: 1775180138,
+            confidence: "high",
+            unstableCount: 0,
+          },
+        ],
+      ]);
+
+      await saveCodexBindingRegistryToFile(filePath, registry);
+
+      const loaded = new Map();
+      await loadCodexBindingRegistryFromFile(filePath, loaded);
+
+      assert.equal(loaded.size, 1);
+      assert.equal(loaded.get("19077:1775000000").threadId, "019d1f7f");
+      assert.equal(loaded.get("19077:1775000000").confidence, "high");
+    } finally {
+      await rm(dir, { recursive: true });
+    }
+  });
+
+  it("prunes dead bindings older than cutoff", () => {
+    const now = Math.floor(Date.now() / 1000);
+    const registry = new Map([
+      [
+        "old",
+        {
+          pid: 1,
+          cwd: "/tmp/old",
+          threadId: "old",
+          rolloutPath: "/tmp/old.jsonl",
+          lastVerifiedAt: now - 10 * 86400,
+          confidence: "low",
+          unstableCount: 2,
+          deadAt: now - 8 * 86400,
+        },
+      ],
+      [
+        "alive",
+        {
+          pid: 2,
+          cwd: "/tmp/alive",
+          threadId: "alive",
+          rolloutPath: "/tmp/alive.jsonl",
+          lastVerifiedAt: now,
+          confidence: "high",
+          unstableCount: 0,
+        },
+      ],
+    ]);
+
+    const pruned = pruneCodexBindingRegistry(registry, 7);
+    assert.equal(pruned, 1);
+    assert.equal(registry.has("old"), false);
+    assert.equal(registry.has("alive"), true);
+  });
+
+  it("reuses an existing binding when the same thread still exists", () => {
+    const registry = new Map([
+      [
+        "19077:1775000000",
+        {
+          pid: 19077,
+          processStartedAt: 1775000000,
+          cwd: "/Users/macrent/.ai/projects/mjjo",
+          threadId: "019d1f7f",
+          rolloutPath: "/tmp/rollout.jsonl",
+          lastVerifiedAt: 1775180138,
+          confidence: "high",
+          unstableCount: 0,
+        },
+      ],
+    ]);
+
+    const matched = selectCodexBindingSession(
+      registry,
+      19077,
+      1775000000,
+      "/Users/macrent/.ai/projects/mjjo",
+      [
+        {
+          id: "019d1f7f",
+          cwd: "/Users/macrent/.ai/projects/mjjo",
+          filePath: "/tmp/rollout.jsonl",
+          timestamp: 1774349925,
+        },
+      ],
+    );
+
+    assert.equal(matched?.id, "019d1f7f");
+  });
+
+  it("marks missing bindings dead and updates the existing binding in place", () => {
+    const registry = new Map();
+    upsertCodexBindingRecord(registry, {
+      pid: 19077,
+      processStartedAt: 1775000000,
+      cwd: "/Users/macrent/.ai/projects/mjjo",
+      matched: {
+        id: "019d1f7f",
+        cwd: "/Users/macrent/.ai/projects/mjjo",
+        filePath: "/tmp/rollout.jsonl",
+        timestamp: 1774349925,
+        lastActivityAt: 1775180138,
+      },
+      phase: "tool",
+    });
+
+    const updated = markMissingCodexBindingsDead(registry, new Set());
+    assert.equal(updated, 1);
+    assert.equal(registry.get("19077:1775000000")?.deadAt !== undefined, true);
+  });
+});

--- a/tests/codex-sqlite.test.mjs
+++ b/tests/codex-sqlite.test.mjs
@@ -4,7 +4,10 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it } from "node:test";
-import { indexCodexSessionsFromSqlite } from "../dist/scanner/codex-sqlite.js";
+import {
+  buildCodexThreadsQuery,
+  indexCodexSessionsFromSqlite,
+} from "../dist/scanner/codex-sqlite.js";
 
 describe("codex sqlite indexing", () => {
   it("indexes active threads from sqlite", async () => {
@@ -88,6 +91,57 @@ describe("codex sqlite indexing", () => {
       assert.equal(sessions.length, 1);
       assert.ok(sessions[0].totalTokenUsage);
       assert.equal(sessions[0].totalTokenUsage.total_tokens, 500000);
+    } finally {
+      await rm(dir, { recursive: true });
+    }
+  });
+
+  it("builds a query with updated_at gating and cwd exceptions", () => {
+    const query = buildCodexThreadsQuery({
+      recentUpdatedAfter: 1775000000,
+      includeCwds: ["/tmp/active", "/tmp/active"],
+    });
+
+    assert.match(query, /updated_at >= 1775000000/);
+    assert.match(query, /cwd IN \('\/tmp\/active'\)/);
+    assert.match(query, /archived = 0/);
+  });
+
+  it("keeps active cwd rows even when older than the recent cutoff", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "marmonitor-codex-sqlite-"));
+    const dbPath = join(dir, "state.sqlite");
+    try {
+      execSync(`sqlite3 "${dbPath}" "
+        CREATE TABLE threads (
+          id TEXT PRIMARY KEY,
+          rollout_path TEXT NOT NULL,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL,
+          source TEXT NOT NULL DEFAULT 'cli',
+          model_provider TEXT NOT NULL DEFAULT 'openai',
+          cwd TEXT NOT NULL,
+          title TEXT NOT NULL DEFAULT '',
+          sandbox_policy TEXT NOT NULL DEFAULT '{}',
+          approval_mode TEXT NOT NULL DEFAULT 'on-request',
+          tokens_used INTEGER NOT NULL DEFAULT 0,
+          archived INTEGER NOT NULL DEFAULT 0,
+          model TEXT,
+          cli_version TEXT NOT NULL DEFAULT ''
+        );
+        INSERT INTO threads (id, rollout_path, created_at, updated_at, cwd, tokens_used, archived, model)
+        VALUES ('recent', '/tmp/recent.jsonl', 1774000000, 1776000000, '/projects/recent', 10, 0, 'gpt-5.4');
+        INSERT INTO threads (id, rollout_path, created_at, updated_at, cwd, tokens_used, archived, model)
+        VALUES ('old-active', '/tmp/old.jsonl', 1773000000, 1773000000, '/projects/active', 20, 0, 'gpt-5.4');
+        INSERT INTO threads (id, rollout_path, created_at, updated_at, cwd, tokens_used, archived, model)
+        VALUES ('old-cold', '/tmp/cold.jsonl', 1772000000, 1772000000, '/projects/cold', 30, 0, 'gpt-5.4');
+      "`);
+
+      const sessions = await indexCodexSessionsFromSqlite(dbPath, {
+        recentUpdatedAfter: 1775000000,
+        includeCwds: ["/projects/active"],
+      });
+
+      assert.deepEqual(sessions.map((session) => session.id).sort(), ["old-active", "recent"]);
     } finally {
       await rm(dir, { recursive: true });
     }

--- a/tests/utils.test.mjs
+++ b/tests/utils.test.mjs
@@ -421,6 +421,11 @@ describe("determineStatus", () => {
     assert.equal(determineStatus(0.05, 45, true, 0.5, 30, "permission"), "Active");
   });
 
+  it("keeps recent Codex sessions active briefly even when CPU drops to zero", () => {
+    assert.equal(determineStatus(0.0, 20, true, 0.5, 30, undefined, 180, "Codex"), "Active");
+    assert.equal(determineStatus(0.0, 70, true, 0.5, 30, undefined, 180, "Codex"), "Idle");
+  });
+
   it("does not keep old active phases alive forever", () => {
     assert.equal(determineStatus(0.05, 400, true, 0.5, 30, "tool"), "Idle");
   });


### PR DESCRIPTION
## Summary

Resolve #25

Codex session tracking improvements: SQLite enrichment scope limiting, PID-to-thread binding registry, grace period status classification, and debug-phase binding diagnostics.

## Type

- [x] `[PERF]` Performance improvement
- [x] `[FEAT]` New feature
- [x] `[BUG]` Bug fix

## Changes

**SQLite enrichment scope (local #086):**
- `updated_at` 7-day cutoff with active cwd exception in SQLite query
- Prevents full JSONL enrichment of all sessions in high-density environments
- `debug-phase` passes `activeCwds` for long-lived session coverage

**Codex binding registry (#25 / local #087):**
- Daemon maintains `pid+startedAt` keyed bindings to Codex threads
- Prevents same-cwd sessions from flickering between threads
- Registry persisted to `codex-binding-registry.json` with auto-pruning
- `debug-phase` exposes binding confidence, unstableCount, rolloutPath

**Codex status classification:**
- Permission/thinking/tool phases keep Active status within recent activity window
- Codex-specific 60s grace period for CPU burst recovery (Codex drops to ~0% CPU immediately after response)

## Checklist

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (230/230)
- [x] New features have tests
- [x] No hardcoded paths or environment-specific values

## Testing

```bash
# Binding registry check
marmonitor debug-phase --pid <codex_pid> --json
# → codexBinding: { threadId, confidence, unstableCount, rolloutPath }

# Verify Codex sessions are matched
marmonitor status  # Codex sessions should show matched, not Unmatched
```

## Risk

Low — Codex-specific changes only. Claude/Gemini unaffected. Falls back to existing `matchCodexSession()` if binding registry is empty.

<details>
<summary><h2>🇰🇷 한국어 버전</h2></summary>

## 개요

Resolve #25

Codex 세션 추적 개선: SQLite enrichment 범위 제한, PID ↔ thread 바인딩 레지스트리, grace period 상태 판정, debug-phase 진단.

## 변경사항

- **SQLite enrichment 범위 제한** (로컬 #086): updated_at 7일 cutoff + activeCwds 예외. 고밀도 환경 성능 저하 방지.
- **Codex binding registry** (#25 / 로컬 #087): daemon이 pid+startedAt 키로 바인딩 유지. same-cwd 세션 흔들림 방지. codex-binding-registry.json 저장.
- **Codex 상태 판정**: permission/thinking/tool phase Active 유지. Codex 전용 60초 grace period.
- **debug-phase 진단**: Codex binding confidence/unstableCount/rolloutPath 노출.

## 위험도

Low — Codex만 해당. Claude/Gemini 영향 없음. binding registry 비어 있으면 기존 방식 fallback.

</details>