### PR TITLE
[FEAT] #54 Add alerts.tokens toggle and post-0.2.5 docs sync

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,108 +2,162 @@
 
 ## Overview
 
-marmonitor is a passive, local-first monitoring tool for AI coding agents. It detects running agents by scanning OS processes, enriches sessions with local data (tokens, phases, timestamps), and renders output to various terminal surfaces.
+marmonitor is a passive, local-first observer for AI coding agents. A long-running daemon scans OS processes, enriches detected agents with session data (tokens, phases, timestamps, git branch), and writes snapshots that all other surfaces (CLI output, tmux statusline, dock, attention popup) consume cheaply.
 
 ```
-Process List (OS)
-      │
-      ▼
-┌──────────┐     ┌──────────┐     ┌──────────┐
-│ Scanner  │────▶│  Output  │────▶│ Terminal │
-│          │     │          │     │ Surfaces │
-│ - detect │     │ - text   │     │ - stdout │
-│ - enrich │     │ - JSON   │     │ - tmux   │
-│ - phase  │     │ - pills  │     │ - wezterm│
-└──────────┘     └──────────┘     └──────────┘
-      │
-      ▼
-┌──────────┐     ┌──────────┐
-│  Guard   │     │  Config  │
-│          │     │          │
-│ - hooks  │     │ - XDG    │
-│ - rules  │     │ - merge  │
-└──────────┘     └──────────┘
+                              ┌──────────────────────────┐
+                              │  bin/daemon.js           │
+                              │   src/scanner/           │
+                              │   daemon-entry.ts        │
+                              │       │                  │
+ps-list ──┐                   │       ▼                  │
+pidusage ─┼─▶ scanAgents() ──▶│  daemon-loop             │
+JSONL/SQ ─┘                   │   light 2s   heavy 30s   │
+~/.claude/sessions            │       │                  │
+~/.codex/sessions/threads.db  │       ▼                  │
+~/.gemini/tmp/...             │   write snapshot/regs    │
+                              └──────────────────────────┘
+                                       │
+       ┌───────────────────────────────┼───────────────────────────────┐
+       ▼                               ▼                               ▼
+ /tmp/marmonitor/             ~/.config/marmonitor/             ~/.config/marmonitor/
+ daemon-snapshot.json         session-registry.json             activity-log/*.jsonl
+ alerts-snapshot.json         codex-binding-registry.json       alerts.log
+ statusline-*.txt cache
+       │
+       ▼
+ bin/marmonitor.js → src/cli.ts → readDaemonSnapshot → src/output/* → tmux/term
 ```
-
-## Module Responsibilities
-
-### `scanner.ts` — Process Detection & Enrichment
-
-The core module. It:
-
-1. **Detects** AI processes via `ps-list` (name match, then cmd fallback for Node scripts)
-2. **Enriches** with session data by reading agent-specific local files:
-   - Claude: `~/.claude/projects/*/sessions/*.jsonl` (tokens, phases, timestamps)
-   - Codex: session logs and stdout heuristics
-   - Gemini: process-level info only (no session files yet)
-3. **Determines status**: Active, Idle, Stalled, Dead, Unmatched
-4. **Detects phase**: thinking, tool, permission, done
-
-### `output.ts` — Rendering
-
-Formats `AgentSession[]` into various output forms:
-
-| Function | Used By |
-|----------|---------|
-| `printStatus()` | `marmonitor status` |
-| `printStatusJson()` | `marmonitor status --json` |
-| `printDock()` | `marmonitor dock` |
-| `printAttention()` | `marmonitor attention` |
-| `renderStatusline()` | `marmonitor --statusline` |
-
-### `utils.ts` — Pure Functions
-
-Stateless utilities for formatting, sorting, and building data structures:
-
-- `buildAttentionItems()` — Priority-sorted session list (permission > thinking > recent)
-- `buildStatuslineSummary()` — Compact status counts
-- `compactDirLabel()` — Path shortening for display
-- `formatElapsed()` — Human-readable time deltas
-
-### `config.ts` — Configuration
-
-Loads settings from XDG-compliant paths with deep merge:
-
-```
-Priority:
-  1. $XDG_CONFIG_HOME/marmonitor/settings.json
-  2. ~/.config/marmonitor/settings.json
-  3. ~/.marmonitor.json (legacy)
-  4. Built-in defaults
-```
-
-### `guard.ts` — Hook Evaluation
-
-Evaluates Claude Code hook payloads against intervention rules. Fail-open by design — any error returns `{"decision": "allow"}`.
-
-### `tmux.ts` — tmux Integration
-
-Discovers tmux panes, maps PIDs to pane targets, and executes `select-window`/`select-pane` for jump navigation.
-
-### `banner.ts` — Terminal Banner
-
-Renders the marmonitor banner with iTerm2 inline image protocol (pixel-perfect) or ANSI block art fallback.
 
 ## Data Flow
 
 ```
-1. CLI parses command (commander)
-2. Config loaded (XDG merge)
-3. Scanner runs:
-   a. ps-list → agent process list
-   b. For each process: read session files, parse tokens/phases
-   c. Determine status (Active/Idle/Stalled/Dead/Unmatched)
-4. Output renders the AgentSession[] array
-5. For statusline: result cached to /tmp/marmonitor/ with TTL
+1. CLI command parses (commander, src/cli.ts)
+2. For most read commands: readDaemonSnapshot() ─ ~ms.
+   For one-shot enrichment commands (debug-phase, clean): scanAgents() runs inline.
+3. src/output/* renders AgentSession[] → text / JSON / statusline / dock / attention.
+4. tmux statusline goes through a two-layer cache:
+   a) /tmp/marmonitor/statusline-<format>-<limit>-<width>.txt with TTL
+      (TTL = config.performance.statuslineTtlMs, default 2s).
+   b) For tmux-badges, the active panePid is stored in the cache header so that
+      cache hits invalidate when the focused pane changes.
+5. Inside the daemon loop:
+   - light scan: ps-list + pidusage + cached enrichment (hot/warm tier)
+   - heavy scan (every 30s): full JSONL/SQLite parse (covers cold tier and
+     promotes cold sessions when the JSONL mtime advances)
+   - guard / alerts hooks fire here (token thresholds, security trigger)
 ```
