### PR TITLE
[FEAT] highlight active tmux window in statusline attention pills

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -499,33 +499,33 @@ function resolveAttentionLimit(
   return Math.min(Math.max(Math.floor(fallback), 1), 10);
 }
 
-function statuslineCacheFile(
-  format: string,
-  attentionLimit: number,
-  width?: number,
-  activePanePid?: number,
-): string {
+function statuslineCacheFile(format: string, attentionLimit: number, width?: number): string {
   const widthKey = width && width > 0 ? String(width) : "auto";
-  const paneKey = activePanePid ? String(activePanePid) : "none";
-  return join(
-    tmpdir(),
-    "marmonitor",
-    `statusline-${format}-${attentionLimit}-${widthKey}-${paneKey}.txt`,
-  );
+  return join(tmpdir(), "marmonitor", `statusline-${format}-${attentionLimit}-${widthKey}.txt`);
 }
 
+/** Read cached statusline. When activePanePid is provided, the cache is
+ *  only valid if the stored panePid (first line) matches — otherwise the
+ *  active-window highlight would be stale. Returns {content, panePid}. */
 async function readCachedStatusline(
   format: string,
   attentionLimit: number,
   width: number | undefined,
   ttlMs: number,
-  activePanePid?: number,
-): Promise<string | undefined> {
-  const path = statuslineCacheFile(format, attentionLimit, width, activePanePid);
+): Promise<{ content: string; panePid: number | undefined } | undefined> {
+  const path = statuslineCacheFile(format, attentionLimit, width);
   try {
     const fileStat = await stat(path);
     if (Date.now() - fileStat.mtimeMs > ttlMs) return undefined;
-    return (await readFile(path, "utf-8")).trimEnd();
+    const raw = (await readFile(path, "utf-8")).trimEnd();
+    const newline = raw.indexOf("\n");
+    if (newline === -1) return { content: raw, panePid: undefined };
+    const firstLine = raw.slice(0, newline);
+    const pid = Number.parseInt(firstLine, 10);
+    if (Number.isFinite(pid)) {
+      return { content: raw.slice(newline + 1), panePid: pid };
+    }
+    return { content: raw, panePid: undefined };
   } catch {
     return undefined;
   }
@@ -538,10 +538,11 @@ async function writeCachedStatusline(
   value: string,
   activePanePid?: number,
 ): Promise<void> {
-  const path = statuslineCacheFile(format, attentionLimit, width, activePanePid);
+  const path = statuslineCacheFile(format, attentionLimit, width);
+  const data = activePanePid ? `${activePanePid}\n${value}` : value;
   try {
     await mkdir(join(tmpdir(), "marmonitor"), { recursive: true });
-    await writeFile(path, value, "utf-8");
+    await writeFile(path, data, "utf-8");
   } catch {
     // cache failures must never break statusline rendering
   }
@@ -597,22 +598,30 @@ program
         }
         const attentionLimit = config.display.statuslineAttentionLimit;
         const width = resolveStatuslineWidth(opts.width);
-        // Resolve active pane PID early (~5ms tmux call) so the cache key
-        // reflects the current window — otherwise the highlight goes stale
-        // when the user switches tmux windows within the cache TTL.
-        const { getActiveTmuxPanePid } = await import("./tmux/index.js");
-        const activePanePid =
-          opts.statuslineFormat === "tmux-badges" ? await getActiveTmuxPanePid() : undefined;
+        const isTmuxBadges = opts.statuslineFormat === "tmux-badges";
+        // Try cache first. For tmux-badges the cached panePid is checked
+        // against the live pane only on cache hit — the tmux call is
+        // deferred so cache-miss paths pay for it just once.
         const cached = await readCachedStatusline(
           opts.statuslineFormat,
           attentionLimit,
           width,
           config.performance.statuslineTtlMs,
-          activePanePid,
         );
         if (cached) {
-          console.log(cached);
-          return;
+          if (isTmuxBadges && cached.panePid !== undefined) {
+            const { getActiveTmuxPanePid } = await import("./tmux/index.js");
+            const currentPanePid = await getActiveTmuxPanePid();
+            if (currentPanePid !== cached.panePid) {
+              // Active pane changed — fall through to re-render
+            } else {
+              console.log(cached.content);
+              return;
+            }
+          } else {
+            console.log(cached.content);
+            return;
+          }
         }
         const agents = await getAgentsSnapshot();
         if (agents.length === 0) {
@@ -622,16 +631,16 @@ program
         // Check jump-back anchor and resolve active agent for tmux-badges
         let hasJumpAnchor = false;
         let activeAgentPid: number | undefined;
-        if (opts.statuslineFormat === "tmux-badges") {
+        let activePanePid: number | undefined;
+        if (isTmuxBadges) {
           const { tmpdir: td } = await import("node:os");
           const { join: pj } = await import("node:path");
           const { loadJumpAnchor } = await import("./tmux/jump-anchor.js");
+          const { getActiveTmuxPanePid } = await import("./tmux/index.js");
           const agentPids = agents.map((a) => a.pid);
-          const [tty, resolvedActiveAgentPid] = await Promise.all([
-            getClientTty(),
-            findActiveAgentPid(agentPids, activePanePid),
-          ]);
-          activeAgentPid = resolvedActiveAgentPid;
+          const [tty, panePid] = await Promise.all([getClientTty(), getActiveTmuxPanePid()]);
+          activePanePid = panePid;
+          activeAgentPid = await findActiveAgentPid(agentPids, activePanePid);
           if (tty) {
             hasJumpAnchor = Boolean(
               await loadJumpAnchor(pj(td(), "marmonitor", "jump-anchors.json"), tty),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -499,9 +499,19 @@ function resolveAttentionLimit(
   return Math.min(Math.max(Math.floor(fallback), 1), 10);
 }
 
-function statuslineCacheFile(format: string, attentionLimit: number, width?: number): string {
+function statuslineCacheFile(
+  format: string,
+  attentionLimit: number,
+  width?: number,
+  activePanePid?: number,
+): string {
   const widthKey = width && width > 0 ? String(width) : "auto";
-  return join(tmpdir(), "marmonitor", `statusline-${format}-${attentionLimit}-${widthKey}.txt`);
+  const paneKey = activePanePid ? String(activePanePid) : "none";
+  return join(
+    tmpdir(),
+    "marmonitor",
+    `statusline-${format}-${attentionLimit}-${widthKey}-${paneKey}.txt`,
+  );
 }
 
 async function readCachedStatusline(
@@ -509,8 +519,9 @@ async function readCachedStatusline(
   attentionLimit: number,
   width: number | undefined,
   ttlMs: number,
+  activePanePid?: number,
 ): Promise<string | undefined> {
-  const path = statuslineCacheFile(format, attentionLimit, width);
+  const path = statuslineCacheFile(format, attentionLimit, width, activePanePid);
   try {
     const fileStat = await stat(path);
     if (Date.now() - fileStat.mtimeMs > ttlMs) return undefined;
@@ -525,8 +536,9 @@ async function writeCachedStatusline(
   attentionLimit: number,
   width: number | undefined,
   value: string,
+  activePanePid?: number,
 ): Promise<void> {
-  const path = statuslineCacheFile(format, attentionLimit, width);
+  const path = statuslineCacheFile(format, attentionLimit, width, activePanePid);
   try {
     await mkdir(join(tmpdir(), "marmonitor"), { recursive: true });
     await writeFile(path, value, "utf-8");
@@ -585,11 +597,18 @@ program
         }
         const attentionLimit = config.display.statuslineAttentionLimit;
         const width = resolveStatuslineWidth(opts.width);
+        // Resolve active pane PID early (~5ms tmux call) so the cache key
+        // reflects the current window — otherwise the highlight goes stale
+        // when the user switches tmux windows within the cache TTL.
+        const { getActiveTmuxPanePid } = await import("./tmux/index.js");
+        const activePanePid =
+          opts.statuslineFormat === "tmux-badges" ? await getActiveTmuxPanePid() : undefined;
         const cached = await readCachedStatusline(
           opts.statuslineFormat,
           attentionLimit,
           width,
           config.performance.statuslineTtlMs,
+          activePanePid,
         );
         if (cached) {
           console.log(cached);
@@ -600,7 +619,7 @@ program
           console.log(renderUnavailableStatusline(opts.statuslineFormat));
           return;
         }
-        // Check jump-back anchor and active window for tmux-badges
+        // Check jump-back anchor and resolve active agent for tmux-badges
         let hasJumpAnchor = false;
         let activeAgentPid: number | undefined;
         if (opts.statuslineFormat === "tmux-badges") {
@@ -610,7 +629,7 @@ program
           const agentPids = agents.map((a) => a.pid);
           const [tty, resolvedActiveAgentPid] = await Promise.all([
             getClientTty(),
-            findActiveAgentPid(agentPids),
+            findActiveAgentPid(agentPids, activePanePid),
           ]);
           activeAgentPid = resolvedActiveAgentPid;
           if (tty) {
@@ -628,7 +647,13 @@ program
           hasJumpAnchor,
           activeAgentPid,
         );
-        await writeCachedStatusline(opts.statuslineFormat, attentionLimit, width, rendered);
+        await writeCachedStatusline(
+          opts.statuslineFormat,
+          attentionLimit,
+          width,
+          rendered,
+          activePanePid,
+        );
         console.log(rendered);
         return;
       } catch {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,7 +44,12 @@ import { parseGeminiSession } from "./scanner/gemini.js";
 import { scanAgents } from "./scanner/index.js";
 import { loadRegistryFromFile } from "./scanner/session-registry.js";
 import { detectCliStdoutPhase } from "./scanner/status.js";
-import { captureTmuxPaneOutput, jumpToAgent, resolveTmuxJumpTarget } from "./tmux/index.js";
+import {
+  captureTmuxPaneOutput,
+  findActiveAgentPid,
+  jumpToAgent,
+  resolveTmuxJumpTarget,
+} from "./tmux/index.js";
 import { getClientTty, jumpBack } from "./tmux/jump-anchor.js";
 import { findClickedAgent, parseStatusClickToken } from "./tmux/status-click.js";
 import type { AgentSession } from "./types.js";
@@ -595,13 +600,19 @@ program
           console.log(renderUnavailableStatusline(opts.statuslineFormat));
           return;
         }
-        // Check jump-back anchor for indicator
+        // Check jump-back anchor and active window for tmux-badges
         let hasJumpAnchor = false;
+        let activeAgentPid: number | undefined;
         if (opts.statuslineFormat === "tmux-badges") {
           const { tmpdir: td } = await import("node:os");
           const { join: pj } = await import("node:path");
           const { loadJumpAnchor } = await import("./tmux/jump-anchor.js");
-          const tty = await getClientTty();
+          const agentPids = agents.map((a) => a.pid);
+          const [tty, resolvedActiveAgentPid] = await Promise.all([
+            getClientTty(),
+            findActiveAgentPid(agentPids),
+          ]);
+          activeAgentPid = resolvedActiveAgentPid;
           if (tty) {
             hasJumpAnchor = Boolean(
               await loadJumpAnchor(pj(td(), "marmonitor", "jump-anchors.json"), tty),
@@ -615,6 +626,7 @@ program
           width,
           config.integration.tmux.badgeStyle,
           hasJumpAnchor,
+          activeAgentPid,
         );
         await writeCachedStatusline(opts.statuslineFormat, attentionLimit, width, rendered);
         console.log(rendered);

--- a/src/output/badge-themes.ts
+++ b/src/output/badge-themes.ts
@@ -9,6 +9,8 @@
 export interface BadgeTheme {
   badge: string;
   attention: string;
+  /** Attention segment for the currently active tmux window */
+  attentionActive: string;
   focus: string;
   empty: string;
   jumpBack: string;
@@ -19,6 +21,8 @@ export const BADGE_THEMES: Record<string, BadgeTheme> = {
     badge: "#[fg={bg},bg=#1e1e2e]#[bold,fg={fg},bg={bg}] {label} #[fg={bg},bg=#1e1e2e]#[default]",
     attention:
       "#[fg={bg},bg=#1e1e2e]#[bold,fg=#11111b,bg={bg}] {index} #[fg=#313244,bg={bg}]#[fg=#cdd6f4,bg=#313244] {label} #[fg=#313244,bg=#1e1e2e]#[default]",
+    attentionActive:
+      "#[fg={bg},bg=#1e1e2e]#[bold,underscore,fg=#11111b,bg={bg}] {index} #[fg=#45475a,bg={bg}]#[underscore,fg=#cdd6f4,bg=#45475a] {label} #[fg=#45475a,bg=#1e1e2e]#[default]",
     focus: "#[fg=#bac2de,bg=#181825] {text} #[default]",
     empty: "#[fg=#cdd6f4,bg=#313244] no active #[fg=#313244,bg=#1e1e2e]#[default]",
     jumpBack:
@@ -29,6 +33,8 @@ export const BADGE_THEMES: Record<string, BadgeTheme> = {
       "#[fg=#313244,bg=#1e1e2e]#[bold,fg=#cdd6f4,bg=#313244] {label} #[fg=#313244,bg=#1e1e2e]#[default]",
     attention:
       "#[fg=#313244,bg=#1e1e2e]#[bold,fg=#cdd6f4,bg=#313244] {index} #[fg=#1e1e2e,bg=#313244]#[fg=#6c7086,bg=#1e1e2e] {label} #[fg=#1e1e2e]#[default]",
+    attentionActive:
+      "#[fg=#45475a,bg=#1e1e2e]#[bold,underscore,fg=#cdd6f4,bg=#45475a] {index} #[fg=#1e1e2e,bg=#45475a]#[underscore,fg=#cdd6f4,bg=#1e1e2e] {label} #[fg=#1e1e2e]#[default]",
     focus: "#[fg=#6c7086,bg=#181825] {text} #[default]",
     empty:
       "#[fg=#313244,bg=#1e1e2e]#[fg=#6c7086,bg=#313244] no active #[fg=#313244,bg=#1e1e2e]#[default]",
@@ -38,6 +44,8 @@ export const BADGE_THEMES: Record<string, BadgeTheme> = {
   block: {
     badge: "#[bold,fg={fg},bg={bg}] {label} #[default]",
     attention: "#[bold,fg=#11111b,bg={bg}] {index} #[fg=#cdd6f4,bg=#313244] {label} #[default]",
+    attentionActive:
+      "#[bold,underscore,fg=#11111b,bg={bg}] {index} #[underscore,fg=#cdd6f4,bg=#45475a] {label} #[default]",
     focus: "#[fg=#bac2de,bg=#181825] {text} #[default]",
     empty: "#[fg=#cdd6f4,bg=#313244] no active #[default]",
     jumpBack: "#[fg=#bac2de,bg=#45475a] ↩ #[default]",
@@ -45,6 +53,8 @@ export const BADGE_THEMES: Record<string, BadgeTheme> = {
   "block-mono": {
     badge: "#[bold,fg=#cdd6f4,bg=#313244] {label} #[default]",
     attention: "#[bold,fg=#cdd6f4,bg=#313244] {index} #[fg=#6c7086,bg=#1e1e2e] {label} #[default]",
+    attentionActive:
+      "#[bold,underscore,fg=#cdd6f4,bg=#45475a] {index} #[underscore,fg=#cdd6f4,bg=#1e1e2e] {label} #[default]",
     focus: "#[fg=#6c7086,bg=#181825] {text} #[default]",
     empty: "#[fg=#6c7086,bg=#313244] no active #[default]",
     jumpBack: "#[fg=#6c7086,bg=#313244] ↩ #[default]",
@@ -52,6 +62,7 @@ export const BADGE_THEMES: Record<string, BadgeTheme> = {
   text: {
     badge: "#[fg={bg}]{label}#[default]",
     attention: "#[fg={bg}]{index} {label}#[default]",
+    attentionActive: "#[underscore,fg={bg}]{index} {label}#[default]",
     focus: "{text}",
     empty: "no active",
     jumpBack: "#[fg=#89b4fa]↩#[default]",
@@ -59,6 +70,8 @@ export const BADGE_THEMES: Record<string, BadgeTheme> = {
   "text-mono": {
     badge: "#[fg=#cdd6f4]{label}#[default]",
     attention: "#[bold,fg=#cdd6f4]{index}#[default] #[fg=#6c7086]{label}#[default]",
+    attentionActive:
+      "#[bold,underscore,fg=#cdd6f4]{index}#[default] #[underscore,fg=#6c7086]{label}#[default]",
     focus: "#[fg=#6c7086]{text}#[default]",
     empty: "#[fg=#6c7086]no active#[default]",
     jumpBack: "#[fg=#6c7086]↩#[default]",
@@ -76,6 +89,18 @@ export function renderAttention(
   bg: string,
 ): string {
   return theme.attention
+    .replaceAll("{index}", String(index))
+    .replaceAll("{label}", label)
+    .replaceAll("{bg}", bg);
+}
+
+export function renderAttentionActive(
+  theme: BadgeTheme,
+  index: number,
+  label: string,
+  bg: string,
+): string {
+  return theme.attentionActive
     .replaceAll("{index}", String(index))
     .replaceAll("{label}", label)
     .replaceAll("{bg}", bg);

--- a/src/output/index.ts
+++ b/src/output/index.ts
@@ -681,6 +681,7 @@ export async function renderStatusline(
   width?: number,
   badgeStyle: BadgeStyle = "basic",
   hasJumpAnchor = false,
+  activeAgentPid?: number,
 ): Promise<string> {
   const alive = agents.filter((a) => a.status !== "Dead" && a.status !== "Unmatched");
   const unmatched = agents.filter((a) => a.status === "Unmatched");
@@ -722,6 +723,7 @@ export async function renderStatusline(
       attentionLimit,
       width,
       badgeStyle,
+      activeAgentPid,
     );
     return buildTmuxBadgeBar(snapshot, focusText, badgeStyle, hasJumpAnchor);
   }

--- a/src/output/utils.ts
+++ b/src/output/utils.ts
@@ -1,5 +1,11 @@
 import type { AgentSession, SessionPhase } from "../types.js";
-import { renderAttention, renderBadge, renderFocus, resolveTheme } from "./badge-themes.js";
+import {
+  renderAttention,
+  renderAttentionActive,
+  renderBadge,
+  renderFocus,
+  resolveTheme,
+} from "./badge-themes.js";
 
 /**
  * Pure utility functions for marmonitor.
@@ -814,6 +820,7 @@ export function buildTmuxAttentionPills(
   maxCount = 5,
   width?: number,
   badgeStyle: BadgeStyle = "basic",
+  activeAgentPid?: number,
 ): string | undefined {
   if (maxCount <= 0) return undefined;
   const layout = resolveStatuslineDetailLayout(width, maxCount);
@@ -852,9 +859,11 @@ export function buildTmuxAttentionPills(
               : time
                 ? `⚠${agent} ${path} ${time}`
                 : `⚠${agent} ${path}`;
+    const isActive = activeAgentPid !== undefined && item.pid === activeAgentPid;
+    const render = isActive ? renderAttentionActive : renderAttention;
     return tmuxUserRange(
       `pid:${item.pid}`,
-      renderAttention(theme, index + 1, label, attentionBg(item.kind)),
+      render(theme, index + 1, label, attentionBg(item.kind)),
     );
   });
 

--- a/src/tmux/index.ts
+++ b/src/tmux/index.ts
@@ -148,12 +148,18 @@ export async function getActiveTmuxPanePid(): Promise<number | undefined> {
   }
 }
 
-/** Find the agent PID that runs inside the currently active tmux pane */
-export async function findActiveAgentPid(agentPids: number[]): Promise<number | undefined> {
+/** Find the agent PID that runs inside the currently active tmux pane.
+ *  When panePid is provided, skips the tmux query (useful when the caller
+ *  already resolved the active pane PID for cache-key purposes). */
+export async function findActiveAgentPid(
+  agentPids: number[],
+  panePid?: number,
+): Promise<number | undefined> {
   if (agentPids.length === 0) return undefined;
   try {
-    const [activePanePid, childMap] = await Promise.all([getActiveTmuxPanePid(), getProcessTree()]);
+    const activePanePid = panePid ?? (await getActiveTmuxPanePid());
     if (!activePanePid) return undefined;
+    const childMap = await getProcessTree();
     return agentPids.find((pid) => isPidInTree(activePanePid, pid, childMap));
   } catch {
     return undefined;

--- a/src/tmux/index.ts
+++ b/src/tmux/index.ts
@@ -137,6 +137,29 @@ export async function getProcessTree(): Promise<Map<number, number[]>> {
   }
 }
 
+/** Get the PID of the currently active tmux pane */
+export async function getActiveTmuxPanePid(): Promise<number | undefined> {
+  try {
+    const { stdout } = await execFileAsync("tmux", ["display-message", "-p", "#{pane_pid}"]);
+    const pid = Number.parseInt(stdout.trim(), 10);
+    return Number.isFinite(pid) ? pid : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Find the agent PID that runs inside the currently active tmux pane */
+export async function findActiveAgentPid(agentPids: number[]): Promise<number | undefined> {
+  if (agentPids.length === 0) return undefined;
+  try {
+    const [activePanePid, childMap] = await Promise.all([getActiveTmuxPanePid(), getProcessTree()]);
+    if (!activePanePid) return undefined;
+    return agentPids.find((pid) => isPidInTree(activePanePid, pid, childMap));
+  } catch {
+    return undefined;
+  }
+}
+
 export async function resolveTmuxJumpTarget(
   agent: Pick<AgentSession, "pid" | "cwd">,
 ): Promise<TmuxJumpTarget | undefined> {

--- a/tests/badge-themes.test.mjs
+++ b/tests/badge-themes.test.mjs
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import {
   BADGE_THEMES,
   renderAttention,
+  renderAttentionActive,
   renderBadge,
   renderFocus,
   resolveTheme,
@@ -14,6 +15,7 @@ describe("resolveTheme", () => {
       const theme = resolveTheme(style);
       assert.ok(theme.badge, `${style} should have a badge template`);
       assert.ok(theme.attention, `${style} should have an attention template`);
+      assert.ok(theme.attentionActive, `${style} should have an attentionActive template`);
       assert.ok(theme.focus, `${style} should have a focus template`);
       assert.ok(theme.empty, `${style} should have an empty template`);
       assert.ok(theme.jumpBack, `${style} should have a jumpBack template`);
@@ -34,7 +36,14 @@ describe("block badge themes", () => {
 
   it("block theme does not contain Powerline glyphs", () => {
     const theme = BADGE_THEMES.block;
-    const allTemplates = [theme.badge, theme.attention, theme.focus, theme.empty, theme.jumpBack];
+    const allTemplates = [
+      theme.badge,
+      theme.attention,
+      theme.attentionActive,
+      theme.focus,
+      theme.empty,
+      theme.jumpBack,
+    ];
     for (const tmpl of allTemplates) {
       assert.doesNotMatch(tmpl, /\uE0B0/, "should not contain U+E0B0");
       assert.doesNotMatch(tmpl, /\uE0B2/, "should not contain U+E0B2");
@@ -45,7 +54,14 @@ describe("block badge themes", () => {
 
   it("block-mono theme does not contain Powerline glyphs", () => {
     const theme = BADGE_THEMES["block-mono"];
-    const allTemplates = [theme.badge, theme.attention, theme.focus, theme.empty, theme.jumpBack];
+    const allTemplates = [
+      theme.badge,
+      theme.attention,
+      theme.attentionActive,
+      theme.focus,
+      theme.empty,
+      theme.jumpBack,
+    ];
     for (const tmpl of allTemplates) {
       assert.doesNotMatch(tmpl, /\uE0B0/, "should not contain U+E0B0");
       assert.doesNotMatch(tmpl, /\uE0B2/, "should not contain U+E0B2");
@@ -95,6 +111,51 @@ describe("renderAttention with block themes", () => {
     assert.match(result, /⏳Cl projects\/myapp allow/);
     assert.match(result, /bg=#f38ba8/);
     assert.doesNotMatch(result, /[\uE0B0\uE0B2\uE0B4\uE0B6]/);
+  });
+});
+
+describe("renderAttentionActive", () => {
+  it("renders active attention pill with underscore styling", () => {
+    const theme = resolveTheme("basic");
+    const result = renderAttentionActive(theme, 1, "⏳Cl projects/myapp allow", "#f38ba8");
+    assert.match(result, / 1 /);
+    assert.match(result, /⏳Cl projects\/myapp allow/);
+    assert.match(result, /underscore/);
+    assert.match(result, /bg=#f38ba8/);
+  });
+
+  it("renders active attention pill differently from normal attention", () => {
+    const theme = resolveTheme("basic");
+    const normal = renderAttention(theme, 1, "test label", "#f38ba8");
+    const active = renderAttentionActive(theme, 1, "test label", "#f38ba8");
+    assert.notEqual(normal, active);
+    assert.match(active, /underscore/);
+    assert.doesNotMatch(normal, /underscore/);
+  });
+
+  it("renders block style active pill without Powerline glyphs", () => {
+    const theme = resolveTheme("block");
+    const result = renderAttentionActive(theme, 2, "🤔Cx api 5s", "#cba6f7");
+    assert.match(result, / 2 /);
+    assert.match(result, /🤔Cx api 5s/);
+    assert.match(result, /underscore/);
+    assert.doesNotMatch(result, /[\uE0B0\uE0B2\uE0B4\uE0B6]/);
+  });
+
+  it("uses brighter background for active pill label area", () => {
+    const theme = resolveTheme("basic");
+    const active = renderAttentionActive(theme, 1, "label", "#f38ba8");
+    assert.match(active, /bg=#45475a/);
+  });
+
+  it("works for all six themes", () => {
+    for (const style of ["basic", "basic-mono", "block", "block-mono", "text", "text-mono"]) {
+      const theme = resolveTheme(style);
+      const result = renderAttentionActive(theme, 1, "test", "#f38ba8");
+      assert.ok(result, `${style} should render attentionActive`);
+      assert.match(result, /test/, `${style} should contain the label`);
+      assert.match(result, /1/, `${style} should contain the index`);
+    }
   });
 });
 

--- a/tests/utils.test.mjs
+++ b/tests/utils.test.mjs
@@ -1290,6 +1290,75 @@ describe("buildAttentionItems", () => {
     assert.doesNotMatch(text, /•Cx/);
   });
 
+  it("highlights the active agent pill with underscore styling", () => {
+    const now = Math.floor(Date.now() / 1000);
+    const items = [
+      {
+        kind: "permission",
+        priority: 0,
+        pid: 30,
+        agentName: "Claude Code",
+        cwd: "/home/user/projects/myapp",
+        status: "Active",
+        phase: "permission",
+      },
+      {
+        kind: "thinking",
+        priority: 1,
+        pid: 50,
+        agentName: "Claude Code",
+        cwd: "/home/user/projects/api",
+        status: "Active",
+        phase: "thinking",
+        lastActivityAt: now - 5,
+      },
+    ];
+
+    const withActive = buildTmuxAttentionPills(items, 5, undefined, "basic", 50);
+    const withoutActive = buildTmuxAttentionPills(items, 5, undefined, "basic");
+
+    assert.notEqual(withActive, withoutActive);
+    assert.match(withActive, /underscore/);
+  });
+
+  it("does not highlight any pill when activeAgentPid does not match", () => {
+    const items = [
+      {
+        kind: "permission",
+        priority: 0,
+        pid: 30,
+        agentName: "Claude Code",
+        cwd: "/home/user/projects/myapp",
+        status: "Active",
+        phase: "permission",
+      },
+    ];
+
+    const withUnknownPid = buildTmuxAttentionPills(items, 5, undefined, "basic", 9999);
+    const withoutActive = buildTmuxAttentionPills(items, 5, undefined, "basic");
+
+    assert.equal(withUnknownPid, withoutActive);
+  });
+
+  it("highlights active pill in block style without Powerline glyphs", () => {
+    const items = [
+      {
+        kind: "thinking",
+        priority: 1,
+        pid: 42,
+        agentName: "Codex",
+        cwd: "/home/user/projects/api",
+        status: "Active",
+        phase: "thinking",
+      },
+    ];
+
+    const text = buildTmuxAttentionPills(items, 5, undefined, "block", 42);
+    assert.match(text, /underscore/);
+    assert.match(text, /🤔Cx/);
+    assert.doesNotMatch(text, /[\uE0B0\uE0B2\uE0B4\uE0B6]/);
+  });
+
   it("renders attention pills in block style without Powerline glyphs", () => {
     const now = Math.floor(Date.now() / 1000);
     const text = buildTmuxAttentionPills(


### PR DESCRIPTION
## Summary

- Detect which agent session runs in the currently active tmux pane and apply a distinct visual style (underscore + brighter background) to its attention pill in the statusline
- Include active pane PID in the statusline cache key so the highlight updates immediately when the user switches tmux windows
- Add `attentionActive` template to all six badge themes (basic, basic-mono, block, block-mono, text, text-mono)

## Motivation

When multiple AI agent sessions are listed in the tmux statusline, it is difficult to tell which pill corresponds to the currently focused window. This adds a visual indicator (underscore + brighter label background `#45475a`) to distinguish the active window at a glance.

<img width="1717" height="119" alt="image" src="https://github.com/user-attachments/assets/c91e21f4-e87e-4bc9-8b2f-eb952cc27a30" />


## Changes

| File | Description |
|------|-------------|
| `src/tmux/index.ts` | Add `getActiveTmuxPanePid()` and `findActiveAgentPid()` |
| `src/output/badge-themes.ts` | Add `attentionActive` template + `renderAttentionActive()` to all themes |
| `src/output/utils.ts` | Accept `activeAgentPid` in `buildTmuxAttentionPills()` |
| `src/output/index.ts` | Thread `activeAgentPid` through `renderStatusline()` |
| `src/cli.ts` | Resolve active pane PID before cache check; include in cache key |
| `tests/badge-themes.test.mjs` | 5 new tests for `renderAttentionActive` + extended theme validation |
| `tests/utils.test.mjs` | 3 new tests for active pill highlighting in `buildTmuxAttentionPills` |

## Performance

- **Cache hit path**: +~5ms (single `tmux display-message` call to resolve active pane PID for cache key)
- **Cache miss path**: No additional overhead — reuses the already-resolved pane PID
- **Window switch**: Immediately invalidates cache (pane PID changes the cache key)

## Test plan

- [x] `renderAttentionActive` renders underscore styling across all six themes
- [x] Active pill differs from normal `renderAttention` output
- [x] Block themes do not contain Powerline glyphs in `attentionActive`
- [x] `buildTmuxAttentionPills` highlights only the matching `activeAgentPid`
- [x] Non-matching PID produces identical output to no-active rendering
- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] `npm test` passes (278/281, 3 pre-existing sqlite3 failures)

