### PR TITLE
[FEAT] #49 Alert System — reusable notification foundation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       "dependencies": {
         "chalk": "^5.3",
         "commander": "^12.1",
+        "node-notifier": "^10.0.1",
         "pidusage": "^3.0",
         "ps-list": "^8.1",
         "systeminformation": "^5.22"
@@ -26,6 +27,7 @@
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
         "@types/node": "^20.14",
+        "@types/node-notifier": "^8.0.5",
         "@types/pidusage": "^2.0.5",
         "typescript": "^5.5"
       },
@@ -207,6 +209,16 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/node-notifier": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/@types/node-notifier/-/node-notifier-8.0.5.tgz",
+      "integrity": "sha512-LX7+8MtTsv6szumAp6WOy87nqMEdGhhry/Qfprjm1Ma6REjVzeF7SCyvPtp5RaF6IkXCS9V4ra8g5fwvf2ZAYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/pidusage": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/pidusage/-/pidusage-2.0.5.tgz",
@@ -233,6 +245,59 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/growly": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+      "integrity": "sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==",
+      "license": "MIT"
+    },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/node-notifier": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-10.0.1.tgz",
+      "integrity": "sha512-YX7TSyDukOZ0g+gmzjB6abKu+hTGvO8+8+gIFDsRCU2t8fLV/P2unmt+LGFaIa4y64aX98Qksa97rgz4vMNeLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "growly": "^1.3.0",
+        "is-wsl": "^2.2.0",
+        "semver": "^7.3.5",
+        "shellwords": "^0.1.1",
+        "uuid": "^8.3.2",
+        "which": "^2.0.2"
       }
     },
     "node_modules/pidusage": {
@@ -277,6 +342,24 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shellwords": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "license": "MIT"
     },
     "node_modules/systeminformation": {
@@ -325,6 +408,30 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   "dependencies": {
     "chalk": "^5.3",
     "commander": "^12.1",
+    "node-notifier": "^10.0.1",
     "pidusage": "^3.0",
     "ps-list": "^8.1",
     "systeminformation": "^5.22"
@@ -62,6 +63,7 @@
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "@types/node": "^20.14",
+    "@types/node-notifier": "^8.0.5",
     "@types/pidusage": "^2.0.5",
     "typescript": "^5.5"
   },

--- a/src/alerts/desktop.ts
+++ b/src/alerts/desktop.ts
@@ -1,0 +1,27 @@
+/** macOS / Linux desktop notification via node-notifier */
+
+import type { Alert } from "./types.js";
+
+const APP_NAME = "marmonitor";
+
+function title(alert: Alert): string {
+  switch (alert.type) {
+    case "context_critical":
+      return "⚠️ Context Critical";
+    case "context_warn":
+      return "Context Warning";
+    case "security":
+      return "🚨 Security Alert";
+  }
+}
+
+export async function sendDesktopNotification(alert: Alert): Promise<void> {
+  try {
+    // Dynamic import — node-notifier is optional; fail silently if missing
+    const notifier = await import("node-notifier");
+    const message = alert.detail ? `${alert.message}\n${alert.detail}` : alert.message;
+    notifier.default.notify({ title: title(alert), message });
+  } catch {
+    // node-notifier unavailable or notification failed — silent
+  }
+}

--- a/src/alerts/index.ts
+++ b/src/alerts/index.ts
@@ -4,3 +4,4 @@ export { appendAlertLog } from "./log.js";
 export { checkTokenAlert, DEFAULT_TOKEN_THRESHOLDS } from "./token.js";
 export type { TokenAlertThresholds } from "./token.js";
 export { writeAlertsSnapshot, readAlertsSnapshot } from "./snapshot.js";
+export { sendDesktopNotification } from "./desktop.js";

--- a/src/alerts/index.ts
+++ b/src/alerts/index.ts
@@ -1,0 +1,6 @@
+export type { Alert, AlertSeverity, AlertType, AlertsSnapshot } from "./types.js";
+export { AlertStore } from "./store.js";
+export { appendAlertLog } from "./log.js";
+export { checkTokenAlert, DEFAULT_TOKEN_THRESHOLDS } from "./token.js";
+export type { TokenAlertThresholds } from "./token.js";
+export { writeAlertsSnapshot, readAlertsSnapshot } from "./snapshot.js";

--- a/src/alerts/log.ts
+++ b/src/alerts/log.ts
@@ -1,0 +1,16 @@
+/** Append-only alert log writer → ~/.config/marmonitor/alerts.log */
+
+import { appendFile, mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
+import type { Alert } from "./types.js";
+
+export async function appendAlertLog(logPath: string, alert: Alert): Promise<void> {
+  try {
+    await mkdir(dirname(logPath), { recursive: true });
+    const ts = new Date(alert.createdAt).toISOString();
+    const line = `${ts} [${alert.severity.toUpperCase()}] ${alert.type} pid=${alert.agentPid} ${alert.message}${alert.detail ? ` | ${alert.detail}` : ""}\n`;
+    await appendFile(logPath, line, "utf-8");
+  } catch {
+    // log failures must never crash callers
+  }
+}

--- a/src/alerts/snapshot.ts
+++ b/src/alerts/snapshot.ts
@@ -1,0 +1,26 @@
+/** Write/read alerts snapshot alongside daemon snapshot */
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import type { Alert, AlertsSnapshot } from "./types.js";
+
+export async function writeAlertsSnapshot(path: string, active: Alert[]): Promise<void> {
+  try {
+    await mkdir(dirname(path), { recursive: true });
+    const snap: AlertsSnapshot = { active, updatedAt: Date.now() };
+    await writeFile(path, JSON.stringify(snap), "utf-8");
+  } catch {
+    // snapshot write failures must never crash callers
+  }
+}
+
+export async function readAlertsSnapshot(path: string, ttlMs = 10_000): Promise<Alert[]> {
+  try {
+    const raw = await readFile(path, "utf-8");
+    const snap = JSON.parse(raw) as AlertsSnapshot;
+    if (Date.now() - snap.updatedAt > ttlMs) return [];
+    return snap.active ?? [];
+  } catch {
+    return [];
+  }
+}

--- a/src/alerts/store.ts
+++ b/src/alerts/store.ts
@@ -1,0 +1,85 @@
+/** In-memory AlertStore with dedup and auto-expiry */
+
+import type { Alert, AlertSeverity, AlertType } from "./types.js";
+
+/** 5-minute dedup bucket (ms) */
+const DEDUP_BUCKET_MS = 5 * 60 * 1000;
+
+function makeBucket(createdAt: number): number {
+  return Math.floor(createdAt / DEDUP_BUCKET_MS);
+}
+
+function makeId(type: AlertType, agentPid: number, bucket: number): string {
+  return `${type}:${agentPid}:${bucket}`;
+}
+
+export interface CreateAlertOptions {
+  type: AlertType;
+  severity: AlertSeverity;
+  agentPid: number;
+  message: string;
+  sessionId?: string;
+  cwd?: string;
+  detail?: string;
+  /** ms until auto-expiry. Defaults: security=0 (manual), context=5min */
+  ttlMs?: number;
+}
+
+export class AlertStore {
+  private alerts = new Map<string, Alert>();
+
+  /** Create and store an alert. Returns the alert if new, undefined if duplicate. */
+  create(opts: CreateAlertOptions): Alert | undefined {
+    const now = Date.now();
+    const bucket = makeBucket(now);
+    const id = makeId(opts.type, opts.agentPid, bucket);
+
+    if (this.alerts.has(id)) return undefined;
+
+    const ttlMs = opts.ttlMs ?? (opts.type === "security" ? 0 : DEDUP_BUCKET_MS);
+    const alert: Alert = {
+      id,
+      type: opts.type,
+      severity: opts.severity,
+      agentPid: opts.agentPid,
+      sessionId: opts.sessionId,
+      cwd: opts.cwd,
+      message: opts.message,
+      detail: opts.detail,
+      createdAt: now,
+      expiresAt: ttlMs > 0 ? now + ttlMs : undefined,
+    };
+
+    this.alerts.set(id, alert);
+    return alert;
+  }
+
+  dismiss(id: string): void {
+    const alert = this.alerts.get(id);
+    if (alert) {
+      alert.dismissedAt = Date.now();
+      this.alerts.delete(id);
+    }
+  }
+
+  /** Prune expired and dismissed alerts */
+  prune(): void {
+    const now = Date.now();
+    for (const [id, alert] of this.alerts) {
+      if (alert.dismissedAt) {
+        this.alerts.delete(id);
+      } else if (alert.expiresAt && now > alert.expiresAt) {
+        this.alerts.delete(id);
+      }
+    }
+  }
+
+  active(): Alert[] {
+    this.prune();
+    return [...this.alerts.values()];
+  }
+
+  count(): number {
+    return this.active().length;
+  }
+}

--- a/src/alerts/token.ts
+++ b/src/alerts/token.ts
@@ -27,12 +27,15 @@ function contextLimit(model?: string): number {
 }
 
 export interface TokenAlertThresholds {
-  warnAt: number; // e.g. 0.70
-  critAt: number; // e.g. 0.85
+  /** 경고 임계값 (0~1). 1.0이면 비활성화. */
+  warnAt: number;
+  /** 위험 임계값 (0~1). */
+  critAt: number;
 }
 
+/** Phase 1 기본값: warn 비활성(1.0), crit 85% */
 export const DEFAULT_TOKEN_THRESHOLDS: TokenAlertThresholds = {
-  warnAt: 0.7,
+  warnAt: 1.0,
   critAt: 0.85,
 };
 

--- a/src/alerts/token.ts
+++ b/src/alerts/token.ts
@@ -1,0 +1,83 @@
+/** Token threshold alert trigger */
+
+import type { AgentSession } from "../types.js";
+import type { AlertStore } from "./store.js";
+import type { Alert } from "./types.js";
+
+/** Known model context window sizes (tokens) */
+const MODEL_CONTEXT_LIMITS: Record<string, number> = {
+  "claude-opus-4": 200_000,
+  "claude-sonnet-4": 200_000,
+  "claude-haiku-4": 200_000,
+  "claude-3-5-sonnet": 200_000,
+  "claude-3-5-haiku": 200_000,
+  "claude-3-opus": 200_000,
+  "claude-3-sonnet": 200_000,
+  "claude-3-haiku": 200_000,
+};
+
+const DEFAULT_CONTEXT_LIMIT = 200_000;
+
+function contextLimit(model?: string): number {
+  if (!model) return DEFAULT_CONTEXT_LIMIT;
+  for (const [key, limit] of Object.entries(MODEL_CONTEXT_LIMITS)) {
+    if (model.toLowerCase().includes(key)) return limit;
+  }
+  return DEFAULT_CONTEXT_LIMIT;
+}
+
+export interface TokenAlertThresholds {
+  warnAt: number; // e.g. 0.70
+  critAt: number; // e.g. 0.85
+}
+
+export const DEFAULT_TOKEN_THRESHOLDS: TokenAlertThresholds = {
+  warnAt: 0.7,
+  critAt: 0.85,
+};
+
+/**
+ * Check an agent's token usage against thresholds.
+ * Creates an alert in store if threshold exceeded (deduped).
+ * Returns the created alert or undefined if no threshold crossed or deduped.
+ */
+export function checkTokenAlert(
+  store: AlertStore,
+  agent: AgentSession,
+  thresholds: TokenAlertThresholds = DEFAULT_TOKEN_THRESHOLDS,
+): Alert | undefined {
+  const usage = agent.tokenUsage;
+  if (!usage) return undefined;
+
+  // lastInputTokens = most recent API call's input_tokens = actual current context size.
+  // Fall back to cumulative inputTokens only if lastInputTokens is unavailable.
+  const used = usage.lastInputTokens ?? usage.inputTokens;
+  const limit = contextLimit(agent.model);
+  const ratio = used / limit;
+
+  if (ratio >= thresholds.critAt) {
+    return store.create({
+      type: "context_critical",
+      severity: "critical",
+      agentPid: agent.pid,
+      sessionId: agent.sessionId,
+      cwd: agent.cwd,
+      message: `Context ${Math.round(ratio * 100)}% full — /clear or new session recommended`,
+      detail: `used=${used.toLocaleString()} limit=${limit.toLocaleString()} model=${agent.model ?? "unknown"}`,
+    });
+  }
+
+  if (ratio >= thresholds.warnAt) {
+    return store.create({
+      type: "context_warn",
+      severity: "warn",
+      agentPid: agent.pid,
+      sessionId: agent.sessionId,
+      cwd: agent.cwd,
+      message: `Context ${Math.round(ratio * 100)}% full`,
+      detail: `used=${used.toLocaleString()} limit=${limit.toLocaleString()} model=${agent.model ?? "unknown"}`,
+    });
+  }
+
+  return undefined;
+}

--- a/src/alerts/types.ts
+++ b/src/alerts/types.ts
@@ -1,0 +1,30 @@
+/** Alert system types for marmonitor */
+
+export type AlertType =
+  | "context_warn" // token 70% threshold
+  | "context_critical" // token 85%+ threshold
+  | "security"; // dangerous command detected
+
+export type AlertSeverity = "info" | "warn" | "critical";
+
+export interface Alert {
+  /** Deterministic dedup ID: `type:agentPid:bucket` */
+  id: string;
+  type: AlertType;
+  severity: AlertSeverity;
+  agentPid: number;
+  sessionId?: string;
+  cwd?: string;
+  message: string;
+  /** Extra context: token count, command, etc. */
+  detail?: string;
+  createdAt: number; // unix ms
+  dismissedAt?: number;
+  expiresAt?: number;
+}
+
+/** Snapshot of active alerts written alongside agent snapshot */
+export interface AlertsSnapshot {
+  active: Alert[];
+  updatedAt: number; // unix ms
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -893,7 +893,7 @@ program
             createdAt: Date.now(),
           };
           await appendAlertLog(alertsLogPath, alert);
-          await sendDesktopNotification(alert);
+          void sendDesktopNotification(alert); // fire-and-forget
         }
       }
       console.log(formatGuardOutput(result));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -865,11 +865,12 @@ program
         return;
       }
       const result = evaluateGuard(config, event);