+
+## Module Responsibilities
+
+### `src/scanner/index.ts` — `scanAgents()`
+
+Entry point of the scan pipeline.
+
+1. `ps-list` → filter by per-agent `processNames` from config (Electron sub-processes and the VS Code Codex `app-server` are excluded).
+2. Batch `pidusage` for CPU/memory.
+3. For Codex, pre-resolve cwd and pre-index sessions once (SQLite `threads` + recent JSONL merge).
+4. Per process, run agent-specific enrichment (`claude.ts`, `codex.ts`, `gemini.ts`) — gated by **session tier** (`session-tier.ts`):
+   - `hot` (≤2 min activity, or live phase) — full enrich every scan.
+   - `warm` (≤10 min) — full enrich on heavy scan only.
+   - `cold` — cache reused, but JSONL mtime is checked and bumps the session back to hot when changed.
+5. `determineStatus` + `applyStatusHysteresis` (`status.ts`) decide Active/Idle/Stalled with a 30s grace window (longer for Codex).
+6. `groupByParent` (`group.ts`) merges child PIDs into the parent worker tree.
+
+### Per-agent enrichment
+
+| Module | Identity Resolver | File Binding | Phase Detection |
+|--|--|--|--|
+| `claude.ts` | `~/.claude/sessions/{pid}.json` → `sessionId` | `<encodedCwd>/<sessionId>.jsonl` direct, with `chooseStaleSessionOverride` to detect `/clear` | tail jsonl, message kinds + decay |
+| `codex.ts` + `codex-sqlite.ts` + `codex-binding-registry.ts` | `cwd + processStartedAt` against SQLite thread index | rollout JSONL via persistent binding registry (PID×start) | jsonl tail + `detectCliStdoutPhase` (tmux capture-pane heuristic) |
+| `gemini.ts` | `cwd` → `~/.gemini/tmp/<hash>/chats/session-*.json` | latest mtime | session JSON inspection + stdout heuristic |
+
+The Codex binding registry is what keeps long-lived sessions stable across `/clear`, restarts, and multiple sessions in the same `cwd`. Each record carries a confidence and `unstableCount`, and is marked `deadAt` when its PID disappears so that pruning is bounded (default 7 days).
+
+### `src/scanner/daemon-loop.ts`
+
+Long-running loop spawned by `bin/daemon.js`. Responsibilities:
+
+- Two-tier cadence (`intervalMs` light + `detailIntervalMs` heavy).
+- Snapshot file writes (`daemon-snapshot.json`, `alerts-snapshot.json`).
+- Session registry persistence (`session-registry.json`, 30-day prune).
+- Activity log: incremental JSONL cursor per session → `activity-log/YYYY-MM-DD.jsonl`, with daily cleanup.
+- Token-threshold alerts via `checkTokenAlert` (per `config.alerts`).
+- Memory monitor warns when RSS > 200 MB.
+- Graceful shutdown on SIGTERM/SIGINT: flush registries and remove pidfile.
+
+### `src/output/`
+
+Pure render layer over `AgentSession[]`. `index.ts` exposes:
+
+| Function | Used by |
+|--|--|
+| `printStatus`, `printStatusJson` | `marmonitor status` |
+| `printAttention`, `printAttentionJson` | `marmonitor attention` |
+| `printDock` | `marmonitor dock` |
+| `renderStatusline`, `renderUnavailableStatusline` | `marmonitor --statusline` |
+| `printJumpResult`, `printJumpJson`, `renderJumpAttentionChooser` | `attention --interactive` / `jump` |
+| `printCleanPlan`, `printCleanJson` | `marmonitor clean` |
+
+`utils.ts` is the side-effect-free home of `buildAttentionItems`, `buildStatuslineSummary`, phase decay helpers, path compaction, and tmux click-token builders. `badge-themes.ts` defines the six rendering styles (`basic` / `basic-mono` / `block` / `block-mono` / `text` / `text-mono`).
+
+### `src/config/index.ts`
+
+XDG-compliant loader with deep merge:
+
+```
+1. $XDG_CONFIG_HOME/marmonitor/settings.json
+2. ~/.config/marmonitor/settings.json
+3. ~/.marmonitor.json (legacy fallback)
+4. Built-in defaults
+```
+
+`resolveRuntimeDataPaths()` layers env-vars (`MARMONITOR_CLAUDE_HOME`, `MARMONITOR_CLAUDE_PROJECTS`, `MARMONITOR_CLAUDE_SESSIONS`, `MARMONITOR_CODEX_HOME`, `MARMONITOR_CODEX_SESSIONS`) over `paths.*` so users can monitor non-default install locations.
+
+### `src/guard/index.ts`
+
+Evaluates Claude Code hook payloads from stdin.
+
+- Triggers: `dangerous_command`, `prod_path_access`, `secret_access`, `out_of_cwd_write`. Detection is done with conservative regexes that require both option flags and a system path for `rm`, exact suffixes for credential files, etc., to keep false-positive noise low.
+- Outcome: `{ decision: "allow" | "block" }` derived from `intervention.rules` (or `intervention.defaultAction`).
+- **Fail-open by design** — any error returns `{"decision": "allow"}`. Today the CLI also fans out `dangerous_command` / `secret_access` events into the alerts pipeline (this fan-out is currently inlined in `cli.ts` and slated to move into the guard module).
+
+### `src/tmux/`
+
+- `index.ts` — list panes, build the PID tree from `ps -eo pid=,ppid=`, then match each agent to a pane via PID-tree first, then `cwd` fallback. `jumpToAgent` saves a jump-back anchor and runs `select-window` / `select-pane` (or `switch-client` when inside tmux).
+- `jump-anchor.ts` — per-TTY anchor file in `/tmp/marmonitor/jump-anchors.json`, used by `jump-back` and the `↩` indicator on `tmux-badges`.
+- `setup.ts` — manages the `marmonitor-tmux` block in `~/.tmux.conf`, with detection for local checkouts vs the TPM-managed plugin.
+- `status-click.ts` — parses tmux mouse status range tokens so clicking a numbered pill jumps to that session.
+
+### `src/alerts/`
+
+- `store.ts` — in-memory alerts with deterministic dedup (`type:agentPid:5min-bucket`) and per-type TTL.
+- `token.ts` — `checkTokenAlert(store, agent, thresholds)` triggers `context_warn` / `context_critical` against per-model context limits.
+- `log.ts`, `snapshot.ts`, `desktop.ts` — disk log appender, JSON snapshot writer, `node-notifier` desktop notification.
+
+The daemon is the primary producer; the guard pipeline is a secondary producer for `security` alerts.
+
+### `src/banner/`
+
+iTerm2 inline-image banner with ANSI block-art fallback. Emitted by `marmonitor banner` and during `--help`/install.
 
 ## Key Design Decisions
 
