### PR TITLE
[BUG] #55 Guard token alert against cumulative inputTokens fallback (workaround)

### DIFF
--- a/src/alerts/token.ts
+++ b/src/alerts/token.ts
@@ -53,8 +53,13 @@ export function checkTokenAlert(
   if (!usage) return undefined;
 
   // lastInputTokens = most recent API call's input_tokens = actual current context size.
-  // Fall back to cumulative inputTokens only if lastInputTokens is unavailable.
-  const used = usage.lastInputTokens ?? usage.inputTokens;
+  // Only fire when this definitive signal is available. Falling back to the
+  // cumulative inputTokens (which grows unboundedly across a session) would
+  // massively overstate the context % for agents that do not populate
+  // lastInputTokens — most notably Codex. Tracked as GitHub #55 / local #102
+  // (root fix: split TokenUsage into cumulative vs context-window fields).
+  if (usage.lastInputTokens === undefined) return undefined;
+  const used = usage.lastInputTokens;
   const limit = contextLimit(agent.model);
   const ratio = used / limit;
 

--- a/src/alerts/token.ts
+++ b/src/alerts/token.ts
@@ -53,13 +53,15 @@ export function checkTokenAlert(
   if (!usage) return undefined;
 
   // lastInputTokens = most recent API call's input_tokens = actual current context size.
-  // Only fire when this definitive signal is available. Falling back to the
-  // cumulative inputTokens (which grows unboundedly across a session) would
-  // massively overstate the context % for agents that do not populate
-  // lastInputTokens — most notably Codex. Tracked as GitHub #55 / local #102
-  // (root fix: split TokenUsage into cumulative vs context-window fields).
-  if (usage.lastInputTokens === undefined) return undefined;
-  const used = usage.lastInputTokens;
+  // Only fire when this definitive signal is available as a finite number.
+  // `Number.isFinite` rejects undefined / null (e.g. from external JSON) / NaN /
+  // Infinity in one check. Falling back to the cumulative inputTokens (which
+  // grows unboundedly across a session) would massively overstate the context %
+  // for agents that do not populate lastInputTokens — most notably Codex.
+  // Tracked as GitHub #55 / local #102 (root fix: split TokenUsage into
+  // cumulative vs context-window fields).
+  if (!Number.isFinite(usage.lastInputTokens)) return undefined;
+  const used = usage.lastInputTokens as number;
   const limit = contextLimit(agent.model);
   const ratio = used / limit;
 

--- a/tests/alerts-token.test.mjs
+++ b/tests/alerts-token.test.mjs
@@ -62,6 +62,42 @@ describe("checkTokenAlert (context-size gate, #102 G2)", () => {
     assert.equal(alert, undefined);
   });
 
+  it("does not fire when lastInputTokens is null (external JSON null)", () => {
+    // gemini-code-assist review on PR #59: external JSON parsing can yield
+    // `null` instead of `undefined`. Number.isFinite guard handles both.
+    const store = new AlertStore();
+    const alert = checkTokenAlert(
+      store,
+      makeAgent({
+        inputTokens: 2_000_000,
+        outputTokens: 0,
+        cacheCreationTokens: 0,
+        cacheReadTokens: 0,
+        totalTokens: 2_000_000,
+        lastInputTokens: null,
+      }),
+    );
+    assert.equal(alert, undefined);
+  });
+
+  it("does not fire when lastInputTokens is NaN or non-finite", () => {
+    const store = new AlertStore();
+    for (const bad of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+      const alert = checkTokenAlert(
+        store,
+        makeAgent({
+          inputTokens: 0,
+          outputTokens: 0,
+          cacheCreationTokens: 0,
+          cacheReadTokens: 0,
+          totalTokens: 0,
+          lastInputTokens: bad,
+        }),
+      );
+      assert.equal(alert, undefined, `bad value ${bad} should not fire`);
+    }
+  });
+
   it("does not fire when lastInputTokens is below thresholds", () => {
     const store = new AlertStore();
     const alert = checkTokenAlert(

--- a/tests/alerts-token.test.mjs
+++ b/tests/alerts-token.test.mjs
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { AlertStore, checkTokenAlert } from "../dist/alerts/index.js";
+
+function makeAgent(tokenUsage, overrides = {}) {
+  return {
+    agentName: "Claude Code",
+    pid: 1234,
+    cwd: "/tmp/agent",
+    cpuPercent: 0,
+    memoryMb: 0,
+    status: "Active",
+    model: "claude-opus-4-7",
+    tokenUsage,
+    ...overrides,
+  };
+}
+
+describe("checkTokenAlert (context-size gate, #102 G2)", () => {
+  it("fires context_critical when lastInputTokens crosses critAt (Claude normal path)", () => {
+    const store = new AlertStore();
+    const alert = checkTokenAlert(
+      store,
+      makeAgent({
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheCreationTokens: 0,
+        cacheReadTokens: 0,
+        totalTokens: 0,
+        lastInputTokens: 180_000, // 90% of 200K
+      }),
+    );
+    assert.ok(alert, "alert should be created");
+    assert.equal(alert?.type, "context_critical");
+  });
+
+  it("does NOT fire when lastInputTokens is missing — Codex cumulative regression (#102)", () => {
+    // Reproduces the production case at 2026-05-08: Codex sessions arrive
+    // with a multi-million cumulative inputTokens but no lastInputTokens,
+    // which previously fell back to cumulative and produced 8983%/15700% alerts.
+    const store = new AlertStore();
+    const alert = checkTokenAlert(
+      store,
+      makeAgent(
+        {
+          inputTokens: 1_500_000, // cumulative across the session
+          outputTokens: 12_000,
+          cacheCreationTokens: 0,
+          cacheReadTokens: 0,
+          totalTokens: 1_512_000,
+          // lastInputTokens intentionally omitted
+        },
+        { agentName: "Codex", model: "gpt-5.4", pid: 2222 },
+      ),
+    );
+    assert.equal(alert, undefined);
+  });
+
+  it("does not fire when tokenUsage is absent", () => {
+    const store = new AlertStore();
+    const alert = checkTokenAlert(store, makeAgent(undefined));
+    assert.equal(alert, undefined);
+  });
+
+  it("does not fire when lastInputTokens is below thresholds", () => {
+    const store = new AlertStore();
+    const alert = checkTokenAlert(
+      store,
+      makeAgent({
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheCreationTokens: 0,
+        cacheReadTokens: 0,
+        totalTokens: 0,
+        lastInputTokens: 50_000, // 25%
+      }),
+    );
+    assert.equal(alert, undefined);
+  });
+});


### PR DESCRIPTION
## Summary

Workaround for #55 (does not close it). Refuse to fire `context_warn` / `context_critical` when `tokenUsage.lastInputTokens` is undefined. The previous fallback to cumulative `inputTokens` overstated context % for agents that do not populate `lastInputTokens` — most notably Codex — producing impossible 8983% / 15700% alerts on long-running sessions.

The root fix is the type split between cumulative usage and context-window usage (see #55 comments, item F0 / F1). This PR is the conservative guard (item G2) so the alert pipeline stops misfiring while that larger work lands separately.

## Type

- [x] `[BUG]` Bug fix

## Changes

- `src/alerts/token.ts`: remove the cumulative fallback, gate the alert path on `lastInputTokens !== undefined`.
- `tests/alerts-token.test.mjs` (new): 4 cases incl. the Codex regression — large cumulative `inputTokens` (1.5M) with missing `lastInputTokens` → no alert.

## Checklist

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (301/301, +4)
- [x] New features have tests
- [ ] README updated — N/A (no user-facing surface change beyond silencing false alerts)
- [x] No hardcoded paths or environment-specific values

## Testing

- Unit: `tests/alerts-token.test.mjs` — Claude normal path still fires `context_critical` at 90% of context, Codex cumulative scenario stays silent, missing `tokenUsage` and below-threshold paths stay silent.
- Live (own daemon, 2026-05-16): enabled all four alert flags (`alerts.enabled / desktop / log / tokens` all true) and restarted the daemon onto this branch's dist. 60s wait covering two heavy scans → `alerts.log` line count unchanged (2154 → 2154), zero desktop notifications. Without G2, four Codex PIDs would each have fired:
  - pid=40040 cum=1,282,671 ≈ 641%
  - pid=22863 cum=1,478,468 ≈ 739%
  - pid=55954 cum=1,540,418 ≈ 770%
  - pid=74203 cum=33,684,011 ≈ 16842%

## Risk

Low. Claude's normal path is unchanged (it already populates `lastInputTokens`). For agents that do not populate it (Codex, today; possibly Gemini), this trades a stream of false-positive `context_critical` alerts for silent omission until the type split (#55 F0) lands. Visual surfaces (status table, `activity` command) are unaffected — they still display `outputTokens` cumulative as before.

## Issue

ref #55 — issue intentionally left OPEN per Codex review (2026-05-12 comment): the structural fix is the TokenUsage type split, not this guard.