### PR TITLE
[FEAT] #27 Add session activity log and CLI

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1072,6 +1072,104 @@ program
   });
 
 program
+  .command("activity")
+  .description("Show recent tool usage and token activity per session")
+  .option("--pid <pid>", "Filter by AI process PID")
+  .option("--session <sid>", "Filter by session ID (prefix match)")
+  .option("--days <n>", "Number of days to show", "1")
+  .option("--json", "Output as JSON")
+  .action(async (opts) => {
+    const { getConfigDir } = await import("./config/index.js");
+    const { join: pj } = await import("node:path");
+    const { getRecentDateKeys, readActivityLog } = await import("./scanner/activity-log.js");
+
+    const logDir = pj(getConfigDir(), "activity-log");
+    const days = Math.max(1, Math.min(90, Number(opts.days) || 1));
+    const allEntries = [];
+
+    for (const dateStr of getRecentDateKeys(days)) {
+      const entries = await readActivityLog(logDir, dateStr);
+      allEntries.push(...entries);
+    }
+
+    // Filter
+    let filtered = allEntries;
+    if (opts.pid) {
+      const agents = await getAgentsSnapshot();
+      const agent = agents.find((a) => a.pid === Number(opts.pid));
+      if (agent?.sessionId) {
+        const sidPrefix = agent.sessionId.slice(0, 12);
+        filtered = filtered.filter((e) => e.sid.startsWith(sidPrefix));
+      } else {
+        filtered = [];
+      }
+    }
+    if (opts.session) {
+      const prefix = opts.session;
+      filtered = filtered.filter((e) => e.sid.startsWith(prefix));
+    }
+
+    if (opts.json) {
+      console.log(JSON.stringify(filtered, null, 2));
+      return;
+    }
+
+    if (filtered.length === 0) {
+      console.log("No activity found.");
+      return;
+    }
+
+    // Group by session
+    const bySession = new Map();
+    for (const e of filtered) {
+      const key = `${e.sid}|${e.agent}|${e.cwd}`;
+      if (!bySession.has(key)) bySession.set(key, []);
+      bySession.get(key).push(e);
+    }
+
+    for (const [key, entries] of bySession) {
+      const [sid, agent, cwd] = key.split("|");
+      const totalOut = entries.reduce(
+        (sum: number, e: Record<string, unknown>) =>
+          sum + ((e.tokens as Record<string, number>)?.out ?? 0),
+        0,
+      );
+      const totalCache = entries.reduce(
+        (sum: number, e: Record<string, unknown>) =>
+          sum + ((e.tokens as Record<string, number>)?.cache ?? 0),
+        0,
+      );
+      console.log(`\n${agent}  ${sid}...  ${cwd}`);
+      console.log(
+        `  ${entries.length} actions  out:${formatTokensShort(totalOut)}  cache:${formatTokensShort(totalCache)}`,
+      );
+      console.log("  ─────────────────────────────────────");
+      for (const e of entries.slice(-20)) {
+        const t = new Date(e.ts * 1000).toLocaleTimeString("en-GB", {
+          hour: "2-digit",
+          minute: "2-digit",
+        });
+        console.log(`  ${t}  ${e.tool}: ${truncateForDisplay(e.target, 60)}`);
+      }
+      if (entries.length > 20) {
+        console.log(`  ... +${entries.length - 20} more`);
+      }
+    }
+  });
+
+function formatTokensShort(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
+}
+
+function truncateForDisplay(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  if (maxLength <= 3) return value.slice(0, maxLength);
+  return `${value.slice(0, maxLength - 3)}...`;
+}
+
+program
   .command("clean")
   .description("Show or terminate unmatched processes")
   .option("--config <path>", "Path to settings.json")

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -93,6 +93,7 @@ export interface MarmonitorConfig {
     statuslineTtlMs: number;
     stdoutHeuristicTtlMs: number;
     daemonIntervalSec: number;
+    activityRetentionDays: number;
   };
 }
 
@@ -175,6 +176,7 @@ const DEFAULTS: MarmonitorConfig = {
     statuslineTtlMs: 2000,
     stdoutHeuristicTtlMs: 2000,
     daemonIntervalSec: 2,
+    activityRetentionDays: 7,
   },
 };
 

