### PR TITLE
[BUG] #28 Fix Codex binding key mismatch in foreground paths

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -779,10 +779,27 @@ program
       sessionLastActivityAt = gemini.lastActivityAt;
       sessionLastResponseAt = gemini.lastResponseAt;
     } else if (agent.agentName === "Codex") {
+      const { loadCodexBindingRegistryFromFile, selectCodexBindingSession, buildCodexBindingKey } =
+        await import("./scanner/codex-binding-registry.js");
+      const { getConfigDir } = await import("./config/index.js");
+      const { join: pj } = await import("node:path");
       const codexSessions = await indexCodexSessions(config, { activeCwds: [agent.cwd] });
-      const matched = matchCodexSession(agent.cwd, agent.startedAt, codexSessions);
+      const bindingRegistry = new Map();
+      await loadCodexBindingRegistryFromFile(
+        pj(getConfigDir(), "codex-binding-registry.json"),
+        bindingRegistry,
+      );
+      const matched =
+        selectCodexBindingSession(
+          bindingRegistry,
+          agent.pid,
+          agent.processStartedAt,
+          agent.cwd,
+          codexSessions,
+        ) ?? matchCodexSession(agent.cwd, agent.processStartedAt, codexSessions);
       sessionPhase = await detectCodexPhase(matched?.filePath, config);
       sessionSourceFile = matched?.filePath;
+      sessionLastActivityAt = matched?.lastActivityAt;
     } else if (agent.agentName === "Claude Code" && agent.sessionId) {
       const phaseResult = await detectClaudePhase(
         agent.sessionId,
@@ -832,7 +849,7 @@ program
         pj(getConfigDir(), "codex-binding-registry.json"),
         bindingRegistry,
       );
-      const binding = bindingRegistry.get(buildCodexBindingKey(agent.pid, agent.startedAt));
+      const binding = bindingRegistry.get(buildCodexBindingKey(agent.pid, agent.processStartedAt));
       if (binding) {
         payload.codexBinding = {
           threadId: binding.threadId,

--- a/tests/codex-binding-registry.test.mjs
+++ b/tests/codex-binding-registry.test.mjs
@@ -128,6 +128,51 @@ describe("codex binding registry", () => {
     assert.equal(matched?.id, "019d1f7f");
   });
 
+  it("requires processStartedAt rather than thread timestamp for registry reuse", () => {
+    const registry = new Map([
+      [
+        "19077:1775000000",
+        {
+          pid: 19077,
+          processStartedAt: 1775000000,
+          cwd: "/Users/macrent/.ai/projects/mjjo",
+          threadId: "019d1f7f",
+          rolloutPath: "/tmp/rollout.jsonl",
+          lastVerifiedAt: 1775180138,
+          confidence: "high",
+          unstableCount: 0,
+        },
+      ],
+    ]);
+
+    const sessions = [
+      {
+        id: "019d1f7f",
+        cwd: "/Users/macrent/.ai/projects/mjjo",
+        filePath: "/tmp/rollout.jsonl",
+        timestamp: 1774349925,
+      },
+    ];
+
+    const wrong = selectCodexBindingSession(
+      registry,
+      19077,
+      1774349925,
+      "/Users/macrent/.ai/projects/mjjo",
+      sessions,
+    );
+    const correct = selectCodexBindingSession(
+      registry,
+      19077,
+      1775000000,
+      "/Users/macrent/.ai/projects/mjjo",
+      sessions,
+    );
+
+    assert.equal(wrong, undefined);
+    assert.equal(correct?.id, "019d1f7f");
+  });
+
   it("marks missing bindings dead and updates the existing binding in place", () => {
     const registry = new Map();
     upsertCodexBindingRecord(registry, {


### PR DESCRIPTION
## Summary

Resolve #28

Fix Codex binding lookups so foreground/debug paths use the same `pid + processStartedAt` key as the daemon registry.

## 한국어 요약

Codex binding registry의 canonical key가 `pid + processStartedAt`인데, 일부 foreground/debug 경로는 `startedAt`를 사용하고 있었습니다.

이번 수정으로:
- `debug-phase`의 Codex 경로가 registry를 먼저 재사용
- fallback match도 `processStartedAt` 기준으로 통일
- binding diagnostics lookup도 `processStartedAt` 기준으로 수정
- thread timestamp와 process start time을 혼동하지 않도록 회귀 테스트 추가

## Type

- [ ] `[FEAT]` New feature
- [x] `[BUG]` Bug fix
- [ ] `[HOTFIX]` Urgent fix
- [ ] `[PERF]` Performance improvement
- [ ] `[REFACTOR]` Code restructuring
- [ ] `[DOCS]` Documentation
- [ ] `[TEST]` Test coverage
- [ ] `[CICD]` CI/CD or release
- [ ] `[CHORE]` Maintenance

## Changes

- make Codex `debug-phase` reuse the binding registry before fallback matching
- switch foreground Codex fallback matching from `startedAt` to `processStartedAt`
- switch binding diagnostics lookup from `startedAt` to `processStartedAt`
- add regression coverage proving registry reuse must key on process start time, not thread timestamp

## Checklist

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (all tests green)
- [x] New features have tests
- [ ] README updated (if user-facing changes)
- [x] No hardcoded paths or environment-specific values

## Testing

- `npm run build`
- `npm test`
- `npm run lint`
- manual check:
  - `node bin/marmonitor.js debug-phase --pid <codex-pid> --json`
  - compare registry-backed diagnostics before/after with same-cwd long-lived Codex sessions

## Risk

Low to medium. Scope is limited to Codex binding selection in foreground/debug paths, but regressions here could affect `debug-phase` diagnostics and Codex thread selection consistency.
