### PR TITLE
[BUG] #47 stopDaemon polls until process dies to prevent double daemon

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1416,15 +1416,23 @@ async function stopDaemon(): Promise<boolean> {
     return false;
   }
   process.kill(pid, "SIGTERM");
-  // Poll until the process actually dies (up to 3s) to prevent double-start
-  // on restart when the daemon is mid-scan and 500ms isn't enough.
-  for (let i = 0; i < 30; i++) {
+  // Poll until the process actually dies (up to 2s) to prevent double-start
+  // on restart when the daemon is mid-scan and a fixed wait isn't enough.
+  let dead = false;
+  for (let i = 0; i < 20; i++) {
     await new Promise((r) => setTimeout(r, 100));
     try {
       process.kill(pid, 0);
     } catch {
+      dead = true;
       break; // process confirmed dead
     }
+  }
+  // Fallback: SIGKILL if still alive after 2s (should not happen in normal operation)
+  if (!dead) {
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {}
   }
   console.log(`✓ Daemon stopped (PID: ${pid})`);
   return true;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1416,6 +1416,16 @@ async function stopDaemon(): Promise<boolean> {
     return false;
   }
   process.kill(pid, "SIGTERM");
+  // Poll until the process actually dies (up to 3s) to prevent double-start
+  // on restart when the daemon is mid-scan and 500ms isn't enough.
+  for (let i = 0; i < 30; i++) {
+    await new Promise((r) => setTimeout(r, 100));
+    try {
+      process.kill(pid, 0);
+    } catch {
+      break; // process confirmed dead
+    }
+  }
   console.log(`✓ Daemon stopped (PID: ${pid})`);
   return true;
 }
@@ -1441,7 +1451,6 @@ program
   .description("Restart background scan daemon")
   .action(async () => {
     await stopDaemon();
-    await new Promise((r) => setTimeout(r, 500));
     await startDaemon();
     process.exit(0);
   });


### PR DESCRIPTION
## Summary

Resolve #47

Fix a race condition in `marmonitor restart` that occasionally left two daemon processes running simultaneously.

## 한국어 요약

- `stopDaemon()`이 SIGTERM만 보내고 즉시 리턴하는 문제를 수정했습니다.
- 기존 `restart`는 고정 500ms 대기 후 새 데몬을 시작했는데, 데몬이 스캔 중(파일 I/O, ps 서브프로세스)이면 500ms 안에 죽지 않아 `startDaemon()`이 "already running"으로 조기 종료되는 경우가 있었습니다.
- 사용자가 재시도로 `marmonitor start`를 실행하면, 그 사이 구 데몬이 사망하여 두 번째 데몬이 시작되고 2개가 공존하는 현상이 발생했습니다.
- SIGTERM 전송 후 최대 2초간 100ms 간격으로 프로세스 생존 여부를 polling하도록 변경했습니다.
- 2초 내에도 살아있으면 SIGKILL로 강제 종료합니다.
- `restart`의 고정 500ms sleep은 불필요해져 제거했습니다.

## Type

- [ ] `[FEAT]` New feature
- [x] `[BUG]` Bug fix
- [ ] `[HOTFIX]` Urgent fix
- [ ] `[PERF]` Performance improvement
- [ ] `[REFACTOR]` Code restructuring
- [ ] `[DOCS]` Documentation
- [ ] `[TEST]` Test coverage
- [ ] `[CICD]` CI/CD or release
- [ ] `[CHORE]` Maintenance

## Changes

- `stopDaemon()`: poll `process.kill(pid, 0)` every 100ms (up to 2s) after SIGTERM to confirm process is dead
- `stopDaemon()`: SIGKILL fallback if process is still alive after 2s
- `restart` command: remove fixed 500ms sleep — redundant since `stopDaemon()` now waits for actual termination

## Checklist

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (all tests green)
- [ ] New features have tests
- [ ] README updated (if user-facing changes)
- [x] No hardcoded paths or environment-specific values

## Testing

- `npm run build`
- `npm run lint`
- `npm test`
- manual check:
  - `marmonitor restart` while daemon is mid-scan — confirm only one process remains
  - `ps aux | grep marmonitor` shows single daemon after restart

## Risk

Low. Change is limited to the stop/restart lifecycle. `process.kill(pid, 0)` is a standard existence check with no side effects. SIGKILL is only sent as a last resort after 2s — daemon write operations (snapshot.json, registry.json) are idempotent and recover on next scan.
