### PR TITLE
[CICD] #51 Prepare v0.2.5 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to marmonitor are documented here.
 
+## [0.2.5] - 2026-04-12
+
+### Added
+- **Active tmux window highlight** in statusline attention pills so the currently focused agent session is visually distinguished.
+- **Alert system foundation** with alert types, storage, logging, snapshot support, and token threshold tracking.
+- **Alert CLI controls**: `marmonitor alerts`, `marmonitor alerts on|off`, and `marmonitor alerts notify on|off`.
+- **Desktop notifications** for critical alerts via `node-notifier`.
+
+### Fixed
+- `marmonitor restart` now waits for daemon shutdown more reliably to avoid leaving duplicate daemon processes behind.
+
 ## [0.2.4] - 2026-04-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -275,6 +275,28 @@ tmux badges and terminal text output can share one style via `integration.tmux.b
 - `text` — plain colored text, no filled background
 - `text-mono` — grayscale text only
 
+The currently active tmux pane is also highlighted in the attention pill row so it is easier to see which session belongs to the focused window.
+
+### Alerts
+
+`marmonitor` includes an alert system for important runtime signals such as critical token/context usage and guard-triggered risk events.
+
+Useful commands:
+
+```bash
+marmonitor alerts
+marmonitor alerts on
+marmonitor alerts off
+marmonitor alerts notify on
+marmonitor alerts notify off
+```
+
+Desktop notifications can be enabled separately from alert collection. After changing alert settings, restart the daemon to apply them:
+
+```bash
+marmonitor restart
+```
+
 ## Configuration
 
 Config is loaded from (first found wins):

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "marmonitor",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "marmonitor",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "hasInstallScript": true,
       "license": "MIT",
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marmonitor",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "author": "MJ JO <mjjo16@gmail.com>",
   "description": "tmux status bar monitor for AI coding agents — track Claude Code, Codex, Gemini sessions, tokens, and phases in real time",
   "type": "module",


### PR DESCRIPTION
## Summary

Resolve #51

Prepare the `v0.2.5` release metadata on `dev`.

## Type

- [ ] `[FEAT]` New feature
- [ ] `[BUG]` Bug fix
- [ ] `[HOTFIX]` Urgent fix
- [ ] `[PERF]` Performance improvement
- [ ] `[REFACTOR]` Code restructuring
- [ ] `[DOCS]` Documentation
- [ ] `[TEST]` Test coverage
- [x] `[CICD]` CI/CD or release
- [ ] `[CHORE]` Maintenance

## Changes

- bump package version from `0.2.4` to `0.2.5`
- add the `v0.2.5` changelog entry
- document the alert system commands and active tmux pane highlight in `README.md`

## Checklist

- [ ] `npm run build` passes
- [ ] `npm run lint` passes
- [ ] `npm test` passes (all tests green)
- [x] New features have tests
- [x] README updated (if user-facing changes)
- [x] No hardcoded paths or environment-specific values

## Testing

Not run yet.

## Risk

Low. This PR only updates release metadata and user-facing documentation for the `v0.2.5` release.