-- **No daemon**: Each invocation is a fresh scan. Caching via temp files with TTL.
-- **Fail-safe**: Every external call (ps, tmux, file reads) is wrapped in try-catch. Failures degrade silently.
-- **No network**: Zero outbound connections. All data is local.
-- **Agent-agnostic**: New agents can be added via config `processNames` + optional enrichment logic.
+- **Daemon-first.** As of 0.2.0, every read path consumes `daemon-snapshot.json` (≈1 ms). Without `marmonitor start`, most commands print `Daemon not running. Run: marmonitor start`. One-shot scans live only inside `debug-phase`, `clean`, and the daemon itself.
+- **Two-tier scanning.** Light scans keep statusline fresh on a 2-second budget; heavy scans pay the JSONL/SQLite cost. Cold sessions skip heavy work but watch JSONL mtimes so changes promote them back to hot.
+- **Persistent bindings.** Codex needs a stable PID-to-thread mapping that survives `/clear`, file-creation lag, and same-cwd parallelism. The binding registry on disk records confidence and prunes dead PIDs after 7 days.
+- **Fail-safe.** Every external call (`ps`, `lsof`, `tmux`, file IO) is wrapped in try/catch; cache writes silently swallow errors. The guard returns `allow` on any malformed input.
+- **No network.** Zero outbound connections; everything is parsed from local files and OS APIs.
+- **Agent-agnostic.** Adding a new agent means adding a `processNames` entry in config plus a `<agent>.ts` enrichment module. The current branching in `scanAgents()` is being tracked for adapter-style refactoring (see `.worklog/issues/post-review-roadmap.md`).
 
-## Adding Support for a New Agent
+## Extending
 