-      // Security alert logging is independent of intervention.enabled —
-      // always detect and log dangerous_command / secret_access.
-      const securityTriggers = detectGuardTriggers(event).filter(
-        (t) => t === "dangerous_command" || t === "secret_access",
-      );
+      // Security alert: alerts.enabled 확인 후 dangerous_command / secret_access 감지·기록
+      const securityTriggers = config.alerts.enabled
+        ? detectGuardTriggers(event).filter(
+            (t) => t === "dangerous_command" || t === "secret_access",
+          )
+        : [];
       if (securityTriggers.length > 0) {
         const { appendAlertLog } = await import("./alerts/index.js");
         const { getConfigDir } = await import("./config/index.js");
@@ -892,8 +893,8 @@ program
             detail: `tool=${event.toolName ?? "?"} trigger=${trigger}`,
             createdAt: Date.now(),
           };
-          await appendAlertLog(alertsLogPath, alert);
-          void sendDesktopNotification(alert); // fire-and-forget
+          if (config.alerts.log) await appendAlertLog(alertsLogPath, alert);
+          if (config.alerts.desktop) void sendDesktopNotification(alert); // fire-and-forget
         }
       }
       console.log(formatGuardOutput(result));
@@ -901,6 +902,85 @@ program
       console.log(JSON.stringify({ decision: "allow" }));
     }
   });
