### PR TITLE
[FIX] skip Electron sub-processes in agent detection

### DIFF
--- a/src/scanner/process.ts
+++ b/src/scanner/process.ts
@@ -87,11 +87,18 @@ export function matchesProcessCommand(command: string, processName: string): boo
   return new RegExp(`(?:^|[/\\\\])${escaped}(?:\\s|$)`, "i").test(command);
 }
 
+/** Electron sub-process flags that indicate a desktop GUI helper, not a CLI agent. */
+const ELECTRON_TYPE_RE = /--type=(utility|renderer|gpu-process|zygote|broker)/;
+
 /** Match a process against agent signatures using process name first, then cmd fallback. */
 export function detectAgentFromProcessSignature(
   proc: { name: string; cmd?: string },
   config: MarmonitorConfig,
 ): string | null {
+  // Skip Electron sub-processes (renderer, utility, gpu, zygote) to avoid
+  // false-positive detection of desktop apps (e.g. Claude Desktop) as CLI agents.
+  if (proc.cmd && ELECTRON_TYPE_RE.test(proc.cmd)) return null;
+
   const name = proc.name.toLowerCase();
   const command = (proc.cmd ?? "").toLowerCase();
   for (const [agentName, agentConfig] of Object.entries(config.agents)) {

--- a/tests/scanner.test.mjs
+++ b/tests/scanner.test.mjs
@@ -39,6 +39,41 @@ describe("detectAgentFromProcessSignature", () => {
     );
   });
 
+  it("does not match Electron sub-processes from desktop apps", () => {
+    // Claude Desktop on Linux spawns Electron utility/renderer processes
+    // whose binary name is "claude" but are not Claude Code CLI sessions.
+    assert.equal(
+      detectAgentFromProcessSignature(
+        {
+          name: "claude",
+          cmd: "/proc/self/exe --type=utility --utility-sub-type=network.mojom.NetworkService --user-data-dir=/home/user/.config/Claude",
+        },
+        config,
+      ),
+      null,
+    );
+    assert.equal(
+      detectAgentFromProcessSignature(
+        {
+          name: "claude",
+          cmd: "/proc/self/exe --type=renderer --user-data-dir=/home/user/.config/Claude",
+        },
+        config,
+      ),
+      null,
+    );
+    assert.equal(
+      detectAgentFromProcessSignature(
+        {
+          name: "claude",
+          cmd: "/proc/self/exe --type=gpu-process --user-data-dir=/home/user/.config/Claude",
+        },
+        config,
+      ),
+      null,
+    );
+  });
+
   it("does not falsely match unrelated node processes", () => {
     assert.equal(
       detectAgentFromProcessSignature(


### PR DESCRIPTION
On Linux, Claude Desktop's Electron child processes (utility, renderer, gpu-process, zygote) share the "claude" binary name and are falsely detected as Claude Code CLI sessions. This adds an early check for the --type= flag that all Electron sub-processes carry, returning null before the name/command matching logic runs.

Tested on Linux with Claude Desktop running alongside Claude Code CLI.

https://claude.ai/code/session_017t3pEReGUAWUmCm18AfVpC

<!-- PR title format: [TYPE] #{issue} description -->
<!-- Examples: [FEAT] #1 Add risk alert badges to statusline -->
<!--           [BUG] #5 Fix stalled permission excluded from attention -->
<!--           [HOTFIX] #8 Crash on startup with missing config -->

## Summary

<!-- What does this PR do? Link related issues with "Resolve #N" -->

Resolve #

## Type

- [ ] `[FEAT]` New feature
- [x] `[BUG]` Bug fix
- [ ] `[HOTFIX]` Urgent fix
- [ ] `[PERF]` Performance improvement
- [ ] `[REFACTOR]` Code restructuring
- [ ] `[DOCS]` Documentation
- [ ] `[TEST]` Test coverage
- [ ] `[CICD]` CI/CD or release
- [ ] `[CHORE]` Maintenance

## Changes

-

## Checklist

- [ ] `npm run build` passes
- [ ] `npm run lint` passes
- [ ] `npm test` passes (all tests green)
- [ ] New features have tests
- [ ] README updated (if user-facing changes)
- [ ] No hardcoded paths or environment-specific values

## Testing

<!-- How did you verify this works? Include commands or screenshots -->

## Risk

<!-- Low / Medium / High — what could break? -->
