### PR TITLE
[FIX] skip Codex `app-server` backends in agent detection

### DIFF
--- a/src/scanner/process.ts
+++ b/src/scanner/process.ts
@@ -76,7 +76,7 @@ export function detectRuntimeSource(agentName: string, cmd?: string): RuntimeSou
   if (agentName !== "Codex") return undefined;
   const normalized = (cmd ?? "").toLowerCase();
   if (!normalized) return "unknown";
-  if (normalized.includes(".vscode/extensions") || normalized.includes("app-server")) {
+  if (normalized.includes(".vscode/extensions")) {
     return "vscode";
   }
   return "cli";
@@ -90,6 +90,9 @@ export function matchesProcessCommand(command: string, processName: string): boo
 /** Electron sub-process flags that indicate a desktop GUI helper, not a CLI agent. */
 const ELECTRON_TYPE_RE = /--type=(utility|renderer|gpu-process|zygote|broker)/;
 
+/** Codex `app-server` mode is an IDE/Desktop embedded RPC backend, not an interactive CLI session. */
+const CODEX_APP_SERVER_RE = /\bcodex\b[\s\S]*\bapp-server\b/i;
+
 /** Match a process against agent signatures using process name first, then cmd fallback. */
 export function detectAgentFromProcessSignature(
   proc: { name: string; cmd?: string },
@@ -98,6 +101,9 @@ export function detectAgentFromProcessSignature(
   // Skip Electron sub-processes (renderer, utility, gpu, zygote) to avoid
   // false-positive detection of desktop apps (e.g. Claude Desktop) as CLI agents.
   if (proc.cmd && ELECTRON_TYPE_RE.test(proc.cmd)) return null;
+  // Skip `codex app-server` backends spawned by Codex Desktop or the VS Code
+  // Codex extension — these are RPC backends, not interactive CLI sessions.
+  if (proc.cmd && CODEX_APP_SERVER_RE.test(proc.cmd)) return null;
 
   const name = proc.name.toLowerCase();
   const command = (proc.cmd ?? "").toLowerCase();

--- a/tests/scanner.test.mjs
+++ b/tests/scanner.test.mjs
@@ -74,6 +74,32 @@ describe("detectAgentFromProcessSignature", () => {
     );
   });
 
+  it("does not match Codex `app-server` backends from Desktop or VS Code", () => {
+    // Codex Desktop and the VS Code Codex extension spawn the real codex
+    // binary in `app-server` mode as an RPC backend — not an interactive
+    // session — so it must not show up as a CLI agent.
+    assert.equal(
+      detectAgentFromProcessSignature(
+        {
+          name: "node",
+          cmd: "/home/sam/.asdf/installs/nodejs/24.13.0/bin/node /home/sam/.npm-global/bin/codex app-server --analytics-default-enabled",
+        },
+        config,
+      ),
+      null,
+    );
+    assert.equal(
+      detectAgentFromProcessSignature(
+        {
+          name: "codex",
+          cmd: "/home/sam/.npm-global/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/codex/codex app-server --analytics-default-enabled",
+        },
+        config,
+      ),
+      null,
+    );
+  });
+
   it("does not falsely match unrelated node processes", () => {
     assert.equal(
       detectAgentFromProcessSignature(


### PR DESCRIPTION
## Summary
- Codex Desktop and the VS Code Codex extension spawn the real `codex` binary in `app-server` mode as an embedded RPC backend. Its `cmd` does not carry the Electron `--type=` flag, so the existing Electron filter (PR #40) missed it and these backend processes surfaced as Codex CLI sessions in the statusline (e.g. `•Cx ~ 8m`).
- Add a parallel `app-server` early-return in `detectAgentFromProcessSignature` so any `codex ... app-server` cmd is excluded from agent detection.
- Drop the now-unreachable `app-server` clause from `detectRuntimeSource` (the `.vscode/extensions` clause is kept).

## Test plan
- [x] `npm run build` clean
- [x] `npm test` — 282/282 pass, including 2 new regression cases covering both observed Codex Desktop signatures (`node ... codex app-server …` and `…/codex/codex app-server …`)
- [x] Live verification on Linux with Codex Desktop running alongside the Codex CLI: the two desktop backend PIDs are now filtered, real CLI sessions still detect as `Codex`/`cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)