### PR TITLE
[FEAT] add block and block-mono badge styles without Powerline glyphs

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -71,7 +71,7 @@ export interface MarmonitorConfig {
         dockToggle: string;
         directJump: string[];
       };
-      badgeStyle: "basic" | "basic-mono" | "text" | "text-mono";
+      badgeStyle: "basic" | "basic-mono" | "block" | "block-mono" | "text" | "text-mono";
     };
     wezterm: {
       enabled: boolean;

--- a/src/output/badge-themes.ts
+++ b/src/output/badge-themes.ts
@@ -35,6 +35,20 @@ export const BADGE_THEMES: Record<string, BadgeTheme> = {
     jumpBack:
       "#[fg=#313244,bg=#1e1e2e]#[fg=#6c7086,bg=#313244] ↩ #[fg=#313244,bg=#1e1e2e]#[default]",
   },
+  block: {
+    badge: "#[bold,fg={fg},bg={bg}] {label} #[default]",
+    attention: "#[bold,fg=#11111b,bg={bg}] {index} #[fg=#cdd6f4,bg=#313244] {label} #[default]",
+    focus: "#[fg=#bac2de,bg=#181825] {text} #[default]",
+    empty: "#[fg=#cdd6f4,bg=#313244] no active #[default]",
+    jumpBack: "#[fg=#bac2de,bg=#45475a] ↩ #[default]",
+  },
+  "block-mono": {
+    badge: "#[bold,fg=#cdd6f4,bg=#313244] {label} #[default]",
+    attention: "#[bold,fg=#cdd6f4,bg=#313244] {index} #[fg=#6c7086,bg=#1e1e2e] {label} #[default]",
+    focus: "#[fg=#6c7086,bg=#181825] {text} #[default]",
+    empty: "#[fg=#6c7086,bg=#313244] no active #[default]",
+    jumpBack: "#[fg=#6c7086,bg=#313244] ↩ #[default]",
+  },
   text: {
     badge: "#[fg={bg}]{label}#[default]",
     attention: "#[fg={bg}]{index} {label}#[default]",

--- a/src/output/index.ts
+++ b/src/output/index.ts
@@ -48,7 +48,8 @@ let monoMode = false;
 
 /** Apply badge style to terminal chalk output: mono uses bold/dim only */
 export function applyTerminalStyle(badgeStyle: BadgeStyle): void {
-  monoMode = badgeStyle === "basic-mono" || badgeStyle === "text-mono";
+  monoMode =
+    badgeStyle === "basic-mono" || badgeStyle === "block-mono" || badgeStyle === "text-mono";
 }
 
 /** Agent name with distinct color */

--- a/src/output/utils.ts
+++ b/src/output/utils.ts
@@ -769,7 +769,7 @@ export function buildStatuslineSummary(
   return standardParts.join(" | ");
 }
 
-export type BadgeStyle = "basic" | "basic-mono" | "text" | "text-mono";
+export type BadgeStyle = "basic" | "basic-mono" | "block" | "block-mono" | "text" | "text-mono";
 
 function attentionBg(kind: Exclude<AttentionKind, "unmatched">): string {
   if (kind === "permission") return "#f38ba8";

--- a/tests/badge-themes.test.mjs
+++ b/tests/badge-themes.test.mjs
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  BADGE_THEMES,
+  renderAttention,
+  renderBadge,
+  renderFocus,
+  resolveTheme,
+} from "../dist/output/badge-themes.js";
+
+describe("resolveTheme", () => {
+  it("resolves all six built-in badge styles", () => {
+    for (const style of ["basic", "basic-mono", "block", "block-mono", "text", "text-mono"]) {
+      const theme = resolveTheme(style);
+      assert.ok(theme.badge, `${style} should have a badge template`);
+      assert.ok(theme.attention, `${style} should have an attention template`);
+      assert.ok(theme.focus, `${style} should have a focus template`);
+      assert.ok(theme.empty, `${style} should have an empty template`);
+      assert.ok(theme.jumpBack, `${style} should have a jumpBack template`);
+    }
+  });
+
+  it("falls back to basic for unknown style names", () => {
+    assert.deepEqual(resolveTheme("nonexistent"), BADGE_THEMES.basic);
+  });
+});
+
+describe("block badge themes", () => {
+  it("block theme contains background colors", () => {
+    const theme = BADGE_THEMES.block;
+    assert.match(theme.badge, /bg=/);
+    assert.match(theme.attention, /bg=/);
+  });
+
+  it("block theme does not contain Powerline glyphs", () => {
+    const theme = BADGE_THEMES.block;
+    const allTemplates = [theme.badge, theme.attention, theme.focus, theme.empty, theme.jumpBack];
+    for (const tmpl of allTemplates) {
+      assert.doesNotMatch(tmpl, /\uE0B0/, "should not contain U+E0B0");
+      assert.doesNotMatch(tmpl, /\uE0B2/, "should not contain U+E0B2");
+      assert.doesNotMatch(tmpl, /\uE0B4/, "should not contain U+E0B4");
+      assert.doesNotMatch(tmpl, /\uE0B6/, "should not contain U+E0B6");
+    }
+  });
+
+  it("block-mono theme does not contain Powerline glyphs", () => {
+    const theme = BADGE_THEMES["block-mono"];
+    const allTemplates = [theme.badge, theme.attention, theme.focus, theme.empty, theme.jumpBack];
+    for (const tmpl of allTemplates) {
+      assert.doesNotMatch(tmpl, /\uE0B0/, "should not contain U+E0B0");
+      assert.doesNotMatch(tmpl, /\uE0B2/, "should not contain U+E0B2");
+      assert.doesNotMatch(tmpl, /\uE0B4/, "should not contain U+E0B4");
+      assert.doesNotMatch(tmpl, /\uE0B6/, "should not contain U+E0B6");
+    }
+  });
+
+  it("block-mono uses monochrome palette only", () => {
+    const theme = BADGE_THEMES["block-mono"];
+    assert.doesNotMatch(theme.badge, /\{fg\}/, "should not use dynamic fg color");
+    assert.doesNotMatch(theme.badge, /\{bg\}/, "should not use dynamic bg color");
+  });
+
+  it("basic themes still contain Powerline glyphs for comparison", () => {
+    const basic = BADGE_THEMES.basic;
+    const hasGlyph = /[\uE0B0\uE0B2\uE0B4\uE0B6]/;
+    assert.match(basic.badge, hasGlyph, "basic badge should use Powerline separators");
+    assert.match(basic.attention, hasGlyph, "basic attention should use Powerline separators");
+  });
+});
+
+describe("renderBadge with block themes", () => {
+  it("renders block badge with substituted colors", () => {
+    const theme = resolveTheme("block");
+    const result = renderBadge(theme, "Cl 3", "#cdd6f4", "#89b4fa");
+    assert.match(result, /Cl 3/);
+    assert.match(result, /fg=#cdd6f4/);
+    assert.match(result, /bg=#89b4fa/);
+    assert.doesNotMatch(result, /[\uE0B0\uE0B2\uE0B4\uE0B6]/);
+  });
+
+  it("renders block-mono badge without dynamic color placeholders", () => {
+    const theme = resolveTheme("block-mono");
+    const result = renderBadge(theme, "Cx 1", "#cdd6f4", "#89b4fa");
+    assert.match(result, /Cx 1/);
+    assert.match(result, /bg=#313244/);
+    assert.doesNotMatch(result, /[\uE0B0\uE0B2\uE0B4\uE0B6]/);
+  });
+});
+
+describe("renderAttention with block themes", () => {
+  it("renders block attention pill with index and label", () => {
+    const theme = resolveTheme("block");
+    const result = renderAttention(theme, 1, "⏳Cl projects/myapp allow", "#f38ba8");
+    assert.match(result, / 1 /);
+    assert.match(result, /⏳Cl projects\/myapp allow/);
+    assert.match(result, /bg=#f38ba8/);
+    assert.doesNotMatch(result, /[\uE0B0\uE0B2\uE0B4\uE0B6]/);
+  });
+});
+
+describe("renderFocus with block themes", () => {
+  it("renders focus text in block style with background", () => {
+    const theme = resolveTheme("block");
+    const result = renderFocus(theme, "⏳ Claude myapp allow");
+    assert.match(result, /⏳ Claude myapp allow/);
+    assert.match(result, /bg=#181825/);
+  });
+});

--- a/tests/utils.test.mjs
+++ b/tests/utils.test.mjs
@@ -667,6 +667,56 @@ describe("buildStatuslineSummary", () => {
     assert.match(text, /#cdd6f4/);
   });
 
+  it("renders block badge style with colored bg but no Powerline glyphs", () => {
+    const snapshot = {
+      aliveCount: 5,
+      waitingCount: 1,
+      riskCount: 0,
+      stalledCount: 0,
+      unmatchedCount: 0,
+      activeCount: 3,
+      highCpuCount: 0,
+      thinkingCount: 1,
+      toolCount: 0,
+      claudeCount: 3,
+      codexCount: 2,
+      geminiCount: 0,
+    };
+    const text = buildTmuxBadgeBar(snapshot, undefined, "block");
+    assert.match(text, /Cl 3/);
+    assert.match(text, /Cx 2/);
+    assert.match(text, /bg=/);
+    assert.doesNotMatch(text, /\uE0B0/);
+    assert.doesNotMatch(text, /\uE0B2/);
+    assert.doesNotMatch(text, /\uE0B4/);
+    assert.doesNotMatch(text, /\uE0B6/);
+  });
+
+  it("renders block-mono badge style without Powerline glyphs", () => {
+    const snapshot = {
+      aliveCount: 2,
+      waitingCount: 0,
+      riskCount: 0,
+      stalledCount: 0,
+      unmatchedCount: 0,
+      activeCount: 1,
+      highCpuCount: 0,
+      thinkingCount: 0,
+      toolCount: 0,
+      claudeCount: 2,
+      codexCount: 0,
+      geminiCount: 0,
+    };
+    const text = buildTmuxBadgeBar(snapshot, undefined, "block-mono");
+    assert.match(text, /Cl 2/);
+    assert.match(text, /#cdd6f4/);
+    assert.match(text, /bg=#313244/);
+    assert.doesNotMatch(text, /\uE0B0/);
+    assert.doesNotMatch(text, /\uE0B2/);
+    assert.doesNotMatch(text, /\uE0B4/);
+    assert.doesNotMatch(text, /\uE0B6/);
+  });
+
   it("defaults to basic style when badgeStyle not specified", () => {
     const snapshot = {
       aliveCount: 1,
@@ -1238,5 +1288,43 @@ describe("buildAttentionItems", () => {
     assert.match(text, /⏳Cl p\/mjjo allow/);
     assert.doesNotMatch(text, /🤔Cl/);
     assert.doesNotMatch(text, /•Cx/);
+  });
+
+  it("renders attention pills in block style without Powerline glyphs", () => {
+    const now = Math.floor(Date.now() / 1000);
+    const text = buildTmuxAttentionPills(
+      [
+        {
+          kind: "permission",
+          priority: 0,
+          pid: 30,
+          agentName: "Claude Code",
+          cwd: "/home/user/projects/myapp",
+          status: "Active",
+          phase: "permission",
+        },
+        {
+          kind: "thinking",
+          priority: 1,
+          pid: 50,
+          agentName: "Codex",
+          cwd: "/home/user/projects/api",
+          status: "Active",
+          phase: "thinking",
+          lastActivityAt: now - 5,
+        },
+      ],
+      5,
+      undefined,
+      "block",
+    );
+    assert.match(text, / 1 /);
+    assert.match(text, /⏳Cl/);
+    assert.match(text, / 2 /);
+    assert.match(text, /🤔Cx/);
+    assert.match(text, /bg=/);
+    assert.doesNotMatch(text, /\uE0B0/);
+    assert.doesNotMatch(text, /\uE0B4/);
+    assert.doesNotMatch(text, /\uE0B6/);
   });
 });


### PR DESCRIPTION
The basic/basic-mono styles use Powerline arrow glyphs (U+E0B0, U+E0B4, U+E0B6) that render with visible overlap or misalignment on many Linux terminal + font combinations (e.g. Ghostty + JetBrains Mono Nerd Font). The new block/block-mono styles provide the same Catppuccin colored-background pill look without any Powerline separator characters, using plain color transitions instead.

<img width="856" height="92" alt="image" src="https://github.com/user-attachments/assets/faeff484-a6af-4534-8f8e-fb88639d7f0a" />


Users can switch via:
  { "integration": { "tmux": { "badgeStyle": "block" } } }

https://claude.ai/code/session_017t3pEReGUAWUmCm18AfVpC

<!-- PR title format: [TYPE] #{issue} description -->
<!-- Examples: [FEAT] #1 Add risk alert badges to statusline -->
<!--           [BUG] #5 Fix stalled permission excluded from attention -->
<!--           [HOTFIX] #8 Crash on startup with missing config -->

## Summary

<!-- What does this PR do? Link related issues with "Resolve #N" -->

Resolve #

## Type

- [x] `[FEAT]` New feature
- [ ] `[BUG]` Bug fix
- [ ] `[HOTFIX]` Urgent fix
- [ ] `[PERF]` Performance improvement
- [ ] `[REFACTOR]` Code restructuring
- [ ] `[DOCS]` Documentation
- [ ] `[TEST]` Test coverage
- [ ] `[CICD]` CI/CD or release
- [ ] `[CHORE]` Maintenance

## Changes

-

## Checklist

- [ ] `npm run build` passes
- [ ] `npm run lint` passes
- [ ] `npm test` passes (all tests green)
- [ ] New features have tests
- [ ] README updated (if user-facing changes)
- [ ] No hardcoded paths or environment-specific values

## Testing

<!-- How did you verify this works? Include commands or screenshots -->

## Risk

<!-- Low / Medium / High — what could break? -->