-See [CONTRIBUTING.md](CONTRIBUTING.md#adding-a-new-ai-agent) for the step-by-step guide.
+To add a new agent:
+
+1. Add an `agents.<name>` entry in `src/config/index.ts` defaults (or via `settings.json`).
+2. Implement `src/scanner/<agent>.ts` — at minimum a session resolver and a phase detector. Keep all IO behind try/catch.
+3. Wire it into `src/scanner/index.ts` `scanAgents()` enrichment branch.
+4. Extend `src/output/` labels/colors and add tests under `tests/<agent>.test.mjs`.
+5. Document the data layout in `~/.ai/projects/mjjo/works/work_mjjo_marmonitor/agent-data-spec.md`.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor guide.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,75 +4,181 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**marmonitor** - AI 에이전트 감시 & 모니터링 TUI 도구. 마멋이 굴 입구에서 경계 서듯이, 로컬에서 돌아가는 AI 에이전트(Claude Code, Codex, Gemini 등)를 감시한다.
+**marmonitor** — 로컬에서 돌아가는 AI 코딩 에이전트(Claude Code, Codex, Gemini)의 세션·토큰·phase·tmux 위치를 외부에서 관찰하는 도구. 마멋이 굴 입구에서 경계 서듯이 감시한다.
+
+- 배포: `marmonitor` (npm, macOS/Linux). 진입점은 `bin/marmonitor.js` (CLI), `bin/daemon.js` (백그라운드 데몬).
+- 패시브 옵저버: 외부 API/플러그인 없이 OS 프로세스와 에이전트별 로컬 세션 파일만 읽는다.
 
 ## Project Management (문서 연동)
 
-기획/검토/로드맵 등 프로젝트 관리 문서는 별도 경로에서 관리:
+기획·검토·로드맵·로컬 이슈는 별도 경로에서 관리:
 
 ```
 ~/.ai/projects/mjjo/works/work_mjjo_marmonitor/
-├── README.md              <- 문서 구조 가이드
-├── prd.md                 <- 제품 요구사항 정의서
-├── feasibility.md         <- 구현 가능성 검토 (기술 검증)
-├── agent-data-spec.md     <- 에이전트별 로컬 데이터 구조 분석
-├── roadmap.md             <- 구현 로드맵 (v0.1 ~ v1.0)
-└── ...
+├── README.md, prd.md, feasibility.md, agent-data-spec.md, roadmap.md, ...
+├── issues.md            <- 인덱스 (OPEN/IN_PROGRESS/DONE 테이블)
+└── issues/
+    ├── RULES.md         <- 이슈 작성/운영 규칙 (양식, 작성자 표기, 처리 이력)
+    ├── NNN-slug.md      <- 개별 이슈 파일 (시리얼 번호)
+    └── G001~G00N        <- GitHub 연동 그룹 이슈
 ```
 
-코드 변경 시 프로젝트 관리 문서 업데이트가 필요하면 위 경로 참조.
+리뷰 결과·작업 분담·후속 트랙은 위 `issues/`의 개별 파일로 분리. 본 레포의 `.worklog/`는 세션 로그(`activity.md`, `sessions/`)만 보관하고 이슈 파일은 두지 않는다.
 
-## Code Structure
+## High-level Architecture
+
+0.2.0부터 **데몬 + 스냅샷** 모델이다. CLI는 거의 모두 stateless reader.
+
+```
+bin/daemon.js  ──▶  src/scanner/daemon-entry.ts ─▶ runDaemonLoop()
+                       │
+                       │ light scan (default 2s)  : ps-list + pidusage + 캐시 enrich
+                       │ heavy scan (30s)         : Claude/Codex/Gemini jsonl·sqlite 풀 파싱
+                       │
+                       ├─ /tmp/marmonitor/daemon-snapshot.json   (statusline 소비자)
+                       ├─ /tmp/marmonitor/alerts-snapshot.json
+                       ├─ ~/.config/marmonitor/session-registry.json
+                       ├─ ~/.config/marmonitor/codex-binding-registry.json
+                       ├─ ~/.config/marmonitor/activity-log/YYYY-MM-DD.jsonl
+                       └─ ~/.config/marmonitor/alerts.log
+
+bin/marmonitor.js ─▶ src/cli.ts ─▶ readDaemonSnapshot() ─▶ src/output/* render
+```
+
+핵심 불변식:
+- **싱글 데이몬**: `start`는 ps-list로 중복 체크 후 fork. `stop`은 SIGTERM → 2s wait → SIGKILL.
+- **fail-safe**: `ps`/`lsof`/`tmux`/file IO 모든 외부 호출은 try/catch + 캐시 쓰기 실패 무시. guard는 fail-open(`{"decision":"allow"}`).
+- **statusline TTL 캐시**: `/tmp/marmonitor/statusline-<format>-<limit>-<width>.txt`. `tmux-badges`는 active panePid를 첫 줄에 박아 active 창이 바뀌면 즉시 invalidate.
+
+## Code Layout
 
 ```
 src/
-├── cli.ts             <- CLI 엔트리포인트 (commander)
-├── scanner.ts         <- AI 프로세스 탐지 + 세션 파싱
-├── output.ts          <- 출력 포매터 (text, json, statusline)
-└── types.ts           <- TypeScript 타입 정의
+├── cli.ts                  Commander 등록 + 모든 subcommand 액션 (1.6k LOC, 분리 예정)
+├── version.ts              릴리스 버전 상수
+├── process-safety.ts       uncaught/SIGINT 핸들러 헬퍼
+├── types.ts                AgentSession / TokenUsage / SessionStatus / SessionPhase
+│
+├── scanner/                ── 도메인 코어
+│   ├── index.ts            scanAgents() — 메인 파이프라인
+│   ├── daemon-entry.ts     데몬 main(): config 로드 → runDaemonLoop
+│   ├── daemon-loop.ts      light/heavy 두 단계 polling, snapshot/registry/activity 기록
+│   ├── daemon-utils.ts     read/writeDaemonSnapshot, pid 파일
+│   ├── process.ts          ps-list 결과 → agent 매칭, lsof로 cwd, ps -o lstart= 시작시간
+│   ├── claude.ts           ~/.claude/projects/<encodedCwd>/<sessionId>.jsonl 파싱
+│   ├── codex.ts            ~/.codex/sessions/* + SQLite 인덱스 머지
+│   ├── codex-binding-registry.ts  PID×processStartedAt → thread/rollout 영속 매핑(/clear 견딤)
+│   ├── codex-sqlite.ts     ~/.codex 의 SQLite threads 테이블 인덱싱
+│   ├── gemini.ts           ~/.gemini/tmp/<hash>/chats/session-*.json 최신 mtime 선택
+│   ├── status.ts           Active/Idle/Stalled hysteresis + stdout 휴리스틱
+│   ├── session-tier.ts     hot(≤2m)/warm(≤10m)/cold 분류 → 차등 enrichment
+│   ├── session-registry.ts sessionId 평생 이력 (PID 변경, 토큰 누적)
+│   ├── activity-log.ts     tool_use 추출, 일별 JSONL, 7일 retention
+│   ├── group.ts            부모/자식 PID 머지(워커 트리)
+│   ├── cache.ts            BoundedMap LRU 인스턴스 모음 + TTL 상수
+│   ├── bounded-map.ts      LRU Map
+│   ├── concurrency.ts      promiseAllLimited
+│   ├── perf.ts             MARMONITOR_PERF=1 일 때 perfStart/perfEnd
+│   └── types.ts            ScanOptions
+│
+├── output/                 ── 렌더러 (text/json/statusline/dock/attention/jump)
+│   ├── index.ts            printStatus / renderStatusline / printAttention / printDock 등
+│   ├── utils.ts            buildAttentionItems / buildStatuslineSummary / phase decay 등 순수 함수
+│   └── badge-themes.ts     basic / basic-mono / block / block-mono / text / text-mono
+│
+├── config/index.ts         XDG 우선 settings.json + MARMONITOR_* 환경변수 + 기본값 deep merge
+│
+├── guard/index.ts          Claude hook stdin → trigger 검출(dangerous_command/secret_access/...)
+│                           → intervention 룰 매칭 → allow/block 결정
+│
+├── tmux/                   ── tmux 통합
+│   ├── index.ts            list-panes, pid-tree → cwd 우선 매칭, switch-client/select-pane
+│   ├── jump-anchor.ts      jump-back 앵커 (TTY 단위)
+│   ├── setup.ts            ~/.tmux.conf 에 marmonitor-tmux 플러그인 추가/제거
+│   └── status-click.ts     tmux 상태바 mouse range token 파싱
+│
+├── alerts/                 ── 알림 시스템(0.2.5+)
+│   ├── store.ts            5분 dedup 버킷 in-memory 스토어
+│   ├── token.ts            컨텍스트 사용량 임계치 검사 (model별 한도)
+│   ├── log.ts / snapshot.ts / desktop.ts (node-notifier)
+│   └── types.ts            Alert / AlertSeverity / AlertType
+│
+└── banner/index.ts         iTerm2 inline image / ANSI block 폴백
+
 bin/
-└── marmonitor.js      <- CLI 바이너리 엔트리
+├── marmonitor.js           dist/cli.js dynamic import
+├── daemon.js               dist/scanner/daemon-entry.js dynamic import
+├── postinstall.cjs         실행 중 데몬 재시작 + update-integration --quiet
+└── preuninstall.cjs        잔여 정리
+
+tests/                      node --test 기반 *.test.mjs (25개+)
 ```
 
 ## Commands
 
 ```bash
-# 의존성 설치
+# 의존성
 npm install
 
-# 빌드
-npm run build
+# 빌드 / 워치
+npm run build            # tsc → dist/
+npm run dev              # tsc --watch
 
-# 실행
-marmonitor status              # one-shot 텍스트 출력
-marmonitor status --json       # JSON 출력
-marmonitor --statusline        # tmux 상태바용 한 줄 출력
-marmonitor                     # TUI 대시보드 (v0.3+)
+# 품질
+npm run lint             # biome check src tests
+npm test                 # node --test tests/*.test.mjs
+node --test tests/scanner.test.mjs    # 단일 테스트
 
-# 개발
-npm run dev                    # tsc --watch
-npm test                       # node --test
-npm run lint                   # eslint
+# 실행 (데몬이 먼저 떠 있어야 함)
+marmonitor start                       # 데몬 fork
+marmonitor stop / restart
+marmonitor status [--json]             # daemon snapshot 한방 출력
+marmonitor attention [--interactive|--pid|--attention-index]
+marmonitor activity [--pid|--session|--days|--lines|--order|--json]
+marmonitor watch / dock                # live 갱신
+marmonitor --statusline --statusline-format <compact|standard|extended|tmux-badges>
+marmonitor jump-back                   # 직전 pane 복귀
+marmonitor debug-phase --pid <pid>     # phase/세션/stdout/tmux/Codex binding 종합 진단
+marmonitor clean [--kill] [--pid ...]  # Unmatched 프로세스 SIGTERM
+marmonitor guard                       # stdin Claude hook 평가 (fail-open)
+marmonitor alerts [on|off|notify on|off]
+marmonitor settings-{path,show,init [--advanced]}
+marmonitor setup tmux | update-integration | uninstall-integration
 ```
 
-## Architecture
+## Environment & Paths
 
-- **scanner.ts**: ps-list + pidusage로 프로세스 스캔, 에이전트별 세션 데이터 파싱
-- **output.ts**: 스캐너 결과를 다양한 포맷으로 출력 (chalk 컬러, json, statusline)
-- **cli.ts**: commander 기반 CLI, 실행 모드 분기 (status, TUI, statusline)
+```
+~/.config/marmonitor/settings.json     XDG 우선 (legacy: ~/.marmonitor.json)
+~/.config/marmonitor/{session-registry,codex-binding-registry,alerts.log}
+~/.config/marmonitor/activity-log/YYYY-MM-DD.jsonl
+/tmp/marmonitor/{daemon.pid,daemon-snapshot.json,alerts-snapshot.json,statusline-*.txt,jump-anchors.json}
 
-에이전트 추가 시 `scanner.ts`의 `AGENT_SIGNATURES`에 탐지 규칙 추가, 필요 시 전용 파서 함수 작성.
+MARMONITOR_CLAUDE_HOME / MARMONITOR_CODEX_HOME    경로 루트 오버라이드
+MARMONITOR_CLAUDE_PROJECTS / _CLAUDE_SESSIONS / _CODEX_SESSIONS    PATH 형식 다중 경로
+MARMONITOR_PERF=1                                  scan 단계별 timing 출력
+```
 
-## Key Dependencies
+## Adding a New Agent
 
-- `ps-list`: 프로세스 목록 조회
-- `pidusage`: 프로세스별 CPU/메모리
-- `systeminformation`: 시스템 리소스 (CPU, MEM, 배터리, GPU)
-- `chalk`: 터미널 컬러 출력
-- `commander`: CLI 파서
+1. `src/config/index.ts` DEFAULTS.agents에 `processNames` 추가.
+2. `src/scanner/<agent>.ts`에 세션 파서·phase 검출 함수 작성.
+3. `src/scanner/index.ts` `scanAgents()`에서 agentName 분기 추가(현재 if/else 구조 — 어댑터화 예정).
+4. 필요 시 `src/types.ts`의 `RuntimeSource` union 확장, output 라벨/색상 추가.
+5. tests/scanner.test.mjs 또는 전용 *.test.mjs 추가.
 
 ## Conventions
 
-- TypeScript strict mode, ESM (type: module)
-- 한국어 문서, 영어 코드/커밋
-- 에이전트별 파서는 실패 시 graceful degradation (프로세스 스캔 폴백)
+- TypeScript strict mode, ESM only (`"type": "module"`).
+- Lint/format은 biome (`biome.json`). PR 전에 `npm run lint && npm test`.
+- 한국어 문서, 영어 코드/주석/커밋. 커밋 메시지는 `~` 라 끝맺는 명령형(예: "exclude vscode codex app-server").
+- 외부 호출은 모두 fail-safe로 감싼다. 캐시 쓰기 실패는 무시(스타일 일관).
+- 새 기능을 데몬 사이클에 끼울 땐 light vs heavy 분류를 먼저 결정한다(JSONL/SQLite read는 heavy).
+
+## Branching & Release
+
+자세한 흐름은 `~/.claude/projects/-Users-macrent-Documents-mjjo-marmonitor/memory/project_branch_strategy.md` 참조.
+
+- `feature/* → dev → main`. PR은 항상 `dev` 대상.
+- `main`에 push되면 npm 자동 배포(OIDC Trusted Publisher). 따라서 main 직접 push는 금지.
+- postinstall이 실행 중 데몬을 자동 재시작하므로 새 버전 배포 후 추가 작업 불필요.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -907,7 +907,7 @@ program
 
 async function patchAlertsConfig(
   configPath: string,
-  patch: Partial<{ enabled: boolean; desktop: boolean; log: boolean }>,
+  patch: Partial<{ enabled: boolean; desktop: boolean; log: boolean; tokens: boolean }>,
 ): Promise<void> {
   await mkdir(dirname(configPath), { recursive: true });
   let current: Record<string, unknown> = {};
@@ -936,6 +936,7 @@ const alertsCmd = program
     console.log(`alerts.enabled  : ${a.enabled}`);
     console.log(`alerts.desktop  : ${a.desktop}`);
     console.log(`alerts.log      : ${a.log}`);
+    console.log(`alerts.tokens   : ${a.tokens} (token/context threshold alerts)`);
     console.log(
       `alerts.contextCritThreshold: ${a.contextCritThreshold} (${Math.round(a.contextCritThreshold * 100)}%)`,
     );
@@ -977,6 +978,22 @@ alertsCmd
     await patchAlertsConfig(p, { desktop: toggle === "on" });
     console.log(
       `Desktop notifications ${toggle === "on" ? "enabled" : "disabled"}. Restart daemon to apply: marmonitor restart`,
+    );
+  });
+
+alertsCmd
+  .command("tokens <on|off>")
+  .description("Toggle token/context threshold alerts (security alerts unaffected)")
+  .option("--config <path>", "Path to settings.json")
+  .action(async (toggle, opts) => {
+    if (toggle !== "on" && toggle !== "off") {
+      console.error("Usage: marmonitor alerts tokens on|off");
+      process.exit(1);
+    }
+    const p = resolveConfigPath(opts) ?? getDefaultConfigPath();
+    await patchAlertsConfig(p, { tokens: toggle === "on" });
+    console.log(
+      `Token/context alerts ${toggle === "on" ? "enabled" : "disabled"}. Restart daemon to apply: marmonitor restart`,
     );
   });
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -102,6 +102,8 @@ export interface MarmonitorConfig {
     desktop: boolean;
     /** alerts.log 파일 기록 */
     log: boolean;
+    /** 토큰/컨텍스트 임계 알림 카테고리 토글. 보안 알림과 분리 가능. 기본 true */
+    tokens: boolean;
     /** 컨텍스트 경고 임계값 (0~1). 0 = 비활성화. 기본 1.0 (비활성) */
     contextWarnThreshold: number;
     /** 컨텍스트 위험 임계값 (0~1). 기본 0.85 */
@@ -194,6 +196,7 @@ const DEFAULTS: MarmonitorConfig = {
     enabled: false,
     desktop: false,
     log: false,
+    tokens: true, // 활성 시 토큰/컨텍스트 임계 알림 발사. 보안 알림은 별도 게이트 없음
     contextWarnThreshold: 1.0, // 기본 비활성 (0.70으로 설정 시 활성화)
     contextCritThreshold: 0.85,
   },

--- a/src/scanner/daemon-loop.ts
+++ b/src/scanner/daemon-loop.ts
@@ -55,6 +55,11 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/** Token/context threshold alerts fire only when both master and category toggles are on. */
+export function shouldRunTokenAlerts(config: MarmonitorConfig): boolean {
+  return Boolean(config.alerts.enabled && config.alerts.tokens);
+}
+
 export async function runDaemonLoop(
   config: MarmonitorConfig,
   options: DaemonOptions,
@@ -136,8 +141,8 @@ export async function runDaemonLoop(
       // Write snapshot for statusline consumers
       await writeDaemonSnapshot(snapshotPath, agents);
 
-      // Check token thresholds and fire alerts (alerts.enabled 확인)
-      if (config.alerts.enabled) {
+      // Check token thresholds and fire alerts (alerts.enabled + alerts.tokens 확인)
+      if (shouldRunTokenAlerts(config)) {
         const thresholds = {
           warnAt: config.alerts.contextWarnThreshold,
           critAt: config.alerts.contextCritThreshold,

--- a/tests/config.test.mjs
+++ b/tests/config.test.mjs
@@ -60,6 +60,14 @@ describe("getDefaults", () => {
     assert.equal(config.performance.stdoutHeuristicTtlMs, 2000);
   });
 
+  it("defaults alerts.tokens=true and master toggles=false", () => {
+    const config = getDefaults();
+    assert.equal(config.alerts.enabled, false);
+    assert.equal(config.alerts.desktop, false);
+    assert.equal(config.alerts.log, false);
+    assert.equal(config.alerts.tokens, true);
+  });
+
   it("includes all three default agents", () => {
     const config = getDefaults();
     assert.ok(config.agents["Claude Code"]);
@@ -165,6 +173,29 @@ describe("loadConfig", () => {
       assert.deepEqual(config.paths.extraRoots, []);
       assert.equal(config.performance.snapshotTtlMs, 2000);
       assert.deepEqual(config.agents.Codex.processNames, ["codex"]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("merges alerts.tokens override (security alerts unaffected)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "marmonitor-config-"));
+    const path = join(dir, "settings.json");
+    await writeFile(
+      path,
+      JSON.stringify({
+        alerts: { enabled: true, desktop: true, tokens: false },
+      }),
+    );
+
+    try {
+      const config = await loadConfig(path);
+      assert.equal(config.alerts.enabled, true);
+      assert.equal(config.alerts.desktop, true);
+      assert.equal(config.alerts.tokens, false);
+      // unspecified fields fall back to defaults
+      assert.equal(config.alerts.log, false);
+      assert.equal(config.alerts.contextCritThreshold, 0.85);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/tests/daemon-token-gate.test.mjs
+++ b/tests/daemon-token-gate.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { getDefaults } from "../dist/config/index.js";
+import { shouldRunTokenAlerts } from "../dist/scanner/daemon-loop.js";
+
+describe("shouldRunTokenAlerts (daemon token-alert gate)", () => {
+  it("fires only when both enabled and tokens are true", () => {
+    const cfg = getDefaults();
+    cfg.alerts.enabled = true;
+    cfg.alerts.tokens = true;
+    assert.equal(shouldRunTokenAlerts(cfg), true);
+  });
+
+  it("skips when alerts.tokens is false (security path stays on master toggle)", () => {
+    const cfg = getDefaults();
+    cfg.alerts.enabled = true;
+    cfg.alerts.tokens = false;
+    assert.equal(shouldRunTokenAlerts(cfg), false);
+  });
+
+  it("skips when master alerts.enabled is false even if tokens is true", () => {
+    const cfg = getDefaults();
+    cfg.alerts.enabled = false;
+    cfg.alerts.tokens = true;
+    assert.equal(shouldRunTokenAlerts(cfg), false);
+  });
+
+  it("skips when both toggles are off (default state)", () => {
+    const cfg = getDefaults();
+    cfg.alerts.enabled = false;
+    cfg.alerts.tokens = false;
+    assert.equal(shouldRunTokenAlerts(cfg), false);
+  });
+});


### PR DESCRIPTION
## Summary

Resolve #54

Add `alerts.tokens` configuration field that gates the daemon's token/context threshold alerts independently from the master `alerts.enabled` switch. Users can keep security alerts (`dangerous_command`, `secret_access`) active while silencing token/context alerts — a precondition for landing the Codex context-percent fix (#55) without forcing users to disable the security path. Also includes the post-0.2.5 documentation sync (`CLAUDE.md`, `ARCHITECTURE.md`) that the 2026-05-04 review identified as stale.

## Type

- [x] `[FEAT]` New feature
- [x] `[DOCS]` Documentation

## Changes

- `src/config/index.ts`: add `MarmonitorConfig.alerts.tokens` (default `true`, backward compatible).
- `src/scanner/daemon-loop.ts`: extract `shouldRunTokenAlerts(config)` pure helper, gate `checkTokenAlert` on it.
- `src/cli.ts`: extend `patchAlertsConfig` signature, render `alerts.tokens` row in `marmonitor alerts`, add `marmonitor alerts tokens on|off` subcommand.
- `tests/config.test.mjs`: assert the new default and the override merge semantics (+2).
- `tests/daemon-token-gate.test.mjs` (new): regression for the four `enabled × tokens` combinations (+4).
- `CLAUDE.md`: refresh to current `src/` directory layout, daemon lifecycle, env vars, agent-extension steps; redirect project-management section to `~/.ai/projects/.../issues/`.
- `ARCHITECTURE.md`: replace stale "no daemon" claim with daemon-first two-tier scan model, refresh module responsibility tables and data-flow diagram.

## Checklist

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (296/296, +6)
- [x] New features have tests
- [ ] README updated — N/A (no user-facing change to existing flows; new subcommand surfaces via `marmonitor help`)
- [x] No hardcoded paths or environment-specific values

## Testing

- `npm run build && npm run lint && npm test` → 296/296.
- Manual: reproduced the Codex \`Context Critical 8983%\` flood on local machine (the bug tracked as #55). Ran `marmonitor alerts tokens off && marmonitor restart`. Confirmed no further token alerts; the security path (#54 leaves it untouched) was smoke-tested by feeding a `dangerous_command` payload to `marmonitor guard`.

## Risk

Low.
- `alerts.tokens` defaults to `true`, so existing users see no behaviour change.
- Documentation-only edits don't affect runtime.
- The underlying Codex context-percent miscalculation remains tracked under #55 and is out of scope here. The toggle is the user-side off switch until that lands.