+
+// ── alerts command ──────────────────────────────────────────────────────────
+
+async function patchAlertsConfig(
+  configPath: string,
+  patch: Partial<{ enabled: boolean; desktop: boolean; log: boolean }>,
+): Promise<void> {
+  await mkdir(dirname(configPath), { recursive: true });
+  let current: Record<string, unknown> = {};
+  try {
+    current = JSON.parse(await readFile(configPath, "utf-8")) as Record<string, unknown>;
+  } catch {
+    // file missing — start fresh
+  }
+  const alerts = (
+    current.alerts && typeof current.alerts === "object"
+      ? { ...(current.alerts as Record<string, unknown>) }
+      : {}
+  ) as Record<string, unknown>;
+  Object.assign(alerts, patch);
+  current.alerts = alerts;
+  await writeFile(configPath, `${JSON.stringify(current, null, 2)}\n`, "utf-8");
+}
+
+const alertsCmd = program
+  .command("alerts")
+  .description("Show or toggle alert settings")
+  .option("--config <path>", "Path to settings.json")
+  .action(async (opts) => {
+    const config = await loadConfig(resolveConfigPath(opts));
+    const a = config.alerts;
+    console.log(`alerts.enabled  : ${a.enabled}`);
+    console.log(`alerts.desktop  : ${a.desktop}`);
+    console.log(`alerts.log      : ${a.log}`);
+    console.log(
+      `alerts.contextCritThreshold: ${a.contextCritThreshold} (${Math.round(a.contextCritThreshold * 100)}%)`,
+    );
+    console.log(
+      `alerts.contextWarnThreshold: ${a.contextWarnThreshold === 1.0 ? "disabled" : `${a.contextWarnThreshold} (${Math.round(a.contextWarnThreshold * 100)}%)`}`,
+    );
+  });
+
+alertsCmd
+  .command("on")
+  .description("Enable alert system")
+  .option("--config <path>", "Path to settings.json")
+  .action(async (opts) => {
+    const p = resolveConfigPath(opts) ?? getDefaultConfigPath();
+    await patchAlertsConfig(p, { enabled: true });
+    console.log("Alerts enabled. Restart daemon to apply: marmonitor restart");
+  });
+
+alertsCmd
+  .command("off")
+  .description("Disable alert system")
+  .option("--config <path>", "Path to settings.json")
+  .action(async (opts) => {
+    const p = resolveConfigPath(opts) ?? getDefaultConfigPath();
+    await patchAlertsConfig(p, { enabled: false });
+    console.log("Alerts disabled. Restart daemon to apply: marmonitor restart");
+  });
+
+alertsCmd
+  .command("notify <on|off>")
+  .description("Toggle desktop notifications")
+  .option("--config <path>", "Path to settings.json")
+  .action(async (toggle, opts) => {
+    if (toggle !== "on" && toggle !== "off") {
+      console.error("Usage: marmonitor alerts notify on|off");
+      process.exit(1);
+    }
+    const p = resolveConfigPath(opts) ?? getDefaultConfigPath();
+    await patchAlertsConfig(p, { desktop: toggle === "on" });
+    console.log(
+      `Desktop notifications ${toggle === "on" ? "enabled" : "disabled"}. Restart daemon to apply: marmonitor restart`,
+    );
+  });
+
+// ── end alerts command ───────────────────────────────────────────────────────
 
 program
   .command("debug-phase")

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,7 +11,13 @@ import {
   loadConfig,
   resolveConfigPath as resolveLoadedConfigPath,
 } from "./config/index.js";
