### PR TITLE
[CICD] #33 Prepare v0.2.3 release on dev

### DIFF
--- a/docs/pr-cicd-release-v0.2.3.md
+++ b/docs/pr-cicd-release-v0.2.3.md
@@ -1,0 +1,51 @@
+## Summary
+
+Resolve #33
+
+Release `dev` into `main` as `v0.2.3`.
+
+## Type
+
+- [ ] `[FEAT]` New feature
+- [ ] `[BUG]` Bug fix
+- [ ] `[HOTFIX]` Urgent fix
+- [ ] `[PERF]` Performance improvement
+- [ ] `[REFACTOR]` Code restructuring
+- [ ] `[DOCS]` Documentation
+- [ ] `[TEST]` Test coverage
+- [x] `[CICD]` CI/CD or release
+- [ ] `[CHORE]` Maintenance
+
+## Changes
+
+- bump package version from `0.2.2` to `0.2.3`
+- release the post-`v0.2.2` `dev` changes to `main`
+- include completed work from:
+  - `#25` Codex PID-to-thread binding registry
+  - `#27` session activity log and CLI
+  - `#28` Codex binding key mismatch fix
+  - `#31` session continuity and activity freshness stabilization
+- include merged PRs:
+  - `#26` `[FEAT] #25 Codex binding registry and SQLite enrichment optimization`
+  - `#29` `[FEAT] #27 Add session activity log and CLI`
+  - `#30` `[BUG] #28 Fix Codex binding key mismatch in foreground paths`
+  - `#32` `[BUG] #31 Stabilize session continuity and Codex activity freshness`
+
+## Checklist
+
+- [x] `npm run build` passes
+- [x] `npm run lint` passes
+- [x] `npm test` passes (all tests green)
+- [ ] New features have tests
+- [ ] README updated (if user-facing changes)
+- [x] No hardcoded paths or environment-specific values
+
+## Testing
+
+- `npm run -s build`
+- `npm run lint`
+- `npm test`
+
+## Risk
+
+Medium. This is a `dev` to `main` release PR and includes multiple completed features and fixes since `v0.2.2`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "marmonitor",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "marmonitor",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "hasInstallScript": true,
       "license": "MIT",
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marmonitor",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": "MJ JO <mjjo16@gmail.com>",
   "description": "tmux status bar monitor for AI coding agents — track Claude Code, Codex, Gemini sessions, tokens, and phases in real time",
   "type": "module",


### PR DESCRIPTION
## Summary

Resolve #33

Release `dev` into `main` as `v0.2.3`.

## Type

- [ ] `[FEAT]` New feature
- [ ] `[BUG]` Bug fix
- [ ] `[HOTFIX]` Urgent fix
- [ ] `[PERF]` Performance improvement
- [ ] `[REFACTOR]` Code restructuring
- [ ] `[DOCS]` Documentation
- [ ] `[TEST]` Test coverage
- [x] `[CICD]` CI/CD or release
- [ ] `[CHORE]` Maintenance

## Changes

- bump package version from `0.2.2` to `0.2.3`
- release the post-`v0.2.2` `dev` changes to `main`
- include completed work from:
  - `#25` Codex PID-to-thread binding registry
  - `#27` session activity log and CLI
  - `#28` Codex binding key mismatch fix
  - `#31` session continuity and activity freshness stabilization
- include merged PRs:
  - `#26` `[FEAT] #25 Codex binding registry and SQLite enrichment optimization`
  - `#29` `[FEAT] #27 Add session activity log and CLI`
  - `#30` `[BUG] #28 Fix Codex binding key mismatch in foreground paths`
  - `#32` `[BUG] #31 Stabilize session continuity and Codex activity freshness`

## Checklist

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (all tests green)
- [ ] New features have tests
- [ ] README updated (if user-facing changes)
- [x] No hardcoded paths or environment-specific values

## Testing

- `npm run -s build`
- `npm run lint`
- `npm test`

## Risk

Medium. This is a `dev` to `main` release PR and includes multiple completed features and fixes since `v0.2.2`.