--- a/src/scanner/activity-log.ts
+++ b/src/scanner/activity-log.ts
@@ -1,0 +1,263 @@
+/**
+ * Activity log — extracts tool_use from Claude/Codex JSONL and writes daily logs.
+ * Stored in ~/.config/marmonitor/activity-log/YYYY-MM-DD.jsonl
+ */
+
+import { mkdir, readFile, readdir, unlink, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+export interface ActivityEntry {
+  ts: number;
+  sid: string;
+  agent: string;
+  cwd: string;
+  tool: string;
+  target: string;
+  tokens?: { in: number; out: number; cache: number };
+}
+
+export function formatDateKey(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+export function getRecentDateKeys(days: number, now = new Date()): string[] {
+  const keys: string[] = [];
+  for (let d = 0; d < days; d++) {
+    const date = new Date(now);
+    date.setDate(now.getDate() - d);
+    keys.push(formatDateKey(date));
+  }
+  return keys;
+}
+
+/** Extract tool_use entries from Claude Code JSONL lines */
+export function extractClaudeToolUses(
+  lines: string[],
+  sessionId: string,
+  agent: string,
+  cwd: string,
+): ActivityEntry[] {
+  const entries: ActivityEntry[] = [];
+
+  for (const line of lines) {
+    try {
+      const d = JSON.parse(line);
+      if (d.type !== "assistant") continue;
+
+      const msg = d.message ?? {};
+      const usage = msg.usage;
+      const ts = parseTimestamp(d.timestamp);
+      if (!ts) continue;
+
+      const content = msg.content ?? [];
+      for (const c of content) {
+        if (c.type !== "tool_use") continue;
+
+        const entry: ActivityEntry = {
+          ts,
+          sid: sessionId,
+          agent,
+          cwd,
+          tool: c.name ?? "unknown",
+          target: extractTarget(c.name, c.input ?? {}),
+        };
+
+        if (usage) {
+          entry.tokens = {
+            in: usage.input_tokens ?? 0,
+            out: usage.output_tokens ?? 0,
+            cache: usage.cache_read_input_tokens ?? 0,
+          };
+        }
+
+        entries.push(entry);
+      }
+    } catch {
+      // skip malformed lines
+    }
+  }
+
+  return entries;
+}
+
+/** Extract tool events from Codex JSONL lines */
+export function extractCodexToolUses(
+  lines: string[],
+  sessionId: string,
+  agent: string,
+  cwd: string,
+): ActivityEntry[] {
+  const entries: ActivityEntry[] = [];
+  let lastTokens: ActivityEntry["tokens"] | undefined;
+
+  for (const line of lines) {
+    try {
+      const d = JSON.parse(line);
+      if (d.type !== "event_msg") continue;
+
+      const payload = d.payload ?? {};
+      const ts = parseTimestamp(d.timestamp);
+
+      if (payload.type === "token_count") {
+        const last = payload.info?.last_token_usage;
+        if (last) {
+          lastTokens = {
+            in: last.input_tokens ?? 0,
+            out: last.output_tokens ?? 0,
+            cache: last.cached_input_tokens ?? 0,
+          };
+        }
+        continue;
+      }
+
+      if (!ts) continue;
+
+      if (payload.type === "exec_command_end") {
+        const cmd = Array.isArray(payload.command) ? payload.command.slice(-1)[0] : "";
+        entries.push({
+          ts,
+          sid: sessionId,
+          agent,
+          cwd: payload.cwd ?? cwd,
+          tool: "Bash",
+          target: cmd.split("\n")[0].slice(0, 100),
+          ...(lastTokens ? { tokens: lastTokens } : {}),
+        });
+        lastTokens = undefined;
+      } else if (payload.type === "patch_apply_end") {
+        const stdout = payload.stdout ?? "";
+        const fileMatch = stdout.match(/[MA]\s+(.+)/);
+        const target = fileMatch ? fileMatch[1].trim() : "unknown";
+        entries.push({
+          ts,
+          sid: sessionId,
+          agent,
+          cwd,
+          tool: "Edit",
+          target: target.slice(0, 100),
+          ...(lastTokens ? { tokens: lastTokens } : {}),
+        });
+        lastTokens = undefined;
+      } else if (payload.type === "web_search_end") {
+        entries.push({
+          ts,
+          sid: sessionId,
+          agent,
+          cwd,
+          tool: "WebSearch",
+          target: (payload.query ?? "").slice(0, 100),
+          ...(lastTokens ? { tokens: lastTokens } : {}),
+        });
+        lastTokens = undefined;
+      }
+    } catch {
+      // skip malformed lines
+    }
+  }
+
+  return entries;
+}
+
+/** Append activity entries to daily log file */
+export async function appendActivityEntries(
+  logDir: string,
+  dateStr: string,
+  entries: ActivityEntry[],
+): Promise<void> {
+  if (entries.length === 0) return;
+  await mkdir(logDir, { recursive: true });
+  const filePath = join(logDir, `${dateStr}.jsonl`);
+  const data = `${entries.map((e) => JSON.stringify(e)).join("\n")}\n`;
+
+  try {
+    const existing = await readFile(filePath, "utf-8");
+    await writeFile(filePath, existing + data, "utf-8");
+  } catch {
+    await writeFile(filePath, data, "utf-8");
+  }
+}
+
+/** Read activity log for a specific date */
+export async function readActivityLog(logDir: string, dateStr: string): Promise<ActivityEntry[]> {
+  try {
+    const raw = await readFile(join(logDir, `${dateStr}.jsonl`), "utf-8");
+    return raw
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+  } catch {
+    return [];
+  }
+}
+
+/** Delete activity logs older than retentionDays */
+export async function cleanupOldActivityLogs(
+  logDir: string,
+  retentionDays: number,
+  now = new Date(),
+): Promise<number> {
+  // Use start-of-day to avoid deleting today's cutoff date file early
+  const cutoffDate = new Date(now.getTime() - retentionDays * 86400000);
+  const cutoff = new Date(cutoffDate.getFullYear(), cutoffDate.getMonth(), cutoffDate.getDate());
+  const cutoffKey = formatDateKey(cutoff);
+  let deleted = 0;
+
+  try {
+    const files = await readdir(logDir);
+    for (const file of files) {
+      if (!file.endsWith(".jsonl")) continue;
+      const dateStr = file.replace(".jsonl", "");
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) continue;
+      if (dateStr < cutoffKey) {
+        await unlink(join(logDir, file));
+        deleted++;
+      }
+    }
+  } catch {
+    // directory missing — nothing to clean
+  }
+
+  return deleted;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────
+
+function parseTimestamp(ts: unknown): number | undefined {
+  if (typeof ts === "number") return Math.floor(ts);
+  if (typeof ts === "string") {
+    try {
+      return Math.floor(new Date(ts).getTime() / 1000);
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
+function extractTarget(toolName: string, input: Record<string, unknown>): string {
+  if (toolName === "Read" || toolName === "Write" || toolName === "Edit") {
+    return String(input.file_path ?? "unknown").slice(0, 100);
+  }
+  if (toolName === "Bash") {
+    return String(input.command ?? "")
+      .split("\n")[0]
+      .slice(0, 100);
+  }
+  if (toolName === "Grep") {
+    return String(input.pattern ?? "").slice(0, 50);
+  }
+  if (toolName === "Agent") {
+    return String(input.description ?? "").slice(0, 50);
+  }
+  if (toolName === "Skill") {
+    return String(input.skill ?? "");
+  }
+  if (toolName === "Glob") {
+    return String(input.pattern ?? "");
+  }
+  return toolName;
+}

--- a/src/scanner/daemon-entry.ts
+++ b/src/scanner/daemon-entry.ts
@@ -24,6 +24,8 @@ async function main(): Promise<void> {
     pidPath: join(DAEMON_DIR, "daemon.pid"),
     registryPath: join(CONFIG_DIR, "session-registry.json"),
     codexBindingRegistryPath: join(CONFIG_DIR, "codex-binding-registry.json"),
+    activityLogDir: join(CONFIG_DIR, "activity-log"),
+    activityRetentionDays: config.performance.activityRetentionDays,
   });
 }
 

--- a/src/scanner/daemon-loop.ts
+++ b/src/scanner/daemon-loop.ts
@@ -3,8 +3,17 @@
  * Reuses watch/dock pattern: light scan every intervalMs, full every detailIntervalMs.
  */
 
-import { unlink } from "node:fs/promises";
+import { open, readdir, stat, unlink } from "node:fs/promises";
+import { join } from "node:path";
 import type { MarmonitorConfig } from "../config/index.js";
+import {
+  type ActivityEntry,
+  appendActivityEntries,
+  cleanupOldActivityLogs,
+  extractClaudeToolUses,
+  extractCodexToolUses,
+  formatDateKey,
+} from "./activity-log.js";
 import {
   type CodexBindingRegistry,
   loadCodexBindingRegistryFromFile,
@@ -29,6 +38,8 @@ export interface DaemonOptions {
   pidPath: string;
   registryPath: string;
   codexBindingRegistryPath: string;
+  activityLogDir: string;
+  activityRetentionDays: number;
 }
 
 function sleep(ms: number): Promise<void> {
@@ -46,7 +57,13 @@ export async function runDaemonLoop(
     pidPath,
     registryPath,
     codexBindingRegistryPath,
+    activityLogDir,
+    activityRetentionDays,
   } = options;
+
+  // Activity log: per-session JSONL cursor offsets (in-memory only)
+  const activityCursors = new Map<string, number>();
+  let lastActivityCleanupAt = 0;
 
   await writeDaemonPid(pidPath, process.pid);
 
@@ -111,6 +128,86 @@ export async function runDaemonLoop(
         await saveRegistryToFile(registryPath, registry);
         pruneCodexBindingRegistry(codexBindingRegistry, 7);
         await saveCodexBindingRegistryToFile(codexBindingRegistryPath, codexBindingRegistry);
+
+        // Collect activity from session JSONLs (incremental cursor)
+        const today = formatDateKey(new Date(now));
+        const allEntries: ActivityEntry[] = [];
+
+        for (const agent of agents) {
+          if (!agent.sessionId) continue;
+          // Find JSONL path from enrichment cache or registry
+          const jsonlPath =
+            agent.agentName === "Codex"
+              ? codexBindingRegistry.get(`${agent.pid}:${agent.processStartedAt ?? 0}`)?.rolloutPath
+              : undefined;
+
+          // Claude: construct path from sessionId
+          let sessionFile: string | undefined;
+          if (agent.agentName === "Claude Code" && agent.sessionId && agent.cwd) {
+            const { getClaudeSessionRoots } = await import("./claude.js");
+            const roots = getClaudeSessionRoots(config);
+            for (const root of roots) {
+              try {
+                const dirs = await readdir(root);
+                for (const dir of dirs) {
+                  const candidate = join(root, dir, `${agent.sessionId}.jsonl`);
+                  try {
+                    await stat(candidate);
+                    sessionFile = candidate;
+                    break;
+                  } catch {
+                    // not here
+                  }
+                }
+                if (sessionFile) break;
+              } catch {
+                // root doesn't exist
+              }
+            }
+          } else if (agent.agentName === "Codex" && jsonlPath) {
+            sessionFile = jsonlPath;
+          }
+
+          if (!sessionFile) continue;
+
+          const cursorKey = sessionFile;
+          const prevOffset = activityCursors.get(cursorKey) ?? 0;
+
+          try {
+            const fileStat = await stat(sessionFile);
+            if (fileStat.size <= prevOffset) continue;
+
+            const fd = await open(sessionFile, "r");
+            try {
+              const buf = Buffer.alloc(fileStat.size - prevOffset);
+              await fd.read(buf, 0, buf.length, prevOffset);
+              const chunk = buf.toString("utf-8");
+              const lines = chunk.split("\n").filter(Boolean);
+
+              const entries =
+                agent.agentName === "Codex"
+                  ? extractCodexToolUses(lines, agent.sessionId, agent.agentName, agent.cwd)
+                  : extractClaudeToolUses(lines, agent.sessionId, agent.agentName, agent.cwd);
+
+              allEntries.push(...entries);
+              activityCursors.set(cursorKey, fileStat.size);
+            } finally {
+              await fd.close();
+            }
+          } catch {
+            // JSONL read failure — skip this session
+          }
+        }
+
+        if (allEntries.length > 0) {
+          await appendActivityEntries(activityLogDir, today, allEntries);
+        }
+
+        // Cleanup old activity logs (once per day)
+        if (now - lastActivityCleanupAt > 86400000) {
+          await cleanupOldActivityLogs(activityLogDir, activityRetentionDays);
+          lastActivityCleanupAt = now;
+        }
       }
     } catch (err) {
       // scan failures must never crash the daemon

--- a/tests/activity-log.test.mjs
+++ b/tests/activity-log.test.mjs
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import {
+  appendActivityEntries,
+  cleanupOldActivityLogs,
+  extractClaudeToolUses,
+  extractCodexToolUses,
+  formatDateKey,
+  getRecentDateKeys,
+  readActivityLog,
+} from "../dist/scanner/activity-log.js";
+
+describe("activity log", () => {
+  it("extracts Claude tool_use from assistant JSONL lines", () => {
+    const lines = [
+      JSON.stringify({
+        type: "assistant",
+        timestamp: "2026-04-03T10:00:00Z",
+        message: {
+          usage: { input_tokens: 1, output_tokens: 73, cache_read_input_tokens: 1000 },
+          content: [
+            { type: "tool_use", name: "Edit", input: { file_path: "/projects/test/src/cli.ts" } },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        timestamp: "2026-04-03T10:01:00Z",
+        message: {
+          usage: { input_tokens: 2, output_tokens: 50, cache_read_input_tokens: 500 },
+          content: [
+            { type: "tool_use", name: "Bash", input: { command: "npm test\nsome output" } },
+          ],
+        },
+      }),
+      JSON.stringify({ type: "user", message: "hello" }),
+    ];
+
+    const entries = extractClaudeToolUses(lines, "abc123", "Claude Code", "/projects/test");
+    assert.equal(entries.length, 2);
+    assert.equal(entries[0].tool, "Edit");
+    assert.equal(entries[0].target, "/projects/test/src/cli.ts");
+    assert.equal(entries[0].tokens.out, 73);
+    assert.equal(entries[1].tool, "Bash");
+    assert.equal(entries[1].target, "npm test");
+  });
+
+  it("extracts Codex tool events from event_msg lines", () => {
+    const lines = [
+      JSON.stringify({
+        type: "event_msg",
+        timestamp: "2026-04-03T10:00:00Z",
+        payload: {
+          type: "exec_command_end",
+          command: ["/bin/zsh", "-lc", "git status --short"],
+          cwd: "/projects/test",
+        },
+      }),
+      JSON.stringify({
+        type: "event_msg",
+        timestamp: "2026-04-03T10:01:00Z",
+        payload: {
+          type: "patch_apply_end",
+          stdout: "Success. Updated the following files:\nM /projects/test/src/utils.ts\n",
+        },
+      }),
+      JSON.stringify({
+        type: "event_msg",
+        timestamp: "2026-04-03T10:02:00Z",
+        payload: {
+          type: "token_count",
+          info: {
+            last_token_usage: { input_tokens: 100, output_tokens: 50, cached_input_tokens: 200 },
+          },
+        },
+      }),
+    ];
+
+    const entries = extractCodexToolUses(lines, "019d1f7f", "Codex", "/projects/test");
+    assert.equal(entries.length, 2);
+    assert.equal(entries[0].tool, "Bash");
+    assert.equal(entries[0].target, "git status --short");
+    assert.equal(entries[1].tool, "Edit");
+    assert.ok(entries[1].target.includes("utils.ts"));
+  });
+
+  it("appends entries to daily log file and reads them back", async () => {
+    const dir = await mkdir(join(tmpdir(), `marmonitor-activity-test-${Date.now()}`), {
+      recursive: true,
+    });
+    try {
+      const entries = [
+        {
+          ts: 1775190000,
+          sid: "abc123",
+          agent: "Claude Code",
+          cwd: "/test",
+          tool: "Edit",
+          target: "src/cli.ts",
+          tokens: { in: 1, out: 73, cache: 1000 },
+        },
+        {
+          ts: 1775190005,
+          sid: "abc123",
+          agent: "Claude Code",
+          cwd: "/test",
+          tool: "Bash",
+          target: "npm test",
+          tokens: { in: 2, out: 50, cache: 500 },
+        },
+      ];
+      await appendActivityEntries(dir, "2026-04-03", entries);
+
+      const loaded = await readActivityLog(dir, "2026-04-03");
+      assert.equal(loaded.length, 2);
+      assert.equal(loaded[0].tool, "Edit");
+      assert.equal(loaded[1].tool, "Bash");
+
+      // Append more
+      await appendActivityEntries(dir, "2026-04-03", [
+        {
+          ts: 1775190010,
+          sid: "def456",
+          agent: "Codex",
+          cwd: "/other",
+          tool: "Bash",
+          target: "git status",
+        },
+      ]);
+
+      const all = await readActivityLog(dir, "2026-04-03");
+      assert.equal(all.length, 3);
+    } finally {
+      await rm(dir, { recursive: true });
+    }
+  });
+
+  it("cleans up activity logs older than retention days", async () => {
+    const dir = await mkdir(join(tmpdir(), `marmonitor-activity-cleanup-${Date.now()}`), {
+      recursive: true,
+    });
+    try {
+      await writeFile(join(dir, "2026-03-20.jsonl"), "{}\n");
+      await writeFile(join(dir, "2026-03-25.jsonl"), "{}\n");
+      await writeFile(join(dir, "2026-04-03.jsonl"), "{}\n");
+
+      const deleted = await cleanupOldActivityLogs(dir, 7, new Date("2026-04-03"));
+      assert.equal(deleted, 2);
+
+      const remaining = await readActivityLog(dir, "2026-04-03");
+      assert.equal(remaining.length, 1);
+    } finally {
+      await rm(dir, { recursive: true });
+    }
+  });
+
+  it("does not delete cutoff-day file when called mid-day", async () => {
+    const dir = await mkdir(join(tmpdir(), `marmonitor-activity-boundary-${Date.now()}`), {
+      recursive: true,
+    });
+    try {
+      await writeFile(join(dir, "2026-03-27.jsonl"), "{}\n");
+      await writeFile(join(dir, "2026-03-28.jsonl"), "{}\n");
+      await writeFile(join(dir, "2026-04-03.jsonl"), "{}\n");
+
+      // 7 days from Apr 3 23:59 = Mar 27 23:59 cutoff
+      // Mar 27 should be kept (cutoff day itself), Mar 26 and older should be deleted
+      const deleted = await cleanupOldActivityLogs(dir, 7, new Date("2026-04-03T23:59:00"));
+      assert.equal(deleted, 0); // Mar 27 and later should all be kept
+    } finally {
+      await rm(dir, { recursive: true });
+    }
+  });
+
+  it("formats date keys using local calendar date", () => {
+    const date = new Date(2026, 3, 3, 23, 59, 0);
+    assert.equal(formatDateKey(date), "2026-04-03");
+  });
+
+  it("returns recent local date keys in descending order", () => {
+    const keys = getRecentDateKeys(3, new Date(2026, 3, 3, 23, 59, 0));
+    assert.deepEqual(keys, ["2026-04-03", "2026-04-02", "2026-04-01"]);
+  });
+});

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -1,21 +1,25 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { describe, it } from "node:test";
 import { fileURLToPath } from "node:url";
 import { renderJumpAttentionChooser } from "../dist/output/index.js";
+import { formatDateKey } from "../dist/scanner/activity-log.js";
 import { parseSelectionInput, selectJumpAttentionItemOnPage } from "../dist/output/utils.js";
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 const cliPath = join(repoRoot, "bin", "marmonitor.js");
 
-function runCli(args) {
+function runCli(args, envOverrides = {}) {
   return execFileSync("node", [cliPath, ...args], {
     cwd: repoRoot,
     encoding: "utf8",
     env: {
       ...process.env,
       TERM_PROGRAM: "Ghostty",
+      ...envOverrides,
     },
   });
 }
@@ -62,6 +66,50 @@ describe("config CLI helpers", () => {
     assert.match(output, /done/);
     assert.match(output, /Active/);
     assert.match(output, /Stalled/);
+  });
+
+  it("shows no activity when no local activity log exists", async () => {
+    const xdgRoot = await mkdir(join(tmpdir(), `marmonitor-cli-empty-${Date.now()}`), {
+      recursive: true,
+    });
+    try {
+      const output = runCli(["activity"], { XDG_CONFIG_HOME: xdgRoot });
+      assert.match(output, /No activity found\./);
+    } finally {
+      await rm(xdgRoot, { recursive: true });
+    }
+  });
+
+  it("prints activity log entries as json", async () => {
+    const xdgRoot = await mkdir(join(tmpdir(), `marmonitor-cli-activity-${Date.now()}`), {
+      recursive: true,
+    });
+    try {
+      const logDir = join(xdgRoot, "marmonitor", "activity-log");
+      await mkdir(logDir, { recursive: true });
+      const today = formatDateKey(new Date());
+      await writeFile(
+        join(logDir, `${today}.jsonl`),
+        `${JSON.stringify({
+          ts: 1775190000,
+          sid: "abc123456789",
+          agent: "Claude Code",
+          cwd: "/tmp/project",
+          tool: "Edit",
+          target: "src/cli.ts",
+          tokens: { in: 1, out: 73, cache: 1000 },
+        })}\n`,
+        "utf8",
+      );
+
+      const output = runCli(["activity", "--json"], { XDG_CONFIG_HOME: xdgRoot });
+      const parsed = JSON.parse(output);
+      assert.equal(parsed.length, 1);
+      assert.equal(parsed[0].tool, "Edit");
+      assert.equal(parsed[0].target, "src/cli.ts");
+    } finally {
+      await rm(xdgRoot, { recursive: true });
+    }
   });
 });
 

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -6,8 +6,8 @@ import { dirname, join } from "node:path";
 import { describe, it } from "node:test";
 import { fileURLToPath } from "node:url";
 import { renderJumpAttentionChooser } from "../dist/output/index.js";
-import { formatDateKey } from "../dist/scanner/activity-log.js";
 import { parseSelectionInput, selectJumpAttentionItemOnPage } from "../dist/output/utils.js";
+import { formatDateKey } from "../dist/scanner/activity-log.js";
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 const cliPath = join(repoRoot, "bin", "marmonitor.js");


### PR DESCRIPTION
## Summary

Resolve #27

Add daemon-backed session activity logging for Claude/Codex and expose it through a new `marmonitor activity` CLI.

## 한국어 요약

Claude/Codex 세션 JSONL에서 작업 이력을 증분 수집해 날짜별 activity log로 저장하고, 이를 조회하는 `marmonitor activity` 명령을 추가했습니다.

주요 변경:
- daemon full scan에서 세션 activity를 증분 수집
- `~/.config/marmonitor/activity-log/YYYY-MM-DD.jsonl` 날짜별 로그 저장
- `marmonitor activity --pid/--session/--days/--json` 명령 추가
- Codex activity lookup을 binding registry의 `processStartedAt` 기준으로 보정
- 날짜 버킷을 UTC 고정이 아니라 시스템 로컬 날짜 기준으로 정리
- 긴 target은 텍스트 출력에서만 `...`로 축약

## Type

- [x] `[FEAT]` New feature
- [ ] `[BUG]` Bug fix
- [ ] `[HOTFIX]` Urgent fix
- [ ] `[PERF]` Performance improvement
- [ ] `[REFACTOR]` Code restructuring
- [ ] `[DOCS]` Documentation
- [ ] `[TEST]` Test coverage
- [ ] `[CICD]` CI/CD or release
- [ ] `[CHORE]` Maintenance

## Changes

- add `src/scanner/activity-log.ts` for Claude/Codex activity extraction and daily JSONL storage
- collect incremental activity during daemon heavy scans
- add `marmonitor activity` CLI with `--pid`, `--session`, `--days`, `--json`
- use local calendar date for activity log file bucketing while keeping event timestamps as epoch
- fix Codex activity lookup to use binding registry `processStartedAt` key
- add CLI/activity coverage and local-date retention tests
- apply text-only ellipsis truncation for long activity targets

## Checklist

- [x] `npm run build` passes
- [ ] `npm run lint` passes
- [x] `npm test` passes (all tests green)
- [x] New features have tests
- [ ] README updated (if user-facing changes)
- [x] No hardcoded paths or environment-specific values

## Testing

- `npm run build`
- `npm test`
- manual check:
  - `node bin/marmonitor.js activity`
  - `node bin/marmonitor.js activity --days 3`
  - `node bin/marmonitor.js activity --pid <PID>`
  - `node bin/marmonitor.js activity --json`

## Risk

Medium. This adds daemon-side file reads and local activity persistence, so regressions would mainly affect activity collection volume, log retention boundaries, or Codex lookup correctness.