-import { evaluateGuard, formatGuardOutput, parseHookEvent, readStdin } from "./guard/index.js";
+import {
+  detectGuardTriggers,
+  evaluateGuard,
+  formatGuardOutput,
+  parseHookEvent,
+  readStdin,
+} from "./guard/index.js";
 import {
   applyTerminalStyle,
   printAttention,
@@ -859,6 +865,34 @@ program
         return;
       }
       const result = evaluateGuard(config, event);
+      // Security alert logging is independent of intervention.enabled —
+      // always detect and log dangerous_command / secret_access.
+      const securityTriggers = detectGuardTriggers(event).filter(
+        (t) => t === "dangerous_command" || t === "secret_access",
+      );
+      if (securityTriggers.length > 0) {
+        const { appendAlertLog } = await import("./alerts/index.js");
+        const { getConfigDir } = await import("./config/index.js");
+        const { join } = await import("node:path");
+        const alertsLogPath = join(getConfigDir(), "alerts.log");
+        const agentPid = typeof process.ppid === "number" ? process.ppid : 0;
+        for (const trigger of securityTriggers) {
+          const message =
+            trigger === "secret_access"
+              ? `Credential file access: ${event.filePath ?? "(unknown)"}`
+              : `Dangerous command detected: ${event.command ?? "(unknown)"}`;
+          await appendAlertLog(alertsLogPath, {
+            id: `security:${agentPid}:${Math.floor(Date.now() / 300_000)}`,
+            type: "security",
+            severity: "critical",
+            agentPid,
+            cwd: event.cwd,
+            message,
+            detail: `tool=${event.toolName ?? "?"} trigger=${trigger}`,
+            createdAt: Date.now(),
+          });
+        }
+      }
       console.log(formatGuardOutput(result));
     } catch {
       console.log(JSON.stringify({ decision: "allow" }));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -875,22 +875,25 @@ program
         const { getConfigDir } = await import("./config/index.js");
         const { join } = await import("node:path");
         const alertsLogPath = join(getConfigDir(), "alerts.log");
+        const { sendDesktopNotification } = await import("./alerts/index.js");
         const agentPid = typeof process.ppid === "number" ? process.ppid : 0;
         for (const trigger of securityTriggers) {
           const message =
             trigger === "secret_access"
               ? `Credential file access: ${event.filePath ?? "(unknown)"}`
               : `Dangerous command detected: ${event.command ?? "(unknown)"}`;
-          await appendAlertLog(alertsLogPath, {
+          const alert = {
             id: `security:${agentPid}:${Math.floor(Date.now() / 300_000)}`,
-            type: "security",
-            severity: "critical",
+            type: "security" as const,
+            severity: "critical" as const,
             agentPid,
             cwd: event.cwd,
             message,
             detail: `tool=${event.toolName ?? "?"} trigger=${trigger}`,
             createdAt: Date.now(),
-          });
+          };
+          await appendAlertLog(alertsLogPath, alert);
+          await sendDesktopNotification(alert);
         }
       }
       console.log(formatGuardOutput(result));

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -95,6 +95,18 @@ export interface MarmonitorConfig {
     daemonIntervalSec: number;
     activityRetentionDays: number;
   };
