### PR TITLE
[BUG] #31 Stabilize session continuity and Codex activity freshness

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -42,6 +42,7 @@ import { detectCodexPhase, indexCodexSessions, matchCodexSession } from "./scann
 import { isDaemonRunning, readDaemonPid, readDaemonSnapshot } from "./scanner/daemon-utils.js";
 import { parseGeminiSession } from "./scanner/gemini.js";
 import { scanAgents } from "./scanner/index.js";
+import { loadRegistryFromFile } from "./scanner/session-registry.js";
 import { detectCliStdoutPhase } from "./scanner/status.js";
 import { captureTmuxPaneOutput, jumpToAgent, resolveTmuxJumpTarget } from "./tmux/index.js";
 import { getClientTty, jumpBack } from "./tmux/jump-anchor.js";
@@ -523,6 +524,14 @@ async function requireDaemonSnapshot(): Promise<AgentSession[]> {
   return agents;
 }
 
+async function loadSessionRegistry(): Promise<
+  Map<string, import("./scanner/session-registry.js").SessionRegistryRecord>
+> {
+  const registry = new Map<string, import("./scanner/session-registry.js").SessionRegistryRecord>();
+  await loadRegistryFromFile(join(getConfigDir(), "session-registry.json"), registry);
+  return registry;
+}
+
 program
   .option("--statusline", "One-line summary for tmux statusbar")
   .option(
@@ -736,7 +745,10 @@ program
 
     let agents: AgentSession[];
     try {
-      agents = await scanAgents(config, { enrichmentMode: "full" });
+      agents = await scanAgents(config, {
+        enrichmentMode: "full",
+        sessionRegistry: await loadSessionRegistry(),
+      });
     } catch (error) {
       const payload = {
         found: false,
@@ -1195,7 +1207,7 @@ program
   .option("--pid <pid...>", "Only include specific unmatched PID(s)")
   .action(async (opts) => {
     const config = await loadConfig(resolveConfigPath(opts));
-    const agents = await scanAgents(config);
+    const agents = await scanAgents(config, { sessionRegistry: await loadSessionRegistry() });
     const selectedPids = Array.isArray(opts.pid)
       ? opts.pid
           .map((value: string) => Number.parseInt(value, 10))

--- a/src/output/utils.ts
+++ b/src/output/utils.ts
@@ -481,10 +481,13 @@ export function buildAttentionItems(
   agents: AgentSession[],
   nowSec = Date.now() / 1000,
 ): AttentionItem[] {
-  const alive = agents.filter(
-    (agent) =>
-      agent.status !== "Dead" && agent.status !== "Unmatched" && agent.status !== "Stalled",
-  );
+  const alive = agents.filter((agent) => {
+    const kind = attentionKind(agent);
+    if (kind === "permission" || kind === "thinking" || kind === "tool") {
+      return true;
+    }
+    return agent.status !== "Dead" && agent.status !== "Unmatched" && agent.status !== "Stalled";
+  });
 
   const toAttentionItem = (
     agent: AgentSession,

--- a/src/scanner/cache.ts
+++ b/src/scanner/cache.ts
@@ -18,6 +18,7 @@ export const CLAUDE_SESSION_AMBIGUITY_GAP_SEC = 300;
 export const CLAUDE_PHASE_RECENT_LINES = 50;
 export const CODEX_PHASE_RECENT_LINES = 30;
 export const RECENT_ACTIVITY_ACTIVE_SEC = 180;
+export const STATUS_HYSTERESIS_SEC = 30;
 
 // ─── Cache Entry Types ─────────────────────────────────────────────
 

--- a/src/scanner/codex-binding-registry.ts
+++ b/src/scanner/codex-binding-registry.ts
@@ -5,7 +5,6 @@
 
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
-import type { SessionPhase } from "../types.js";
 import type { CodexSessionMeta } from "./cache.js";
 
 export interface CodexBindingRecord {
@@ -14,10 +13,6 @@ export interface CodexBindingRecord {
   cwd: string;
   threadId: string;
   rolloutPath: string;
-  threadCreatedAt?: number;
-  threadUpdatedAt?: number;
-  lastActivityAt?: number;
-  lastPhase?: SessionPhase;
   lastVerifiedAt: number;
   confidence: "high" | "medium" | "low";
   unstableCount: number;
@@ -57,11 +52,10 @@ export function upsertCodexBindingRecord(
     processStartedAt?: number;
     cwd: string;
     matched: CodexSessionMeta;
-    phase?: SessionPhase;
     confidence?: CodexBindingRecord["confidence"];
   },
 ): void {
-  const { pid, processStartedAt, cwd, matched, phase, confidence = "high" } = params;
+  const { pid, processStartedAt, cwd, matched, confidence = "high" } = params;
   const key = buildCodexBindingKey(pid, processStartedAt);
   const previous = registry.get(key);
   const now = Math.floor(Date.now() / 1000);
@@ -75,10 +69,6 @@ export function upsertCodexBindingRecord(
     cwd,
     threadId: matched.id,
     rolloutPath: matched.filePath,
-    threadCreatedAt: matched.timestamp,
-    threadUpdatedAt: matched.lastActivityAt,
-    lastActivityAt: matched.lastActivityAt,
-    lastPhase: phase,
     lastVerifiedAt: now,
     confidence,
     unstableCount: isChanged ? (previous?.unstableCount ?? 0) + 1 : (previous?.unstableCount ?? 0),

--- a/src/scanner/daemon-loop.ts
+++ b/src/scanner/daemon-loop.ts
@@ -113,10 +113,11 @@ export async function runDaemonLoop(
       const agents = await scanAgents(config, {
         enrichmentMode,
         codexBindingRegistry,
+        sessionRegistry: registry,
       });
       if (needsHeavy) lastHeavyAt = now;
 
-      // Update session registry
+      // Update session registry with lightweight agent metadata every scan.
       updateRegistry(registry, agents);
 
       // Write snapshot for statusline consumers
@@ -132,6 +133,7 @@ export async function runDaemonLoop(
         // Collect activity from session JSONLs (incremental cursor)
         const today = formatDateKey(new Date(now));
         const allEntries: ActivityEntry[] = [];
+        const registryUpdates = [];
 
         for (const agent of agents) {
           if (!agent.sessionId) continue;
@@ -169,6 +171,17 @@ export async function runDaemonLoop(
           }
 
           if (!sessionFile) continue;
+          registryUpdates.push({
+            agentName: agent.agentName,
+            pid: agent.pid,
+            sessionId: agent.sessionId,
+            cwd: agent.cwd,
+            startedAt: agent.startedAt,
+            tokenUsage: agent.tokenUsage,
+            lastActivityAt: agent.lastActivityAt,
+            model: agent.model,
+            jsonlPath: sessionFile,
+          });
 
           const cursorKey = sessionFile;
           const prevOffset = activityCursors.get(cursorKey) ?? 0;
@@ -201,6 +214,9 @@ export async function runDaemonLoop(
 
         if (allEntries.length > 0) {
           await appendActivityEntries(activityLogDir, today, allEntries);
+        }
+        if (registryUpdates.length > 0) {
+          updateRegistry(registry, registryUpdates);
         }
 
         // Cleanup old activity logs (once per day)

--- a/src/scanner/index.ts
+++ b/src/scanner/index.ts
@@ -48,7 +48,12 @@ import {
   getProcessStartTime,
 } from "./process.js";
 import { classifySessionTier } from "./session-tier.js";
-import { detectCliStdoutPhase, determineStatus } from "./status.js";
+import {
+  applyStatusHysteresis,
+  detectCliStdoutPhase,
+  determineStatus,
+  refreshLastActivityAt,
+} from "./status.js";
 
 import type { ScanOptions } from "./types.js";
 
@@ -62,6 +67,7 @@ export async function scanAgents(
   const enrichmentMode = options.enrichmentMode ?? "full";
   const isFullEnrichment = enrichmentMode === "full";
   const codexBindingRegistry = options.codexBindingRegistry;
+  const sessionRegistry = options.sessionRegistry;
   const seenPids = new Set<number>();
 
   perfStart("scanAgents");
@@ -229,7 +235,8 @@ export async function scanAgents(
         sessionMatched = true;
         sessionId = matched.id;
         startedAt = matched.timestamp;
-        lastActivityAt = matched.lastActivityAt;
+        lastActivityAt =
+          Math.max(cachedEnrichment?.lastActivityAt ?? 0, matched.lastActivityAt ?? 0) || undefined;
         model = matched.model;
         codexSessionFile = matched.filePath;
         if (matched.totalTokenUsage) {
@@ -255,9 +262,18 @@ export async function scanAgents(
           processStartedAt,
           cwd,
           matched,
-          phase,
         });
       }
+
+      lastActivityAt = refreshLastActivityAt(
+        lastActivityAt,
+        cpuPercent,
+        phase,
+        config.status.activeCpuThreshold,
+        agentName,
+      );
+      lastActivityAt =
+        Math.max(cachedEnrichment?.lastActivityAt ?? 0, lastActivityAt ?? 0) || undefined;
     } else if (agentName === "Gemini") {
       cwd = cachedEnrichment?.cwd ?? (await getProcessCwd(proc.pid)) ?? "unknown";
       const geminiData = await parseGeminiSession(cwd);
@@ -274,13 +290,32 @@ export async function scanAgents(
       }
     }
 
+    if (sessionId && sessionRegistry?.has(sessionId)) {
+      const persistedLastActivityAt = sessionRegistry.get(sessionId)?.lastActivityAt;
+      lastActivityAt = Math.max(lastActivityAt ?? 0, persistedLastActivityAt ?? 0) || undefined;
+    }
+
     if (cwd === "unknown" && isFullEnrichment) {
       cwd = cachedEnrichment?.cwd ?? (await getProcessCwd(proc.pid)) ?? "unknown";
     }
 
     const statusBaseAt = lastActivityAt ?? lastResponseAt ?? startedAt;
     const elapsed = statusBaseAt ? Date.now() / 1000 - statusBaseAt : undefined;
-    const status = determineStatus(cpuPercent, elapsed, sessionMatched, phase, config, agentName);
+    const rawStatus = determineStatus(
+      cpuPercent,
+      elapsed,
+      sessionMatched,
+      phase,
+      config,
+      agentName,
+    );
+    const status = applyStatusHysteresis(
+      rawStatus,
+      cachedEnrichment?.status as AgentSession["status"] | undefined,
+      elapsed,
+      phase,
+      agentName,
+    );
 
     const session = {
       agentName,
@@ -311,6 +346,7 @@ export async function scanAgents(
         tokenUsage: session.tokenUsage,
         model: session.model,
         sessionMatched: session.sessionMatched,
+        status: session.status,
         phase: session.phase,
         lastResponseAt: session.lastResponseAt,
         lastActivityAt: session.lastActivityAt,

--- a/src/scanner/session-registry.ts
+++ b/src/scanner/session-registry.ts
@@ -26,34 +26,47 @@ export interface SessionRegistryRecord {
   model?: string;
 }
 
+export interface SessionRegistryUpdate extends Partial<AgentSession> {
+  jsonlPath?: string;
+}
+
 export function updateRegistry(
   registry: Map<string, SessionRegistryRecord>,
-  agents: Partial<AgentSession>[],
+  agents: SessionRegistryUpdate[],
 ): void {
   for (const agent of agents) {
     if (!agent.sessionId) continue;
 
     const existing = registry.get(agent.sessionId);
     if (existing) {
-      // Check if PID changed (resume)
       const lastEntry = existing.history[existing.history.length - 1];
-      if (lastEntry && lastEntry.pid !== agent.pid) {
-        // Mark previous as ended
+      const nextPid = agent.pid ?? 0;
+      const nextStartedAt = agent.startedAt ?? Math.floor(Date.now() / 1000);
+      const nextJsonlPath = agent.jsonlPath;
+      const pidChanged = Boolean(lastEntry && lastEntry.pid !== nextPid);
+      const jsonlChanged = Boolean(
+        lastEntry && nextJsonlPath && lastEntry.jsonlPath && lastEntry.jsonlPath !== nextJsonlPath,
+      );
+
+      if (lastEntry && (pidChanged || jsonlChanged)) {
         if (!lastEntry.endedAt) lastEntry.endedAt = Math.floor(Date.now() / 1000);
-        // Add new PID to history
         existing.history.push({
-          pid: agent.pid ?? 0,
-          startedAt: agent.startedAt ?? Math.floor(Date.now() / 1000),
+          pid: nextPid,
+          jsonlPath: nextJsonlPath,
+          startedAt: nextStartedAt,
         });
+      } else if (lastEntry && nextJsonlPath && !lastEntry.jsonlPath) {
+        lastEntry.jsonlPath = nextJsonlPath;
       }
 
-      // Update token totals
       if (agent.tokenUsage) {
         existing.totalTokens.input = agent.tokenUsage.inputTokens ?? 0;
         existing.totalTokens.output = agent.tokenUsage.outputTokens ?? 0;
         existing.totalTokens.cache = agent.tokenUsage.cacheReadTokens ?? 0;
       }
-      if (agent.lastActivityAt) existing.lastActivityAt = agent.lastActivityAt;
+      if (agent.lastActivityAt) {
+        existing.lastActivityAt = Math.max(existing.lastActivityAt ?? 0, agent.lastActivityAt);
+      }
       if (agent.model) existing.model = agent.model;
       if (agent.cwd) existing.cwd = agent.cwd;
     } else {
@@ -65,6 +78,7 @@ export function updateRegistry(
         history: [
           {
             pid: agent.pid ?? 0,
+            jsonlPath: agent.jsonlPath,
             startedAt: agent.startedAt ?? Math.floor(Date.now() / 1000),
           },
         ],

--- a/src/scanner/status.ts
+++ b/src/scanner/status.ts
@@ -6,7 +6,31 @@ import type { MarmonitorConfig } from "../config/index.js";
 import { detectApprovalPromptPhase } from "../output/utils.js";
 import { captureTmuxPaneOutput, resolveTmuxJumpTarget } from "../tmux/index.js";
 import type { AgentSession, SessionPhase, SessionStatus } from "../types.js";
-import { RECENT_ACTIVITY_ACTIVE_SEC, stdoutHeuristicCache } from "./cache.js";
+import {
+  RECENT_ACTIVITY_ACTIVE_SEC,
+  STATUS_HYSTERESIS_SEC,
+  stdoutHeuristicCache,
+} from "./cache.js";
+
+export function refreshLastActivityAt(
+  lastActivityAt: number | undefined,
+  cpuPercent: number,
+  phase: SessionPhase | undefined,
+  activeCpuThreshold: number,
+  agentName: string | undefined,
+  nowSec = Math.floor(Date.now() / 1000),
+): number | undefined {
+  if (agentName !== "Codex") return lastActivityAt;
+  if (
+    cpuPercent > activeCpuThreshold ||
+    phase === "permission" ||
+    phase === "thinking" ||
+    phase === "tool"
+  ) {
+    return Math.max(lastActivityAt ?? 0, nowSec);
+  }
+  return lastActivityAt;
+}
 
 /** Determine agent activity status */
 export function determineStatus(
@@ -19,6 +43,8 @@ export function determineStatus(
 ): SessionStatus {
   // Zombie: process exists but no matching session
   if (!sessionMatched) return "Unmatched";
+
+  const stalledSec = config.status.stalledAfterMin * 60;
 
   // Active: CPU above threshold
   if (cpuPercent > config.status.activeCpuThreshold) return "Active";
@@ -41,13 +67,50 @@ export function determineStatus(
     return "Active";
   }
 
+  // Codex quiet sessions often hold a live rollout while CPU falls to 0%.
+  // Treat them as idle for a much longer window before escalating to stalled.
+  if (agentName === "Codex" && elapsedSec !== undefined && cpuPercent < 0.1) {
+    const codexStalledSec = Math.max(stalledSec, 24 * 60 * 60);
+    if (elapsedSec > codexStalledSec) return "Stalled";
+    return "Idle";
+  }
+
   // Stalled: idle for longer than configured threshold
-  const stalledSec = config.status.stalledAfterMin * 60;
   if (elapsedSec !== undefined && elapsedSec > stalledSec && cpuPercent < 0.1) {
     return "Stalled";
   }
 
   return "Idle";
+}
+
+export function applyStatusHysteresis(
+  nextStatus: SessionStatus,
+  previousStatus: SessionStatus | undefined,
+  elapsedSec: number | undefined,
+  phase: SessionPhase | undefined,
+  agentName: string | undefined,
+): SessionStatus {
+  if (!previousStatus || previousStatus === nextStatus) return nextStatus;
+  if (nextStatus === "Unmatched" || nextStatus === "Dead") return nextStatus;
+  if (previousStatus === "Unmatched" || previousStatus === "Dead") return nextStatus;
+
+  const hasLivePhase = phase === "permission" || phase === "thinking" || phase === "tool";
+  const hysteresisSec =
+    agentName === "Codex" ? Math.max(STATUS_HYSTERESIS_SEC, 60) : STATUS_HYSTERESIS_SEC;
+
+  if (previousStatus === "Active" && (nextStatus === "Idle" || nextStatus === "Stalled")) {
+    if (elapsedSec === undefined || elapsedSec <= hysteresisSec || hasLivePhase) {
+      return "Active";
+    }
+  }
+
+  if (previousStatus === "Idle" && nextStatus === "Stalled") {
+    if (elapsedSec === undefined || elapsedSec <= hysteresisSec * 2 || hasLivePhase) {
+      return "Idle";
+    }
+  }
+
+  return nextStatus;
 }
 
 export async function detectCliStdoutPhase(

--- a/src/scanner/types.ts
+++ b/src/scanner/types.ts
@@ -3,8 +3,10 @@
  */
 
 import type { CodexBindingRegistry } from "./codex-binding-registry.js";
+import type { SessionRegistryRecord } from "./session-registry.js";
 
 export interface ScanOptions {
   enrichmentMode?: "full" | "light";
   codexBindingRegistry?: CodexBindingRegistry;
+  sessionRegistry?: Map<string, SessionRegistryRecord>;
 }

--- a/tests/codex-binding-registry.test.mjs
+++ b/tests/codex-binding-registry.test.mjs
@@ -33,10 +33,6 @@ describe("codex binding registry", () => {
             cwd: "/Users/macrent/.ai/projects/mjjo",
             threadId: "019d1f7f",
             rolloutPath: "/tmp/rollout.jsonl",
-            threadCreatedAt: 1774349925,
-            threadUpdatedAt: 1775180138,
-            lastActivityAt: 1775180138,
-            lastPhase: "tool",
             lastVerifiedAt: 1775180138,
             confidence: "high",
             unstableCount: 0,
@@ -186,7 +182,6 @@ describe("codex binding registry", () => {
         timestamp: 1774349925,
         lastActivityAt: 1775180138,
       },
-      phase: "tool",
     });
 
     const updated = markMissingCodexBindingsDead(registry, new Set());

--- a/tests/scanner-status.test.mjs
+++ b/tests/scanner-status.test.mjs
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { getDefaults } from "../dist/config/index.js";
+import {
+  applyStatusHysteresis,
+  determineStatus,
+  refreshLastActivityAt,
+} from "../dist/scanner/status.js";
+
+describe("scanner status heuristics", () => {
+  it("refreshes Codex lastActivityAt when live signals exist", () => {
+    const now = 1775223000;
+    assert.equal(refreshLastActivityAt(1775194317, 2.5, "tool", 0.5, "Codex", now), now);
+    assert.equal(refreshLastActivityAt(1775194317, 0.0, "thinking", 0.5, "Codex", now), now);
+  });
+
+  it("does not refresh lastActivityAt for non-Codex sessions", () => {
+    assert.equal(
+      refreshLastActivityAt(1775194317, 2.5, "tool", 0.5, "Claude Code", 1775223000),
+      1775194317,
+    );
+  });
+
+  it("keeps quiet Codex sessions idle for longer before marking stalled", () => {
+    const config = getDefaults();
+    assert.equal(determineStatus(0.0, 7 * 60 * 60, true, undefined, config, "Codex"), "Idle");
+    assert.equal(determineStatus(0.0, 30 * 60 * 60, true, undefined, config, "Codex"), "Stalled");
+  });
+
+  it("keeps a recently active session from dropping immediately to idle", () => {
+    assert.equal(applyStatusHysteresis("Idle", "Active", 10, undefined, "Claude Code"), "Active");
+    assert.equal(applyStatusHysteresis("Stalled", "Active", 10, "thinking", "Codex"), "Active");
+  });
+
+  it("keeps idle sessions from dropping immediately to stalled", () => {
+    assert.equal(applyStatusHysteresis("Stalled", "Idle", 20, undefined, "Claude Code"), "Idle");
+    assert.equal(applyStatusHysteresis("Stalled", "Idle", 40, "tool", "Codex"), "Idle");
+    assert.equal(
+      applyStatusHysteresis("Stalled", "Idle", 120, undefined, "Claude Code"),
+      "Stalled",
+    );
+  });
+});

--- a/tests/session-registry.test.mjs
+++ b/tests/session-registry.test.mjs
@@ -36,6 +36,21 @@ describe("session registry", () => {
     assert.equal(entry.history[0].pid, 1234);
   });
 
+  it("stores jsonlPath on first insert when provided", () => {
+    const registry = new Map();
+    updateRegistry(registry, [
+      {
+        agentName: "Claude Code",
+        pid: 1234,
+        sessionId: "abc",
+        cwd: "/projects/test",
+        jsonlPath: "/projects/test/.claude/session.jsonl",
+        startedAt: 1774000000,
+      },
+    ]);
+    assert.equal(registry.get("abc").history[0].jsonlPath, "/projects/test/.claude/session.jsonl");
+  });
+
   it("appends to history when PID changes for same sessionId", () => {
     const registry = new Map();
     updateRegistry(registry, [
@@ -85,6 +100,61 @@ describe("session registry", () => {
     assert.equal(registry.get("abc").history.length, 1);
   });
 
+  it("fills missing jsonlPath without appending history", () => {
+    const registry = new Map();
+    updateRegistry(registry, [
+      {
+        agentName: "Claude Code",
+        pid: 1234,
+        sessionId: "abc",
+        cwd: "/projects/test",
+        startedAt: 1774000000,
+      },
+    ]);
+    updateRegistry(registry, [
+      {
+        agentName: "Claude Code",
+        pid: 1234,
+        sessionId: "abc",
+        cwd: "/projects/test",
+        jsonlPath: "/projects/test/.claude/session.jsonl",
+        startedAt: 1774000000,
+      },
+    ]);
+    const entry = registry.get("abc");
+    assert.equal(entry.history.length, 1);
+    assert.equal(entry.history[0].jsonlPath, "/projects/test/.claude/session.jsonl");
+  });
+
+  it("appends history when jsonlPath changes for the same PID", () => {
+    const registry = new Map();
+    updateRegistry(registry, [
+      {
+        agentName: "Claude Code",
+        pid: 1234,
+        sessionId: "abc",
+        cwd: "/projects/test",
+        jsonlPath: "/projects/test/.claude/session-1.jsonl",
+        startedAt: 1774000000,
+      },
+    ]);
+    updateRegistry(registry, [
+      {
+        agentName: "Claude Code",
+        pid: 1234,
+        sessionId: "abc",
+        cwd: "/projects/test",
+        jsonlPath: "/projects/test/.claude/session-2.jsonl",
+        startedAt: 1774003600,
+      },
+    ]);
+    const entry = registry.get("abc");
+    assert.equal(entry.history.length, 2);
+    assert.equal(entry.history[0].jsonlPath, "/projects/test/.claude/session-1.jsonl");
+    assert.equal(entry.history[1].jsonlPath, "/projects/test/.claude/session-2.jsonl");
+    assert.equal(entry.history[0].endedAt !== undefined, true);
+  });
+
   it("skips sessions without sessionId", () => {
     const registry = new Map();
     updateRegistry(registry, [{ agentName: "Claude Code", pid: 1234, cwd: "/projects/test" }]);
@@ -111,6 +181,31 @@ describe("session registry", () => {
     assert.equal(entry.totalTokens.input, 100);
     assert.equal(entry.totalTokens.output, 200);
     assert.equal(entry.totalTokens.cache, 50);
+  });
+
+  it("keeps the newer lastActivityAt when older updates arrive later", () => {
+    const registry = new Map();
+    updateRegistry(registry, [
+      {
+        agentName: "Codex",
+        pid: 71304,
+        sessionId: "019d1f7f",
+        cwd: "/repo",
+        startedAt: 1775204196,
+        lastActivityAt: 1775267514,
+      },
+    ]);
+    updateRegistry(registry, [
+      {
+        agentName: "Codex",
+        pid: 71304,
+        sessionId: "019d1f7f",
+        cwd: "/repo",
+        startedAt: 1775204196,
+        lastActivityAt: 1775194317,
+      },
+    ]);
+    assert.equal(registry.get("019d1f7f").lastActivityAt, 1775267514);
   });
 
   it("saves and loads registry from file", async () => {

--- a/tests/utils.test.mjs
+++ b/tests/utils.test.mjs
@@ -867,6 +867,52 @@ describe("buildAttentionItems", () => {
     );
   });
 
+  it("keeps stalled thinking/tool items visible in attention ordering", () => {
+    const now = 5_000;
+    const agents = [
+      {
+        pid: 10,
+        agentName: "Claude Code",
+        cwd: "/repo/stalled-thinking",
+        status: "Stalled",
+        phase: "thinking",
+        lastActivityAt: 4_200,
+      },
+      {
+        pid: 20,
+        agentName: "Codex",
+        cwd: "/repo/stalled-tool",
+        status: "Stalled",
+        phase: "tool",
+        lastActivityAt: 4_100,
+      },
+      {
+        pid: 30,
+        agentName: "Claude Code",
+        cwd: "/repo/idle",
+        status: "Idle",
+        lastActivityAt: 4_300,
+      },
+      {
+        pid: 40,
+        agentName: "Claude Code",
+        cwd: "/repo/stalled-done",
+        status: "Stalled",
+        phase: "done",
+        lastActivityAt: 4_400,
+      },
+    ];
+
+    assert.deepEqual(
+      buildAttentionItems(agents, now).map((item) => [item.kind, item.pid]),
+      [
+        ["active", 30],
+        ["thinking", 10],
+        ["tool", 20],
+      ],
+    );
+  });
+
   it("selects an attention item by 1-based index", () => {
     const agents = [
       { pid: 20, agentName: "Codex", cwd: "/repo/b", status: "Unmatched" },


### PR DESCRIPTION
## Summary

Resolve #31

Fix session continuity gaps in `session-registry.json` and stabilize Codex activity freshness/status handling across daemon and foreground scans.

## 한국어 요약

- `session-registry.json`에 `history[].jsonlPath`를 실제 기록하도록 수정했습니다.
- 같은 PID라도 JSONL source가 바뀌면 history transition으로 append 하도록 보강했습니다.
- Codex quiet session이 CPU 0%만으로 바로 `Stalled`로 흔들리지 않도록 hysteresis를 추가했습니다.
- `thinking/tool` 세션이 attention/statusline에서 쉽게 사라지지 않도록 보정했습니다.
- Codex `lastActivityAt`가 tool 종료 후 과거 rollout mtime으로 되돌아가지 않도록 `session-registry`의 최신값을 foreground/daemon scan 모두에서 재사용하도록 수정했습니다.
- `codex-binding-registry`는 관계 전용 메타만 유지하도록 정리했습니다.

## Type

- [ ] `[FEAT]` New feature
- [x] `[BUG]` Bug fix
- [ ] `[HOTFIX]` Urgent fix
- [ ] `[PERF]` Performance improvement
- [ ] `[REFACTOR]` Code restructuring
- [ ] `[DOCS]` Documentation
- [ ] `[TEST]` Test coverage
- [ ] `[CICD]` CI/CD or release
- [ ] `[CHORE]` Maintenance

## Changes

- persist `jsonlPath` in session registry history and append history when the JSONL source changes
- keep session-registry `lastActivityAt` monotonic so older updates cannot overwrite newer activity
- use persisted session-registry activity as a freshness source in daemon and foreground scans
- add Codex-specific hysteresis so quiet sessions stay `Idle` longer before turning `Stalled`
- keep stalled `thinking/tool` sessions visible in attention ordering/statusline
- simplify Codex binding registry to relation-focused metadata only

## Checklist

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (all tests green)
- [x] New features have tests
- [ ] README updated (if user-facing changes)
- [x] No hardcoded paths or environment-specific values

## Testing

- `npm run build`
- `npm run lint`
- `npm test`
- manual check:
  - `node bin/marmonitor.js status --json`
  - verify Codex `lastActivityAt` remains fresh after `tool -> idle/done`
  - verify `session-registry.json` writes `history[].jsonlPath`

## Risk

Medium. This changes the freshness source and status heuristics for Codex, so regressions would mainly affect statusline/attention ordering or how long quiet sessions remain `Idle` before `Stalled`.
