### PR TITLE
[FEAT] status/attention/activity CLI improvements — branch, model, jump merge

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -535,50 +535,6 @@ const DAEMON_PID_PATH = join(DAEMON_DIR, "daemon.pid");
 const DAEMON_SNAPSHOT_PATH = join(DAEMON_DIR, "daemon-snapshot.json");
 const DAEMON_NOT_RUNNING = "Daemon not running. Run: marmonitor start";
 
-function buildPaneContext(
-  agents: AgentSession[],
-  panePid: number,
-  panePath?: string,
-): string | undefined {
-  if (!panePid || Number.isNaN(panePid)) return undefined;
-
-  // Match pane PID to AI session via process tree (ppid chain)
-  const matched = agents.find(
-    (a) => a.pid === panePid || a.ppid === panePid || a.workers?.some((w) => w.pid === panePid),
-  );
-
-  // Build path + branch from pane path or matched session
-  const cwd = panePath ?? matched?.cwd;
-  if (!cwd) return undefined;
-
-  const home = process.env.HOME ?? "";
-  const shortPath = cwd.startsWith(home) ? `~${cwd.slice(home.length)}` : cwd;
-  const project = shortPath.split("/").pop() ?? shortPath;
-  const branch = matched?.branch ?? "";
-  const branchTag = branch ? ` (${branch})` : "";
-
-  // AI session info
-  const sessionInfo = matched
-    ? (() => {
-        const agent =
-          matched.agentName === "Claude Code" ? "Cl" : matched.agentName === "Codex" ? "Cx" : "Gm";
-        const phase =
-          matched.phase === "permission"
-            ? "⏳"
-            : matched.phase === "thinking"
-              ? "🤔"
-              : matched.phase === "tool"
-                ? "🔧"
-                : matched.phase === "done"
-                  ? "✅"
-                  : "";
-        return `#[fg=#6c7086] ${agent}${phase}#[default]`;
-      })()
-    : "";
-
-  return `#[fg=#6c7086]${project}${branchTag}${sessionInfo} #[default]`;
-}
-
 async function getAgentsSnapshot(): Promise<AgentSession[]> {
   return (await readDaemonSnapshot(DAEMON_SNAPSHOT_PATH, 5_000)) as AgentSession[];
 }
@@ -608,8 +564,6 @@ program
     "compact",
   )
   .option("--width <n>", "Render width hint for responsive statusline compaction")
-  .option("--pane-pid <pid>", "Current tmux pane PID for right-side context")
-  .option("--pane-path <path>", "Current tmux pane working directory")
   .option("--config <path>", "Path to settings.json")
   .action(async (opts) => {
     const validFormats = ["compact", "standard", "extended", "tmux-badges", "wezterm-pills"];
@@ -662,16 +616,8 @@ program
           config.integration.tmux.badgeStyle,
           hasJumpAnchor,
         );
-        // Append right-aligned pane context for tmux-badges
-        let output = rendered;
-        if (opts.statuslineFormat === "tmux-badges" && opts.panePid) {
-          const paneContext = buildPaneContext(agents, Number(opts.panePid), opts.panePath);
-          if (paneContext) {
-            output = `${rendered}#[align=right]${paneContext}`;
-          }
-        }
-        await writeCachedStatusline(opts.statuslineFormat, attentionLimit, width, output);
-        console.log(output);
+        await writeCachedStatusline(opts.statuslineFormat, attentionLimit, width, rendered);
+        console.log(rendered);
         return;
       } catch {
         console.log(renderUnavailableStatusline(opts.statuslineFormat));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -535,6 +535,50 @@ const DAEMON_PID_PATH = join(DAEMON_DIR, "daemon.pid");
 const DAEMON_SNAPSHOT_PATH = join(DAEMON_DIR, "daemon-snapshot.json");
 const DAEMON_NOT_RUNNING = "Daemon not running. Run: marmonitor start";
 
+function buildPaneContext(
+  agents: AgentSession[],
+  panePid: number,
+  panePath?: string,
+): string | undefined {
+  if (!panePid || Number.isNaN(panePid)) return undefined;
+
+  // Match pane PID to AI session via process tree (ppid chain)
+  const matched = agents.find(
+    (a) => a.pid === panePid || a.ppid === panePid || a.workers?.some((w) => w.pid === panePid),
+  );
+
+  // Build path + branch from pane path or matched session
+  const cwd = panePath ?? matched?.cwd;
+  if (!cwd) return undefined;
+
+  const home = process.env.HOME ?? "";
+  const shortPath = cwd.startsWith(home) ? `~${cwd.slice(home.length)}` : cwd;
+  const project = shortPath.split("/").pop() ?? shortPath;
+  const branch = matched?.branch ?? "";
+  const branchTag = branch ? ` (${branch})` : "";
+
+  // AI session info
+  const sessionInfo = matched
+    ? (() => {
+        const agent =
+          matched.agentName === "Claude Code" ? "Cl" : matched.agentName === "Codex" ? "Cx" : "Gm";
+        const phase =
+          matched.phase === "permission"
+            ? "⏳"
+            : matched.phase === "thinking"
+              ? "🤔"
+              : matched.phase === "tool"
+                ? "🔧"
+                : matched.phase === "done"
+                  ? "✅"
+                  : "";
+        return `#[fg=#6c7086] ${agent}${phase}#[default]`;
+      })()
+    : "";
+
+  return `#[fg=#6c7086]${project}${branchTag}${sessionInfo} #[default]`;
+}
+
 async function getAgentsSnapshot(): Promise<AgentSession[]> {
   return (await readDaemonSnapshot(DAEMON_SNAPSHOT_PATH, 5_000)) as AgentSession[];
 }
@@ -564,6 +608,8 @@ program
     "compact",
   )
   .option("--width <n>", "Render width hint for responsive statusline compaction")
