### PR TITLE
[CICD] #43 Prepare v0.2.4 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to marmonitor are documented here.
 
+## [0.2.4] - 2026-04-08
+
+### Added
+- **Git branch context** in status and attention views for enriched sessions.
+- **Current pane context** on the right side of the tmux statusline.
+- **Status table model column** with abbreviated Claude model names and improved worker row alignment.
+- **Activity CLI improvements**: default descending order, `--order`, `--lines`, and better `--pid` guidance when no entries exist.
+- **Block badge styles**: `block` and `block-mono` badge themes without Powerline glyph separators for terminals/fonts that render Nerd Font arrows poorly.
+
+### Fixed
+- Claude Desktop Electron helper processes on Linux are no longer misdetected as Claude Code CLI sessions.
+- Claude Code activity logging now resolves the correct session file path.
+
+## [0.2.3] - 2026-04-04
+
+### Added
+- **Codex PID-to-thread binding registry** for more stable long-lived session mapping.
+- **Session activity log** and CLI views for tool usage and token tracking.
+
+### Fixed
+- Codex binding key mismatch between foreground and daemon paths.
+- Session continuity and activity freshness stabilization across scans.
+
 ## [0.2.2] - 2026-04-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -221,6 +221,8 @@ tmux badges and terminal text output can share one style via `integration.tmux.b
 
 - `basic` — default colored pills
 - `basic-mono` — monochrome pills with Powerline borders
+- `block` — filled background badges without Powerline separator glyphs
+- `block-mono` — monochrome filled badges without Powerline separator glyphs
 - `text` — plain colored text, no filled background
 - `text-mono` — grayscale text only
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "marmonitor",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "marmonitor",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "hasInstallScript": true,
       "license": "MIT",
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marmonitor",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "author": "MJ JO <mjjo16@gmail.com>",
   "description": "tmux status bar monitor for AI coding agents — track Claude Code, Codex, Gemini sessions, tokens, and phases in real time",
   "type": "module",


### PR DESCRIPTION
## Summary

Resolve #43

Prepare the `v0.2.4` release metadata on `dev`.

## Type

- [ ] `[FEAT]` New feature
- [ ] `[BUG]` Bug fix
- [ ] `[HOTFIX]` Urgent fix
- [ ] `[PERF]` Performance improvement
- [ ] `[REFACTOR]` Code restructuring
- [ ] `[DOCS]` Documentation
- [ ] `[TEST]` Test coverage
- [x] `[CICD]` CI/CD or release
- [ ] `[CHORE]` Maintenance

## Changes

- bump package version from `0.2.3` to `0.2.4`
- add the `v0.2.4` changelog entry
- document `block` and `block-mono` badge styles in `README.md`

## Checklist

- [ ] `npm run build` passes
- [ ] `npm run lint` passes
- [ ] `npm test` passes (all tests green)
- [x] New features have tests
- [x] README updated (if user-facing changes)
- [x] No hardcoded paths or environment-specific values

## Testing

Not run yet.

## Risk

Low. This PR only updates release metadata and user-facing documentation for the `v0.2.4` release.