+  alerts: {
+    /** 알림 시스템 마스터 토글 */
+    enabled: boolean;
+    /** macOS/Linux 데스크탑 알림 */
+    desktop: boolean;
+    /** alerts.log 파일 기록 */
+    log: boolean;
+    /** 컨텍스트 경고 임계값 (0~1). 0 = 비활성화. 기본 1.0 (비활성) */
+    contextWarnThreshold: number;
+    /** 컨텍스트 위험 임계값 (0~1). 기본 0.85 */
+    contextCritThreshold: number;
+  };
 }
 
 const DEFAULTS: MarmonitorConfig = {
@@ -177,6 +189,13 @@ const DEFAULTS: MarmonitorConfig = {
     stdoutHeuristicTtlMs: 2000,
     daemonIntervalSec: 2,
     activityRetentionDays: 7,
+  },
+  alerts: {
+    enabled: true,
+    desktop: true,
+    log: true,
+    contextWarnThreshold: 1.0, // 기본 비활성 (0.70으로 설정 시 활성화)
+    contextCritThreshold: 0.85,
   },
 };
 

--- a/src/guard/index.ts
+++ b/src/guard/index.ts
@@ -25,10 +25,41 @@ export interface GuardDecision {
   action?: GuardAction;
 }
 
-const DANGEROUS_COMMAND_PATTERNS = [/\brm\s+-rf\s+\//, /\bmkfs\b/, /\bdd\s+if=.*\sof=\/dev\//];
+const DANGEROUS_COMMAND_PATTERNS = [
+  // 루트/홈/전체 강제 삭제
+  /\brm\s+(-\w*f\w*\s+.*-\w*r\w*|-\w*r\w*\s+.*-\w*f\w*)\s+(\/|~|\/\*|\.\.)/, // rm -rf / ~ /* ..
+  /\brm\s+-rf\s+/, // rm -rf (anything — broad catch)
+  /\bmkfs\b/, // 파일시스템 포맷
+  // sudo + 파괴적 명령
+  /\bsudo\s+rm\b/,
+  /\bsudo\s+chmod\s+-R\b/,
+  /\bsudo\s+dd\b/,
+  // git 강제 push (공유 히스토리 파괴)
+  /\bgit\s+push\b.*--force\b/,
+  /\bgit\s+push\b.*-f\b/,
+  // 원격 스크립트 직접 실행
+  /\bcurl\b.+\|\s*(bash|sh)\b/,
+  /\bwget\b.+\|\s*(bash|sh)\b/,
+  // 프로세스 강제 종료 (PID 1 또는 init/systemd)
+  /\bkill\s+-9\s+1\b/,
+  /\bpkill\s+-9\s+(init|systemd)\b/,
+];
 
-const SECRET_PATH_PATTERNS = [/\.env\b/, /\/secrets?\b/, /\/\.ssh\b/, /id_rsa\b/];
-const PROD_PATH_PATTERNS = [/\/prod\b/, /\/production\b/, /prod/i];
+// secret_access: 정확한 자격증명 파일 경로에만 반응 (content 키워드 false positive 방지)
+// Write/Edit 툴일 때만 체크 → Read는 별도 함수에서 처리
+const SECRET_WRITE_TOOLS = new Set(["Write", "Edit", "str_replace_editor"]);
+const SECRET_EXACT_SUFFIXES = [
+  /(?:^|\/)\.env$/, // .env (not .env.example, .env.local)
+  /(?:^|\/)id_rsa$/, // SSH private key
+  /(?:^|\/)id_ed25519$/, // ED25519 private key
+  /(?:^|\/)id_ecdsa$/, // ECDSA private key
+  /(?:^|\/)\.netrc$/, // netrc credential file
+  /(?:^|\/)credentials$/, // AWS credentials etc
+];
+// Read 툴에서 실제 private key 파일 경로를 읽는 경우
+const SECRET_READ_TOOLS = new Set(["Read", "cat"]);
+
+const PROD_PATH_PATTERNS = [/\/prod\b/, /\/production\b/];
 
 function normalizeAction(action: GuardAction): "allow" | "block" {
   if (action === "block") return "block";
@@ -69,11 +100,16 @@ export function parseHookEvent(input: string): HookEvent | undefined {
   }
 }
 
+function isSecretFilePath(filePath: string): boolean {
+  return SECRET_EXACT_SUFFIXES.some((pattern) => pattern.test(filePath));
+}
+
 export function detectGuardTriggers(event: HookEvent): GuardTrigger[] {
   const triggers = new Set<GuardTrigger>();
   const command = event.command ?? "";
   const filePath = event.filePath ?? "";
   const cwd = event.cwd ?? "";
+  const toolName = event.toolName ?? "";
 
   if (DANGEROUS_COMMAND_PATTERNS.some((pattern) => pattern.test(command))) {
     triggers.add("dangerous_command");
@@ -81,8 +117,12 @@ export function detectGuardTriggers(event: HookEvent): GuardTrigger[] {
   if (PROD_PATH_PATTERNS.some((pattern) => pattern.test(command) || pattern.test(filePath))) {
     triggers.add("prod_path_access");
   }
-  if (SECRET_PATH_PATTERNS.some((pattern) => pattern.test(command) || pattern.test(filePath))) {
-    triggers.add("secret_access");
+  // secret_access: Write/Edit 툴 + 정확한 자격증명 파일 경로
+  //                Read 툴 + 정확한 private key 파일 경로
+  if (filePath && isSecretFilePath(filePath)) {
+    if (SECRET_WRITE_TOOLS.has(toolName) || SECRET_READ_TOOLS.has(toolName)) {
+      triggers.add("secret_access");
+    }
   }
   if (filePath && cwd && !filePath.startsWith(cwd)) {
     triggers.add("out_of_cwd_write");

--- a/src/guard/index.ts
+++ b/src/guard/index.ts
@@ -26,9 +26,10 @@ export interface GuardDecision {
 }
 
 const DANGEROUS_COMMAND_PATTERNS = [
-  // 루트/홈/전체 강제 삭제
-  /\brm\s+(-\w*f\w*\s+.*-\w*r\w*|-\w*r\w*\s+.*-\w*f\w*)\s+(\/|~|\/\*|\.\.)/, // rm -rf / ~ /* ..
-  /\brm\s+-rf\s+/, // rm -rf (anything — broad catch)
+  // 시스템 경로 대상 강제 삭제만 감지 (./node_modules, ./dist 등 상대경로 제외)
+  // 매치 대상: / (루트) · /etc /usr /var /home /root /bin /sbin /sys /proc /dev /boot · ~ · /*
+  /\brm\s+(-\w*f\w*\s+.*-\w*r\w*|-\w*r\w*\s+.*-\w*f\w*)\s+(\/(\s|$|etc|usr|var|home|root|bin|sbin|sys|proc|dev|boot|lib)|~(\s|$)|\/\*)/,
+  /\brm\s+-rf\s+(\/(\s|$|etc|usr|var|home|root|bin|sbin|sys|proc|dev|boot|lib)|~(\s|$)|\/\*)/, // rm -rf /sys-path
   /\bmkfs\b/, // 파일시스템 포맷
   // sudo + 파괴적 명령
   /\bsudo\s+rm\b/,

--- a/src/guard/index.ts
+++ b/src/guard/index.ts
@@ -25,25 +25,39 @@ export interface GuardDecision {
   action?: GuardAction;
 }
 
-const DANGEROUS_COMMAND_PATTERNS = [
-  // 시스템 경로 대상 강제 삭제만 감지 (./node_modules, ./dist 등 상대경로 제외)
-  // 매치 대상: / (루트) · /etc /usr /var /home /root /bin /sbin /sys /proc /dev /boot · ~ · /*
-  /\brm\s+(-\w*f\w*\s+.*-\w*r\w*|-\w*r\w*\s+.*-\w*f\w*)\s+(\/(\s|$|etc|usr|var|home|root|bin|sbin|sys|proc|dev|boot|lib)|~(\s|$)|\/\*)/,
-  /\brm\s+-rf\s+(\/(\s|$|etc|usr|var|home|root|bin|sbin|sys|proc|dev|boot|lib)|~(\s|$)|\/\*)/, // rm -rf /sys-path
-  /\bmkfs\b/, // 파일시스템 포맷
-  // sudo + 파괴적 명령
-  /\bsudo\s+rm\b/,
-  /\bsudo\s+chmod\s+-R\b/,
-  /\bsudo\s+dd\b/,
-  // git 강제 push (공유 히스토리 파괴)
-  /\bgit\s+push\b.*--force\b/,
-  /\bgit\s+push\b.*-f\b/,
-  // 원격 스크립트 직접 실행
-  /\bcurl\b.+\|\s*(bash|sh)\b/,
-  /\bwget\b.+\|\s*(bash|sh)\b/,
-  // 프로세스 강제 종료 (PID 1 또는 init/systemd)
-  /\bkill\s+-9\s+1\b/,
-  /\bpkill\s+-9\s+(init|systemd)\b/,
+// 시스템 경로 판단 기준: /, /*, /etc, /usr, /var, /home, /root, /bin, /sbin, /sys, /proc, /dev, /boot, /lib, ~
+const SYSTEM_PATH = String.raw`(?:\/(?:$|\*|etc(?:\/|$)|usr(?:\/|$)|var(?:\/|$)|home(?:\/|$)|root(?:\/|$)|bin(?:\/|$)|sbin(?:\/|$)|sys(?:\/|$)|proc(?:\/|$)|dev(?:\/|$)|boot(?:\/|$)|lib(?:\/|$))|~(?:\/|$))`;
+
+const DANGEROUS_COMMAND_PATTERNS: RegExp[] = [
+  // ── destructive delete: 시스템 경로 대상 + 재귀/강제 옵션 조합 ──
+  // 단축 옵션: rm -rf /, rm -fr /etc, rm -Rrf ~  (-[옵션]에 r과 f 둘 다 포함)
+  new RegExp(String.raw`\brm\b(?=.*\s-[^\s-]*[rf][^\s-]*[rf])(?=.*\s${SYSTEM_PATH})`, "i"),
+  // 롱 옵션: rm --recursive --force /var  (순서 무관)
+  new RegExp(String.raw`\brm\b(?=.*--recursive\b)(?=.*--force\b)(?=.*\s${SYSTEM_PATH})`, "i"),
+
+  // ── filesystem format ──
+  /\bmkfs(?:\.[a-z0-9]+)?\b/i,
+
+  // ── raw disk write (sudo 유무 무관) ──
+  /\bdd\b.*\bof=\/dev\/(?:sd[a-z]\d*|nvme\d+n\d+(?:p\d+)?|vd[a-z]\d*|zero|null)\b/i,
+  /\bsudo\s+dd\b/i,
+
+  // ── 시스템 경로 대상 권한/소유권 대규모 변경 ──
+  new RegExp(String.raw`\bchmod\b.*\s-[^\s]*R[^\s]*(?=.*\s${SYSTEM_PATH})`, "i"),
+  new RegExp(String.raw`\bchown\b.*\s-[^\s]*R[^\s]*(?=.*\s${SYSTEM_PATH})`, "i"),
+
+  // ── git force push ──
+  /\bgit\s+push\b.*(?:--force\b|-f\b)/i,
+
+  // ── 원격 스크립트 직접 실행 ──
+  /\bcurl\b.+\|\s*(?:bash|sh)\b/i,
+  /\bwget\b.+\|\s*(?:bash|sh)\b/i,
+  /\b(?:bash|sh)\b\s*<\(\s*curl\b/i, // bash <(curl ...)
+  /\bsudo\s+(?:bash|sh)\b.*-c\b.*(?:curl|wget)\b.*\|\s*(?:bash|sh)\b/i, // sudo sh -c '... | bash'
+
+  // ── critical process kill ──
+  /\bkill\s+-9\s+1\b/i,
+  /\bpkill\s+-9\s+(?:init|systemd)\b/i,
 ];
 
 // secret_access: 정확한 자격증명 파일 경로에만 반응 (content 키워드 false positive 방지)

--- a/src/scanner/claude.ts
+++ b/src/scanner/claude.ts
@@ -222,6 +222,7 @@ export async function parseClaudeTokens(
     let outputTokens = cached?.result.tokenUsage?.outputTokens ?? 0;
     let cacheCreationTokens = cached?.result.tokenUsage?.cacheCreationTokens ?? 0;
     let cacheReadTokens = cached?.result.tokenUsage?.cacheReadTokens ?? 0;
+    let lastInputTokens: number | undefined = cached?.result.tokenUsage?.lastInputTokens;
     let model: string | undefined = cached?.result.model;
 
     let raw: string;
@@ -238,6 +239,7 @@ export async function parseClaudeTokens(
       outputTokens = 0;
       cacheCreationTokens = 0;
       cacheReadTokens = 0;
+      lastInputTokens = undefined;
       model = undefined;
     }
 
@@ -253,6 +255,10 @@ export async function parseClaudeTokens(
         outputTokens += usage.output_tokens ?? 0;
         cacheCreationTokens += usage.cache_creation_input_tokens ?? 0;
         cacheReadTokens += usage.cache_read_input_tokens ?? 0;
+        // Track most recent call's input_tokens for context % calculation
+        if (usage.input_tokens != null) {
+          lastInputTokens = usage.input_tokens;
+        }
 
         if (entry?.message?.model) model = entry.message.model;
       } catch {
@@ -270,6 +276,7 @@ export async function parseClaudeTokens(
               cacheCreationTokens,
               cacheReadTokens,
               totalTokens: inputTokens + outputTokens,
+              lastInputTokens,
             },
       model,
     };

--- a/src/scanner/daemon-entry.ts
+++ b/src/scanner/daemon-entry.ts
@@ -21,6 +21,8 @@ async function main(): Promise<void> {
     intervalMs: intervalSec * 1000,
     detailIntervalMs: 30_000,
     snapshotPath: join(DAEMON_DIR, "daemon-snapshot.json"),
+    alertsSnapshotPath: join(DAEMON_DIR, "alerts-snapshot.json"),
+    alertsLogPath: join(CONFIG_DIR, "alerts.log"),
     pidPath: join(DAEMON_DIR, "daemon.pid"),
     registryPath: join(CONFIG_DIR, "session-registry.json"),
     codexBindingRegistryPath: join(CONFIG_DIR, "codex-binding-registry.json"),

--- a/src/scanner/daemon-loop.ts
+++ b/src/scanner/daemon-loop.ts
@@ -136,13 +136,19 @@ export async function runDaemonLoop(
       // Write snapshot for statusline consumers
       await writeDaemonSnapshot(snapshotPath, agents);
 
-      // Check token thresholds and fire alerts
-      for (const agent of agents) {
-        const alert = checkTokenAlert(alertStore, agent);
-        if (alert) {
-          await appendAlertLog(alertsLogPath, alert);
-          if (alert.severity === "critical") {
-            void sendDesktopNotification(alert); // fire-and-forget: 외부 프로세스 spawn이므로 await 금지
+      // Check token thresholds and fire alerts (alerts.enabled 확인)
+      if (config.alerts.enabled) {
+        const thresholds = {
+          warnAt: config.alerts.contextWarnThreshold,
+          critAt: config.alerts.contextCritThreshold,
+        };
+        for (const agent of agents) {
+          const alert = checkTokenAlert(alertStore, agent, thresholds);
+          if (alert) {
+            if (config.alerts.log) await appendAlertLog(alertsLogPath, alert);
+            if (config.alerts.desktop && alert.severity === "critical") {
+              void sendDesktopNotification(alert); // fire-and-forget
+            }
           }
         }
       }

--- a/src/scanner/daemon-loop.ts
+++ b/src/scanner/daemon-loop.ts
@@ -142,7 +142,7 @@ export async function runDaemonLoop(
         if (alert) {
           await appendAlertLog(alertsLogPath, alert);
           if (alert.severity === "critical") {
-            await sendDesktopNotification(alert);
+            void sendDesktopNotification(alert); // fire-and-forget: 외부 프로세스 spawn이므로 await 금지
           }
         }
       }

--- a/src/scanner/daemon-loop.ts
+++ b/src/scanner/daemon-loop.ts
@@ -5,6 +5,12 @@
 
 import { open, stat, unlink } from "node:fs/promises";
 import { join } from "node:path";
+import {
+  AlertStore,
+  appendAlertLog,
+  checkTokenAlert,
+  writeAlertsSnapshot,
+} from "../alerts/index.js";
 import type { MarmonitorConfig } from "../config/index.js";
 import {
   type ActivityEntry,
@@ -35,6 +41,8 @@ export interface DaemonOptions {
   intervalMs: number;
   detailIntervalMs: number;
   snapshotPath: string;
+  alertsSnapshotPath: string;
+  alertsLogPath: string;
   pidPath: string;
   registryPath: string;
   codexBindingRegistryPath: string;
@@ -54,6 +62,8 @@ export async function runDaemonLoop(
     intervalMs,
     detailIntervalMs,
     snapshotPath,
+    alertsSnapshotPath,
+    alertsLogPath,
     pidPath,
     registryPath,
     codexBindingRegistryPath,
@@ -64,6 +74,8 @@ export async function runDaemonLoop(
   // Activity log: per-session JSONL cursor offsets (in-memory only)
   const activityCursors = new Map<string, number>();
   let lastActivityCleanupAt = 0;
+
+  const alertStore = new AlertStore();
 
   await writeDaemonPid(pidPath, process.pid);
 
@@ -122,6 +134,15 @@ export async function runDaemonLoop(
 
       // Write snapshot for statusline consumers
       await writeDaemonSnapshot(snapshotPath, agents);
+
+      // Check token thresholds and fire alerts
+      for (const agent of agents) {
+        const alert = checkTokenAlert(alertStore, agent);
+        if (alert) {
+          await appendAlertLog(alertsLogPath, alert);
+        }
+      }
+      await writeAlertsSnapshot(alertsSnapshotPath, alertStore.active());
 
       // Save registry periodically (on heavy scan) + prune old entries
       if (needsHeavy) {

--- a/src/scanner/daemon-loop.ts
+++ b/src/scanner/daemon-loop.ts
@@ -9,6 +9,7 @@ import {
   AlertStore,
   appendAlertLog,
   checkTokenAlert,
+  sendDesktopNotification,
   writeAlertsSnapshot,
 } from "../alerts/index.js";
 import type { MarmonitorConfig } from "../config/index.js";
@@ -140,6 +141,9 @@ export async function runDaemonLoop(
         const alert = checkTokenAlert(alertStore, agent);
         if (alert) {
           await appendAlertLog(alertsLogPath, alert);
+          if (alert.severity === "critical") {
+            await sendDesktopNotification(alert);
+          }
         }
       }
       await writeAlertsSnapshot(alertsSnapshotPath, alertStore.active());

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,8 @@ export interface TokenUsage {
   cacheCreationTokens: number;
   cacheReadTokens: number;
   totalTokens: number;
+  /** input_tokens from the most recent API response (= current context window size) */
+  lastInputTokens?: number;
 }
 
 /** Agent session status */


### PR DESCRIPTION
## Summary

Resolve #49

Establish a reusable alert foundation for context, security, and performance notifications. All channels default to **off** — users opt in explicitly via `marmonitor alerts on`.

## 한국어 요약

- 컨텍스트·보안·성능 알림을 위한 재사용 가능한 Alert System 기반을 구현했습니다.
- `Alert` 타입, `AlertStore`(인메모리 dedup + 자동 만료), `alerts.log` 파일 기록, 토큰 임계값 체크, alerts-snapshot 등 Phase 1 모듈 전체를 추가했습니다.
- `node-notifier` 기반 macOS/Linux 데스크탑 알림(critical only)을 추가했습니다(Phase 2).
- `guard`에서 `dangerous_command` / `secret_access` 감지 시 alert을 발행하도록 연동했습니다.
- `marmonitor alerts` 서브커맨드(`on` / `off` / `notify`)로 채널별 ON/OFF를 제어할 수 있습니다.
- 기본값을 전부 `false`로 설정하여 기존 사용자에게 동작 변화가 없습니다. 쓰고 싶은 사람만 `marmonitor alerts on`으로 활성화합니다.

## Type

- [x] `[FEAT]` New feature
- [ ] `[BUG]` Bug fix
- [ ] `[HOTFIX]` Urgent fix
- [ ] `[PERF]` Performance improvement
- [ ] `[REFACTOR]` Code restructuring
- [ ] `[DOCS]` Documentation
- [ ] `[TEST]` Test coverage
- [ ] `[CICD]` CI/CD or release
- [ ] `[CHORE]` Maintenance

## Changes

- `src/alerts/types.ts` — `Alert`, `AlertType`, `AlertSeverity`, `AlertsSnapshot` type definitions
- `src/alerts/store.ts` — `AlertStore`: in-memory dedup with 5-minute bucket, auto-expiry, prune
- `src/alerts/log.ts` — append-only writer to `~/.config/marmonitor/alerts.log`
- `src/alerts/token.ts` — token threshold check (warn/crit), per-model context limit mapping
- `src/alerts/snapshot.ts` — read/write `alerts-snapshot.json` alongside agent snapshot
- `src/alerts/desktop.ts` — macOS/Linux desktop notification via `node-notifier` (critical alerts only)
- `src/scanner/daemon-loop.ts` — wire `AlertStore` + token check + `writeAlertsSnapshot` into every scan
- `src/guard/index.ts` — emit alert on `dangerous_command` / `secret_access` detection
- `src/cli.ts` — `marmonitor alerts` subcommand with `on` / `off` / `notify` sub-subcommands
- `src/config/index.ts` — add `alerts` config section; all fields default to `false` (opt-in)

## Checklist

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (288/288 green)
- [ ] New features have tests
- [x] No hardcoded paths or environment-specific values

## Testing

```bash
# confirm all defaults are off
marmonitor alerts

# opt in and verify
marmonitor alerts on
marmonitor alerts

# per-channel control
marmonitor alerts notify desktop off
marmonitor alerts notify log on
```

## Risk

Low. All alert channels default to `false` — no behavioral change for existing users. Desktop notifications use a dynamic `import('node-notifier')` so they fail silently when the package is unavailable or the OS blocks notifications.