+  .option("--pane-pid <pid>", "Current tmux pane PID for right-side context")
+  .option("--pane-path <path>", "Current tmux pane working directory")
   .option("--config <path>", "Path to settings.json")
   .action(async (opts) => {
     const validFormats = ["compact", "standard", "extended", "tmux-badges", "wezterm-pills"];
@@ -616,8 +662,16 @@ program
           config.integration.tmux.badgeStyle,
           hasJumpAnchor,
         );
-        await writeCachedStatusline(opts.statuslineFormat, attentionLimit, width, rendered);
-        console.log(rendered);
+        // Append right-aligned pane context for tmux-badges
+        let output = rendered;
+        if (opts.statuslineFormat === "tmux-badges" && opts.panePid) {
+          const paneContext = buildPaneContext(agents, Number(opts.panePid), opts.panePath);
+          if (paneContext) {
+            output = `${rendered}#[align=right]${paneContext}`;
+          }
+        }
+        await writeCachedStatusline(opts.statuslineFormat, attentionLimit, width, output);
+        console.log(output);
         return;
       } catch {
         console.log(renderUnavailableStatusline(opts.statuslineFormat));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -659,9 +659,11 @@ program
 
 program
   .command("attention")
-  .description("Show prioritized sessions that need attention")
+  .description("Show prioritized sessions that need attention, optionally jump to one")
   .option("--json", "Output as JSON")
   .option("--interactive", "Choose an attention item and jump to its tmux pane")
+  .option("--pid <pid>", "Jump to AI session by PID")
+  .option("--attention-index <n>", "Jump to Nth attention item directly")
   .option("--limit <n>", "Max items to show", "12")
   .option("--config <path>", "Path to settings.json")
   .action(async (opts) => {
@@ -670,11 +672,77 @@ program
     applyTerminalStyle(config.integration.tmux.badgeStyle);
     const limit = resolveAttentionLimit(opts, config.display.attentionLimit);
     const interactiveLimit = resolveAttentionLimit(opts, config.display.attentionLimit, true);
-    if (opts.interactive && opts.json) {
-      console.error("--interactive cannot be combined with --json.");
-      process.exit(1);
+
+    const useDirectPid = typeof opts.pid === "string";
+    const useDirectIndex = typeof opts.attentionIndex === "string";
+    const useInteractive = Boolean(opts.interactive);
+
+    // Direct jump by PID
+    if (useDirectPid) {
+      const pid = Number.parseInt(opts.pid, 10);
+      if (Number.isNaN(pid)) {
+        console.error(`Invalid pid: ${opts.pid}`);
+        process.exit(1);
+      }
+      const agent = agents.find((a) => a.pid === pid);
+      if (!agent) {
+        const result = {
+          found: false,
+          executed: false,
+          insideTmux: Boolean(process.env.TMUX),
+          pid,
+          message: `AI session not found for pid ${pid}.`,
+        };
+        if (opts.json) {
+          printJumpJson(result);
+        } else {
+          printJumpResult(result);
+        }
+        process.exit(1);
+      }
+      const result = await jumpToAgent(agent);
+      if (opts.json) {
+        printJumpJson(result);
+      } else {
+        printJumpResult(result);
+      }
+      if (!result.found) process.exit(1);
+      return;
     }
-    if (opts.interactive) {
+
+    // Direct jump by attention index
+    if (useDirectIndex) {
+      const selection = Number.parseInt(opts.attentionIndex, 10);
+      if (Number.isNaN(selection) || selection < 1) {
+        console.error(`Invalid attention index: ${opts.attentionIndex}`);
+        process.exit(1);
+      }
+      const item = selectJumpAttentionItem(agents, selection);
+      if (!item) {
+        console.error(`No jumpable attention item at index ${selection}.`);
+        process.exit(1);
+      }
+      const agent = agents.find((a) => a.pid === item.pid);
+      if (!agent) {
+        console.error(`AI session not found for pid ${item.pid}.`);
+        process.exit(1);
+      }
+      const result = await jumpToAgent(agent);
+      if (opts.json) {
+        printJumpJson(result);
+      } else {
+        printJumpResult(result);
+      }
+      if (!result.found) process.exit(1);
+      return;
+    }
+
+    // Interactive chooser
+    if (useInteractive) {
+      if (opts.json) {
+        console.error("--interactive cannot be combined with --json.");
+        process.exit(1);
+      }
       if (!process.stdin.isTTY) {
         console.error("--interactive requires an interactive terminal.");
         process.exit(1);
@@ -722,6 +790,8 @@ program
       if (!result.found) process.exit(1);
       return;
     }
+
+    // Default: list mode
     if (opts.json) {
       printAttentionJson(agents, limit);
     } else {
@@ -926,108 +996,25 @@ program
     console.log(payload.paneOutput ?? "(none)");
   });
 
+// "jump" is kept as an alias for backward compatibility (Option+N bindings, scripts).
+// --attention maps to attention --interactive, --attention-index and --pid pass through.
 program
   .command("jump")
-  .description("Jump to the tmux pane running a specific AI session")
-  .option("--pid <pid>", "AI process PID")
+  .description("Alias for 'attention' — jump to an AI session's tmux pane")
+  .option("--pid <pid>", "Jump to AI session by PID")
   .option("--attention", "Choose from attention items interactively")
-  .option("--attention-index <n>", "Jump to Nth jumpable attention item")
+  .option("--attention-index <n>", "Jump to Nth attention item directly")
   .option("--json", "Output as JSON")
   .option("--config <path>", "Path to settings.json")
   .action(async (opts) => {
-    const agents = await requireDaemonSnapshot();
-    const config = await loadConfig(resolveConfigPath(opts));
-    const useAttention = Boolean(opts.attention);
-    const useAttentionIndex = typeof opts.attentionIndex === "string";
-    const usePid = typeof opts.pid === "string";
-
-    const selectedModes = [useAttention, useAttentionIndex, usePid].filter(Boolean).length;
-    if (selectedModes !== 1) {
-      console.error("Use exactly one of --pid <pid>, --attention, or --attention-index <n>.");
-      process.exit(1);
-    }
-
-    let pid: number;
-    if (useAttention) {
-      if (!process.stdin.isTTY) {
-        console.error("--attention requires an interactive terminal.");
-        process.exit(1);
-      }
-      const limit = resolveAttentionLimit(
-        { limit: undefined },
-        config.display.attentionLimit,
-        true,
-      );
-      const totalItems = buildJumpAttentionItems(agents).length;
-      const totalPages = Math.max(1, Math.ceil(totalItems / limit));
-      let currentPage = 1;
-      let item: ReturnType<typeof selectJumpAttentionItemOnPage>;
-      while (true) {
-        clearScreen();
-        console.log(renderJumpAttentionChooser(agents, currentPage, limit));
-        const pageItemCount = Math.min(limit, Math.max(totalItems - (currentPage - 1) * limit, 0));
-        const action = await promptSelectionAction(pageItemCount, currentPage, totalPages);
-        if (!action || action.kind === "cancel") return;
-        if (action.kind === "next") {
-          currentPage = Math.min(currentPage + 1, totalPages);
-          continue;
-        }
-        if (action.kind === "prev") {
-          currentPage = Math.max(currentPage - 1, 1);
-          continue;
-        }
-        item = selectJumpAttentionItemOnPage(agents, currentPage, action.selection, limit);
-        break;
-      }
-      if (!item) {
-        console.error("Invalid selection.");
-        process.exit(1);
-      }
-      pid = item.pid;
-    } else if (useAttentionIndex) {
-      const selection = Number.parseInt(opts.attentionIndex, 10);
-      if (Number.isNaN(selection) || selection < 1) {
-        console.error(`Invalid attention index: ${opts.attentionIndex}`);
-        process.exit(1);
-      }
-      const item = selectJumpAttentionItem(agents, selection);
-      if (!item) {
-        console.error(`No jumpable attention item at index ${selection}.`);
-        process.exit(1);
-      }
-      pid = item.pid;
-    } else {
-      pid = Number.parseInt(opts.pid, 10);
-      if (Number.isNaN(pid)) {
-        console.error(`Invalid pid: ${opts.pid}`);
-        process.exit(1);
-      }
-    }
-
-    const agent = agents.find((item) => item.pid === pid);
-    if (!agent) {
-      const result = {
-        found: false,
-        executed: false,
-        insideTmux: Boolean(process.env.TMUX),
-        pid,
-        message: `AI session not found for pid ${pid}.`,
-      };
-      if (opts.json) {
-        printJumpJson(result);
-      } else {
-        printJumpResult(result);
-      }
-      process.exit(1);
-    }
-
-    const result = await jumpToAgent(agent);
-    if (opts.json) {
-      printJumpJson(result);
-    } else {
-      printJumpResult(result);
-    }
-    if (!result.found) process.exit(1);
+    // Translate jump flags to attention flags and re-parse
+    const args = ["attention"];
+    if (opts.attention) args.push("--interactive");
+    if (opts.attentionIndex) args.push("--attention-index", opts.attentionIndex);
+    if (opts.pid) args.push("--pid", opts.pid);
+    if (opts.json) args.push("--json");
+    if (opts.config) args.push("--config", opts.config);
+    await program.parseAsync(args, { from: "user" });
   });
 
 program

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1117,6 +1117,8 @@ program
   .option("--pid <pid>", "Filter by AI process PID")
   .option("--session <sid>", "Filter by session ID (prefix match)")
   .option("--days <n>", "Number of days to show", "1")
+  .option("--lines <n>", "Max activity lines per session (default 30, max 200)", "30")
+  .option("--order <dir>", "Sort order: desc (newest first) or asc (oldest first)", "desc")
   .option("--json", "Output as JSON")
   .action(async (opts) => {
     const { getConfigDir } = await import("./config/index.js");
@@ -1125,6 +1127,8 @@ program
 
     const logDir = pj(getConfigDir(), "activity-log");
     const days = Math.max(1, Math.min(90, Number(opts.days) || 1));
+    const maxLines = Math.max(1, Math.min(200, Number(opts.lines) || 30));
+    const descOrder = opts.order !== "asc";
     const allEntries = [];
 
     for (const dateStr of getRecentDateKeys(days)) {
@@ -1134,13 +1138,25 @@ program
 
     // Filter
     let filtered = allEntries;
+    let pidFilterAgent:
+      | { agentName: string; pid: number; cwd: string; sessionId: string }
+      | undefined;
     if (opts.pid) {
       const agents = await getAgentsSnapshot();
       const agent = agents.find((a) => a.pid === Number(opts.pid));
       if (agent?.sessionId) {
+        pidFilterAgent = {
+          agentName: agent.agentName,
+          pid: agent.pid,
+          cwd: agent.cwd,
+          sessionId: agent.sessionId,
+        };
         const sidPrefix = agent.sessionId.slice(0, 12);
         filtered = filtered.filter((e) => e.sid.startsWith(sidPrefix));
       } else {
+        pidFilterAgent = agent
+          ? { agentName: agent.agentName, pid: agent.pid, cwd: agent.cwd, sessionId: "" }
+          : undefined;
         filtered = [];
       }
     }
@@ -1150,12 +1166,25 @@ program
     }
 
     if (opts.json) {
+      if (descOrder) filtered.reverse();
       console.log(JSON.stringify(filtered, null, 2));
       return;
     }
 
     if (filtered.length === 0) {
-      console.log("No activity found.");
+      if (pidFilterAgent) {
+        console.log(`No activity found for PID ${pidFilterAgent.pid}.`);
+        console.log(`  Agent: ${pidFilterAgent.agentName}`);
+        console.log(`  CWD:   ${pidFilterAgent.cwd}`);
+        if (pidFilterAgent.sessionId) {
+          console.log(`  SID:   ${pidFilterAgent.sessionId.slice(0, 12)}...`);
+        } else {
+          console.log("  SID:   (no session matched — activity logging may not have started)");
+        }
+        console.log(`\n  Activity log checked: last ${days} day(s) in ${logDir}`);
+      } else {
+        console.log("No activity found.");
+      }
       return;
     }
 
@@ -1184,15 +1213,17 @@ program
         `  ${entries.length} actions  out:${formatTokensShort(totalOut)}  cache:${formatTokensShort(totalCache)}`,
       );
       console.log("  ─────────────────────────────────────");
-      for (const e of entries.slice(-20)) {
+      const sorted = descOrder ? [...entries].reverse() : entries;
+      const shown = sorted.slice(0, maxLines);
+      for (const e of shown) {
         const t = new Date(e.ts * 1000).toLocaleTimeString("en-GB", {
           hour: "2-digit",
           minute: "2-digit",
         });
         console.log(`  ${t}  ${e.tool}: ${truncateForDisplay(e.target, 60)}`);
       }
-      if (entries.length > 20) {
-        console.log(`  ... +${entries.length - 20} more`);
+      if (entries.length > maxLines) {
+        console.log(`  ... +${entries.length - maxLines} more (use --lines to show more)`);
       }
     }
   });

--- a/src/output/index.ts
+++ b/src/output/index.ts
@@ -51,6 +51,16 @@ export function applyTerminalStyle(badgeStyle: BadgeStyle): void {
   monoMode = badgeStyle === "basic-mono" || badgeStyle === "text-mono";
 }
 
+function abbreviateModel(model: string | undefined): string {
+  if (!model) return "—";
+  if (model.includes("opus")) return "opus";
+  if (model.includes("sonnet")) return "sonnet";
+  if (model.includes("haiku")) return "haiku";
+  // For non-Claude models, strip version suffix if too long (e.g. gpt-4o-mini → gpt-4o)
+  if (model.length <= 8) return model;
+  return model.slice(0, 7);
+}
+
 function cwdToProjectName(cwd: string): string {
   const home = process.env.HOME ?? "";
   const short = cwd.startsWith(home) ? cwd.slice(home.length + 1) : cwd;
@@ -217,6 +227,7 @@ export async function printStatus(agents: AgentSession[]): Promise<void> {
     const W = {
       status: 10,
       agent: 7,
+      model: 8,
       pid: 6,
       cpu: 6,
       mem: 7,
@@ -230,6 +241,7 @@ export async function printStatus(agents: AgentSession[]): Promise<void> {
     const cols = [
       "Status".padEnd(W.status),
       "Agent".padEnd(W.agent),
+      "Model".padEnd(W.model),
       "PID".padEnd(W.pid),
       "CPU".padEnd(W.cpu),
       "MEM".padEnd(W.mem),
@@ -268,6 +280,7 @@ export async function printStatus(agents: AgentSession[]): Promise<void> {
                     : chalk.white(statusLabel2);
       const rawStatus = coloredLabel + " ".repeat(Math.max(0, W.status - statusLabel2.length));
       const agentStr = a.agentName === "Claude Code" ? "Claude" : a.agentName;
+      const modelStr = abbreviateModel(a.model);
       const cpu = `${a.cpuPercent}%`;
       const mem = `${a.memoryMb.toFixed(0)}MB`;
       const last = a.lastResponseAt
@@ -282,6 +295,7 @@ export async function printStatus(agents: AgentSession[]): Promise<void> {
       const line = [
         rawStatus,
         padVisible(agentStr, W.agent),
+        chalk.dim(modelStr.padEnd(W.model)),
         String(a.pid).padEnd(W.pid),
         padVisibleRight(cpu, W.cpu),
         padVisibleRight(mem, W.mem),
@@ -297,6 +311,7 @@ export async function printStatus(agents: AgentSession[]): Promise<void> {
           const wLine = [
             " ".repeat(W.status),
             "└─".padEnd(W.agent),
+            " ".repeat(W.model),
             String(w.pid).padEnd(W.pid),
             padVisibleRight(`${w.cpuPercent}%`, W.cpu),
             padVisibleRight(`${w.memoryMb.toFixed(0)}MB`, W.mem),

--- a/src/output/index.ts
+++ b/src/output/index.ts
@@ -51,7 +51,7 @@ export function applyTerminalStyle(badgeStyle: BadgeStyle): void {
   monoMode = badgeStyle === "basic-mono" || badgeStyle === "text-mono";
 }
 
-function abbreviateModel(model: string | undefined): string {
+export function abbreviateModel(model: string | undefined): string {
   if (!model) return "—";
   if (model.includes("opus")) return "opus";
   if (model.includes("sonnet")) return "sonnet";

--- a/src/output/index.ts
+++ b/src/output/index.ts
@@ -56,9 +56,8 @@ function abbreviateModel(model: string | undefined): string {
   if (model.includes("opus")) return "opus";
   if (model.includes("sonnet")) return "sonnet";
   if (model.includes("haiku")) return "haiku";
-  // For non-Claude models, strip version suffix if too long (e.g. gpt-4o-mini → gpt-4o)
-  if (model.length <= 8) return model;
-  return model.slice(0, 7);
+  if (model.length <= 12) return model;
+  return model.slice(0, 11);
 }
 
 function cwdToProjectName(cwd: string): string {
@@ -227,7 +226,7 @@ export async function printStatus(agents: AgentSession[]): Promise<void> {
     const W = {
       status: 10,
       agent: 7,
-      model: 8,
+      model: 12,
       pid: 6,
       cpu: 6,
       mem: 7,

--- a/src/output/index.ts
+++ b/src/output/index.ts
@@ -51,6 +51,45 @@ export function applyTerminalStyle(badgeStyle: BadgeStyle): void {
   monoMode = badgeStyle === "basic-mono" || badgeStyle === "text-mono";
 }
 
+function cwdToProjectName(cwd: string): string {
+  const home = process.env.HOME ?? "";
+  const short = cwd.startsWith(home) ? cwd.slice(home.length + 1) : cwd;
+  const parts = short.split("/");
+  return parts[parts.length - 1] || short;
+}
+
+/** Strip ANSI escape codes to get visible character count */
+function visibleLength(str: string): number {
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escape stripping
+  return str.replace(/\x1b\[\d*(;\d+)*m/g, "").length;
+}
+
+/** Pad string to fixed visible width (ANSI-aware) */
+function padVisible(str: string, width: number): string {
+  const visible = visibleLength(str);
+  return visible >= width ? str : str + " ".repeat(width - visible);
+}
+
+/** Right-align a string to fixed width (for numbers like CPU, MEM) */
+function padVisibleRight(str: string, width: number): string {
+  const visible = visibleLength(str);
+  return visible >= width ? str : " ".repeat(width - visible) + str;
+}
+
+function formatTokensCompact(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
+}
+
+function formatElapsedCompactTable(epochSec: number): string {
+  const sec = Math.floor(Date.now() / 1000 - epochSec);
+  if (sec < 60) return `${sec}s`;
+  if (sec < 3600) return `${Math.floor(sec / 60)}m`;
+  if (sec < 86400) return `${Math.floor(sec / 3600)}h`;
+  return `${Math.floor(sec / 86400)}d`;
+}
+
 /** Agent name with distinct color */
 function agentLabel(name: string): string {
   const label = name === "Claude Code" ? "Claude" : name;
@@ -172,36 +211,97 @@ export async function printStatus(agents: AgentSession[]): Promise<void> {
   }
 
   if (alive.length > 0) {
-    console.log(`AI Sessions (${alive.length} active):`);
+    console.log(`AI Sessions (${alive.length} active):\n`);
+
+    // Column widths — fixed-width columns first, variable-width last
+    const W = {
+      status: 10,
+      agent: 7,
+      pid: 6,
+      cpu: 6,
+      mem: 7,
+      last: 6,
+      tokens: 10,
+      project: 22,
+      branch: 16,
+    };
+
+    // Table header
+    const cols = [
+      "Status".padEnd(W.status),
+      "Agent".padEnd(W.agent),
+      "PID".padEnd(W.pid),
+      "CPU".padEnd(W.cpu),
+      "MEM".padEnd(W.mem),
+      "Last".padEnd(W.last),
+      "Tokens".padEnd(W.tokens),
+      "Project".padEnd(W.project),
+      "Branch",
+    ];
+    console.log(`  ${chalk.dim(cols.join(" "))}`);
+    console.log(chalk.dim(`  ${"─".repeat(cols.join(" ").length)}`));
+
     for (const a of alive) {
-      const icon = displayStatusLabel(a.status, a.phase);
-      const path = shortenPath(a.cwd);
-      const started = formatElapsed(a.startedAt);
-      const tokens = formatTokenUsage(a.tokenUsage, a.model);
-      const agent = agentLabel(a.agentName).padEnd(18);
-      const phase = phaseIcon(a.phase);
-      const runtime = runtimeLabel(a.runtimeSource);
-      const lastTime = a.lastResponseAt
-        ? chalk.dim(`  last response ${formatElapsed(a.lastResponseAt)}`)
+      // Fixed-width status: colorize label only, pad with plain spaces after
+      const statusWord =
+        a.phase === "permission"
+          ? "Allow"
+          : a.phase === "thinking"
+            ? "Think"
+            : a.phase === "tool"
+              ? "Tool"
+              : a.status;
+      const statusLabel2 = `[${statusWord}]`;
+      const coloredLabel =
+        statusWord === "Active"
+          ? chalk.green(statusLabel2)
+          : statusWord === "Idle"
+            ? chalk.yellow(statusLabel2)
+            : statusWord === "Stalled"
+              ? chalk.red(statusLabel2)
+              : statusWord === "Allow"
+                ? chalk.red(statusLabel2)
+                : statusWord === "Think"
+                  ? chalk.magenta(statusLabel2)
+                  : statusWord === "Tool"
+                    ? chalk.green(statusLabel2)
+                    : chalk.white(statusLabel2);
+      const rawStatus = coloredLabel + " ".repeat(Math.max(0, W.status - statusLabel2.length));
+      const agentStr = a.agentName === "Claude Code" ? "Claude" : a.agentName;
+      const cpu = `${a.cpuPercent}%`;
+      const mem = `${a.memoryMb.toFixed(0)}MB`;
+      const last = a.lastResponseAt
+        ? formatElapsedCompactTable(a.lastResponseAt)
         : a.lastActivityAt
-          ? chalk.dim(`  last activity ${formatElapsed(a.lastActivityAt)}`)
-          : "";
-      console.log(`  ${icon}  ${agent} PID:${String(a.pid).padEnd(6)} ${path}${runtime}${phase}`);
-      console.log(
-        `           CPU:${a.cpuPercent}%  MEM:${a.memoryMb.toFixed(0)}MB  started ${started}${lastTime}${tokens}`,
-      );
+          ? formatElapsedCompactTable(a.lastActivityAt)
+          : "—";
+      const tokens = a.tokenUsage ? `out:${formatTokensCompact(a.tokenUsage.outputTokens)}` : "";
+      const project = cwdToProjectName(a.cwd).slice(0, W.project - 1);
+      const branchStr = (a.branch ?? "—").slice(0, W.branch - 1);
+
+      const line = [
+        rawStatus,
+        padVisible(agentStr, W.agent),
+        String(a.pid).padEnd(W.pid),
+        padVisibleRight(cpu, W.cpu),
+        padVisibleRight(mem, W.mem),
+        chalk.dim(last.padStart(W.last)),
+        chalk.dim(tokens.padEnd(W.tokens)),
+        project.padEnd(W.project),
+        chalk.dim(branchStr),
+      ].join(" ");
+      console.log(`  ${line}`);
 
       if (a.workers && a.workers.length > 0) {
-        for (let i = 0; i < a.workers.length; i++) {
-          const w = a.workers[i];
-          const isLast = i === a.workers.length - 1;
-          const branch = isLast ? "└──" : "├──";
-          const wStatus = statusLabel(w.status).trim();
-          console.log(
-            chalk.dim(
-              `           ${branch} PID:${String(w.pid).padEnd(6)} CPU:${w.cpuPercent}%  MEM:${w.memoryMb.toFixed(0)}MB  ${wStatus}`,
-            ),
-          );
+        for (const w of a.workers) {
+          const wLine = [
+            " ".repeat(W.status),
+            "└─".padEnd(W.agent),
+            String(w.pid).padEnd(W.pid),
+            padVisibleRight(`${w.cpuPercent}%`, W.cpu),
+            padVisibleRight(`${w.memoryMb.toFixed(0)}MB`, W.mem),
+          ].join(" ");
+          console.log(chalk.dim(`  ${wLine}`));
         }
       }
     }
@@ -306,6 +406,8 @@ function attentionKindLabel(kind: ReturnType<typeof buildAttentionItems>[number]
 function attentionLine(item: ReturnType<typeof buildAttentionItems>[number]): string {
   const name = item.agentName === "Claude Code" ? "Claude" : item.agentName;
   const path = compactDirLabel(item.cwd);
+  const branch = item.branch;
+  const branchTag = branch ? chalk.dim(` (${branch})`) : "";
   const runtime = runtimeLabel(item.runtimeSource);
   const time = item.lastResponseAt
     ? `  ${chalk.dim(formatElapsed(item.lastResponseAt))}`
@@ -314,21 +416,21 @@ function attentionLine(item: ReturnType<typeof buildAttentionItems>[number]): st
       : "";
 
   if (item.kind === "unmatched") {
-    return `${name}  ${chalk.dim(path)}${runtime}  PID:${item.pid}${time}`;
+    return `${name}  ${chalk.dim(path)}${branchTag}${runtime}  PID:${item.pid}${time}`;
   }
   if (item.kind === "permission") {
-    return `${name}  ${chalk.dim(path)}${runtime}  allow pending  PID:${item.pid}${time}`;
+    return `${name}  ${chalk.dim(path)}${branchTag}${runtime}  allow pending  PID:${item.pid}${time}`;
   }
   if (item.kind === "stalled") {
-    return `${name}  ${chalk.dim(path)}${runtime}  stalled  PID:${item.pid}${time}`;
+    return `${name}  ${chalk.dim(path)}${branchTag}${runtime}  stalled  PID:${item.pid}${time}`;
   }
   if (item.kind === "thinking") {
-    return `${name}  ${chalk.dim(path)}${runtime}  thinking  PID:${item.pid}${time}`;
+    return `${name}  ${chalk.dim(path)}${branchTag}${runtime}  thinking  PID:${item.pid}${time}`;
   }
   if (item.kind === "active") {
-    return `${name}  ${chalk.dim(path)}${runtime}  recent  PID:${item.pid}${time}`;
+    return `${name}  ${chalk.dim(path)}${branchTag}${runtime}  active  PID:${item.pid}${time}`;
   }
-  return `${name}  ${chalk.dim(path)}${runtime}  tool  PID:${item.pid}${time}`;
+  return `${name}  ${chalk.dim(path)}${branchTag}${runtime}  tool  PID:${item.pid}${time}`;
 }
 
 function jumpAttentionStatusLabel(
@@ -337,7 +439,7 @@ function jumpAttentionStatusLabel(
   if (item.kind === "permission") return chalk.red("[Allow]   ");
   if (item.kind === "thinking") return chalk.green("[Thinking]");
   if (item.kind === "tool") return chalk.cyan("[Tool]    ");
-  return chalk.blue("[Recent]  ");
+  return chalk.blue("[Active]  ");
 }
 
 function jumpAttentionPhaseIcon(item: ReturnType<typeof buildJumpAttentionItems>[number]): string {
@@ -350,6 +452,8 @@ function jumpAttentionPhaseIcon(item: ReturnType<typeof buildJumpAttentionItems>
 function jumpAttentionLine(item: ReturnType<typeof buildJumpAttentionItems>[number]): string {
   const name = item.agentName === "Claude Code" ? "Claude" : item.agentName;
   const path = compactDirLabel(item.cwd);
+  const branch = item.branch;
+  const branchTag = branch ? chalk.dim(` (${branch})`) : "";
   const runtime = runtimeLabel(item.runtimeSource);
   const started = item.startedAt ? chalk.dim(` started ${formatElapsed(item.startedAt)}`) : "";
   const activity = item.lastResponseAt
@@ -363,15 +467,15 @@ function jumpAttentionLine(item: ReturnType<typeof buildJumpAttentionItems>[numb
   const agent = agentLabel(item.agentName).padEnd(8);
 
   if (item.kind === "permission") {
-    return `  ${status} ${agent} ${chalk.dim(path)}${runtime}${icon}\n             PID:${item.pid}  ${stats}${started}${activity}`;
+    return `  ${status} ${agent} ${chalk.dim(path)}${branchTag}${runtime}${icon}\n             PID:${item.pid}  ${stats}${started}${activity}`;
   }
   if (item.kind === "thinking") {
-    return `  ${status} ${agent} ${chalk.dim(path)}${runtime}${icon}\n             PID:${item.pid}  ${stats}${started}${activity}`;
+    return `  ${status} ${agent} ${chalk.dim(path)}${branchTag}${runtime}${icon}\n             PID:${item.pid}  ${stats}${started}${activity}`;
   }
   if (item.kind === "tool") {
-    return `  ${status} ${agent} ${chalk.dim(path)}${runtime}${icon}\n             PID:${item.pid}  ${stats}${started}${activity}`;
+    return `  ${status} ${agent} ${chalk.dim(path)}${branchTag}${runtime}${icon}\n             PID:${item.pid}  ${stats}${started}${activity}`;
   }
-  return `  ${status} ${agent} ${chalk.dim(path)}${runtime}${icon}\n             PID:${item.pid}  ${stats}${started}${activity}`;
+  return `  ${status} ${agent} ${chalk.dim(path)}${branchTag}${runtime}${icon}\n             PID:${item.pid}  ${stats}${started}${activity}`;
 }
 
 function paginateJumpAttentionItems<T>(items: T[], page: number, pageSize = 10): T[] {

--- a/src/output/utils.ts
+++ b/src/output/utils.ts
@@ -231,6 +231,7 @@ export interface AttentionItem {
   phase?: AgentSession["phase"];
   lastResponseAt?: number;
   lastActivityAt?: number;
+  branch?: string;
 }
 
 export interface StatusPill {
@@ -507,6 +508,7 @@ export function buildAttentionItems(
     phase: agent.phase,
     lastResponseAt: agent.lastResponseAt,
     lastActivityAt: agent.lastActivityAt,
+    branch: agent.branch,
   });
 
   const tier1 = alive

--- a/src/scanner/index.ts
+++ b/src/scanner/index.ts
@@ -317,6 +317,18 @@ export async function scanAgents(
       agentName,
     );
 
+    // Read git branch from .git/HEAD (full enrichment only, ~0.1ms per session)
+    let branch: string | undefined = cachedEnrichment?.branch;
+    if (isFullEnrichment && cwd !== "unknown") {
+      try {
+        const headContent = await readFile(join(cwd, ".git", "HEAD"), "utf-8");
+        const trimmed = headContent.trim();
+        branch = trimmed.startsWith("ref: refs/heads/") ? trimmed.slice(16) : undefined;
+      } catch {
+        branch = undefined;
+      }
+    }
+
     const session = {
       agentName,
       pid: proc.pid,
@@ -335,6 +347,7 @@ export async function scanAgents(
       lastResponseAt,
       lastActivityAt,
       runtimeSource,
+      branch,
     } as AgentSession;
 
     if (isFullEnrichment) {
@@ -351,6 +364,7 @@ export async function scanAgents(
         lastResponseAt: session.lastResponseAt,
         lastActivityAt: session.lastActivityAt,
         runtimeSource: session.runtimeSource,
+        branch: session.branch,
       });
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,7 @@ export interface AgentSession {
   lastResponseAt?: number; // epoch seconds — last AI response
   lastActivityAt?: number; // epoch seconds — last any event
   runtimeSource?: RuntimeSource;
+  branch?: string; // git branch from .git/HEAD
 }
 
 /** Agent detection signature */

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -111,6 +111,91 @@ describe("config CLI helpers", () => {
       await rm(xdgRoot, { recursive: true });
     }
   });
+
+  it("respects --lines limit", async () => {
+    const xdgRoot = await mkdir(join(tmpdir(), `marmonitor-cli-lines-${Date.now()}`), {
+      recursive: true,
+    });
+    try {
+      const logDir = join(xdgRoot, "marmonitor", "activity-log");
+      await mkdir(logDir, { recursive: true });
+      const today = formatDateKey(new Date());
+      const entries = `${Array.from({ length: 10 }, (_, i) =>
+        JSON.stringify({
+          ts: 1775190000 + i,
+          sid: "abc123456789",
+          agent: "Claude Code",
+          cwd: "/tmp/project",
+          tool: "Edit",
+          target: `src/file${i}.ts`,
+          tokens: { in: 1, out: 10, cache: 0 },
+        }),
+      ).join("\n")}\n`;
+      await writeFile(join(logDir, `${today}.jsonl`), entries, "utf8");
+
+      const output = runCli(["activity", "--lines", "3"], { XDG_CONFIG_HOME: xdgRoot });
+      assert.match(output, /\+7 more/);
+    } finally {
+      await rm(xdgRoot, { recursive: true });
+    }
+  });
+
+  it("returns entries in desc order by default (newest first)", async () => {
+    const xdgRoot = await mkdir(join(tmpdir(), `marmonitor-cli-order-${Date.now()}`), {
+      recursive: true,
+    });
+    try {
+      const logDir = join(xdgRoot, "marmonitor", "activity-log");
+      await mkdir(logDir, { recursive: true });
+      const today = formatDateKey(new Date());
+      const entries = `${[
+        {
+          ts: 1775190001,
+          sid: "abc123456789",
+          agent: "Claude Code",
+          cwd: "/tmp/p",
+          tool: "Edit",
+          target: "first.ts",
+          tokens: { in: 1, out: 1, cache: 0 },
+        },
+        {
+          ts: 1775190002,
+          sid: "abc123456789",
+          agent: "Claude Code",
+          cwd: "/tmp/p",
+          tool: "Edit",
+          target: "second.ts",
+          tokens: { in: 1, out: 1, cache: 0 },
+        },
+        {
+          ts: 1775190003,
+          sid: "abc123456789",
+          agent: "Claude Code",
+          cwd: "/tmp/p",
+          tool: "Edit",
+          target: "third.ts",
+          tokens: { in: 1, out: 1, cache: 0 },
+        },
+      ]
+        .map((e) => JSON.stringify(e))
+        .join("\n")}\n`;
+      await writeFile(join(logDir, `${today}.jsonl`), entries, "utf8");
+
+      // desc (default): third.ts appears before first.ts in JSON output
+      const descOut = JSON.parse(runCli(["activity", "--json"], { XDG_CONFIG_HOME: xdgRoot }));
+      assert.equal(descOut[0].target, "third.ts");
+      assert.equal(descOut[2].target, "first.ts");
+
+      // asc: first.ts appears before third.ts
+      const ascOut = JSON.parse(
+        runCli(["activity", "--json", "--order", "asc"], { XDG_CONFIG_HOME: xdgRoot }),
+      );
+      assert.equal(ascOut[0].target, "first.ts");
+      assert.equal(ascOut[2].target, "third.ts");
+    } finally {
+      await rm(xdgRoot, { recursive: true });
+    }
+  });
 });
 
 describe("postinstall/preuninstall scripts", () => {

--- a/tests/output.test.mjs
+++ b/tests/output.test.mjs
@@ -1,6 +1,28 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { renderUnavailableStatusline } from "../dist/output/index.js";
+import { abbreviateModel, renderUnavailableStatusline } from "../dist/output/index.js";
+
+describe("abbreviateModel", () => {
+  it("abbreviates Claude model variants", () => {
+    assert.equal(abbreviateModel("claude-opus-4-6"), "opus");
+    assert.equal(abbreviateModel("claude-sonnet-4-6"), "sonnet");
+    assert.equal(abbreviateModel("claude-haiku-4-5"), "haiku");
+  });
+
+  it("returns short non-Claude model names as-is", () => {
+    assert.equal(abbreviateModel("gpt-5.4"), "gpt-5.4");
+    assert.equal(abbreviateModel("gpt-4o"), "gpt-4o");
+  });
+
+  it("truncates long non-Claude model names to 11 chars", () => {
+    assert.equal(abbreviateModel("some-very-long-model-name"), "some-very-l");
+  });
+
+  it("returns — for undefined or empty", () => {
+    assert.equal(abbreviateModel(undefined), "—");
+    assert.equal(abbreviateModel(""), "—");
+  });
+});
 
 describe("renderUnavailableStatusline", () => {
   it("returns plain fallback for default formats", () => {

--- a/tests/utils.test.mjs
+++ b/tests/utils.test.mjs
@@ -1240,3 +1240,50 @@ describe("buildAttentionItems", () => {
     assert.doesNotMatch(text, /•Cx/);
   });
 });
+
+describe("buildAttentionItems branch field", () => {
+  it("propagates branch from AgentSession to AttentionItem", () => {
+    const now = 5_000;
+    const agents = [
+      {
+        pid: 10,
+        agentName: "Claude Code",
+        cwd: "/repo/a",
+        status: "Active",
+        phase: "permission",
+        lastActivityAt: 4000,
+        branch: "feature/42",
+      },
+      {
+        pid: 20,
+        agentName: "Codex",
+        cwd: "/repo/b",
+        status: "Active",
+        phase: "thinking",
+        lastActivityAt: 3000,
+        branch: "main",
+      },
+    ];
+
+    const items = buildAttentionItems(agents, now);
+    assert.equal(items.find((i) => i.pid === 10)?.branch, "feature/42");
+    assert.equal(items.find((i) => i.pid === 20)?.branch, "main");
+  });
+
+  it("sets branch to undefined when AgentSession has no branch", () => {
+    const now = 5_000;
+    const agents = [
+      {
+        pid: 30,
+        agentName: "Claude Code",
+        cwd: "/repo/c",
+        status: "Active",
+        phase: "tool",
+        lastActivityAt: 4000,
+      },
+    ];
+
+    const items = buildAttentionItems(agents, now);
+    assert.equal(items.find((i) => i.pid === 30)?.branch, undefined);
+  });
+});


### PR DESCRIPTION
## Summary

Resolves #38

Status/watch table redesign with branch and model columns, attention/jump command merge, and activity log improvements.

## Type

- [x] `[FEAT]` New feature
- [x] `[UX]` UX improvement

## Changes

**Status/watch table (`status`, `watch`):**
- Add Model column next to Agent: abbreviates `claude-opus-*` → `opus`, `claude-sonnet-*` → `sonnet`, `claude-haiku-*` → `haiku`, others up to 12 chars
- Add Branch column: detected from `.git/HEAD` directly, shows `—` if unavailable
- Fix worker row (`└─`) column alignment to account for new Model column

**Branch detection:**
- Read `.git/HEAD` during full enrichment in scanner
- Propagate `branch` field to `AgentSession` and `AttentionItem`

**attention/jump merge:**
- `attention` command absorbs `--pid` and `--attention-index` options
- `jump` kept as backward-compatible alias (delegates to `attention`)
- Removes duplicate interactive chooser loop (~100 lines)
- tmux `prefix j` removed; `prefix a` handles all interactive selection
- Option+N bindings updated to use `attention --attention-index`

**activity improvements:**
- Default sort order changed to desc (newest first)
- Add `--order asc|desc` option
- Add `--lines <n>` option (default 30, max 200)
- `--pid` with no matching activity shows session info (agent, cwd, sid)

## Status / Watch output changes

Before:
```
  Status     Agent   PID    CPU    MEM     Last   Tokens     Project                Branch
  ────────────────────────────────────────────────────────────────────────────────────────
  [Active]   Claude  1001     5%   423MB    50m out:22.3K  my-project             —
  [Active]   Codex   1002     0%    14MB     1d out:0      my-project             —
             └─      1003     0%    18MB
```

After:
```
  Status     Agent   Model        PID    CPU    MEM     Last   Tokens     Project                Branch
  ─────────────────────────────────────────────────────────────────────────────────────────────────────
  [Think]    Claude  opus         1001     1%    67MB     4h out:68.3K  my-project             main
  [Think]    Claude  sonnet       1002    14%   376MB     9s out:47.2K  my-project             feature/1
  [Idle]     Codex   gpt-5.4      1003     0%    13MB     3h out:0      my-project             —
             └─                   1004     0%    10MB

Unmatched Processes (1) — no matching session, consider killing:
  [Unmatched]  Codex  PID:1005  MEM:14MB [vscode]  kill 1005
```

## Checklist

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (258/258)
- [x] New features have tests (`abbreviateModel`, branch field, `activity --order`/`--lines`)
- [x] No hardcoded paths or environment-specific values

## Testing

```bash
marmonitor status           # Model and Branch columns visible
marmonitor attention --interactive          # interactive jump (was: jump --attention)
marmonitor attention --attention-index 1    # direct jump by index
marmonitor jump --attention-index 1         # backward-compat alias
marmonitor activity --pid <pid>             # desc by default, session info on no match
marmonitor activity --order asc --lines 50  # asc order, 50 lines
```

## Risk

Low — scanner and output changes only. Daemon protocol and config schema unchanged.

<details>
<summary><h2>🇰🇷 한국어 버전</h2></summary>

## 개요

status/watch 테이블 재설계 (branch/model 컬럼), attention/jump 통합, activity 로그 개선.

## 변경사항

**status/watch 테이블:**
- Model 컬럼 추가 (Agent 옆): opus/sonnet/haiku 축약, 기타 최대 12자
- Branch 컬럼 추가: `.git/HEAD` 직접 읽기, 없으면 `—`
- worker 행(`└─`) Model 자리 공백 추가로 PID 컬럼 정렬 수정

**attention/jump 통합:**
- `attention`에 `--pid`, `--attention-index` 흡수
- `jump`는 backward-compatible alias로 유지
- tmux `prefix j` 제거 → `prefix a`로 통합
- Option+N 바인딩은 `attention --attention-index`로 변경

**activity 개선:**
- 기본 정렬 desc (최신 먼저)
- `--order asc|desc`, `--lines <n>` 옵션 추가
- `--pid` 결과 없을 때 세션 정보 안내

## 위험도

Low — scanner/output 변경만. daemon 프로토콜/config 스키마 변경 없음.

</details>
