### PR TITLE
[BUG] #56 Guard chooseStaleSessionOverride against same-cwd sibling misrouting

### DIFF
--- a/src/scanner/claude.ts
+++ b/src/scanner/claude.ts
@@ -508,16 +508,20 @@ async function readJsonlSessionMeta(
  * Stale-session override resolver.
  *
  * Picks a non-current jsonl when the current sessionId's metadata is stale
- * (e.g. just after /clear), but refuses to do so when it would conflict with
- * an active sibling session in the same project directory. See local issue
- * #103 / GH #56 for the misrouting case this guards.
+ * (e.g. just after /clear), but refuses to do so when the current jsonl
+ * clearly belongs to this process or when the candidate jsonl is already
+ * claimed in the registry. See local issue #103 / GH #56 for the misrouting
+ * case this guards.
  *
  * Conservative guards layered on top of the legacy mtime-lead check:
  *  - F1: if currentDirectPath exists and its first-line timestamp is on or
  *        after processStartedAt, the current jsonl was authored by this
  *        process — keep it, do not override.
- *  - F2: if the override-candidate sessionId is already direct-bound to
- *        another live PID in claudeSessionRegistry, refuse the override.
+ *  - F2: if the override-candidate sessionId is already recorded as a
+ *        direct binding in claudeSessionRegistry, refuse the override. The
+ *        registry stores filePath / sessionId / cwd / binding (no live-PID
+ *        field), so this is "another scan has already claimed this jsonl
+ *        as authoritative," not a live-process check.
  *  - F3: anything ambiguous falls through to `undefined` (unresolved) —
  *        a missed match is safer than a misrouted one.
  */
@@ -581,8 +585,13 @@ async function chooseStaleSessionOverride(
   if (!recentMeta?.sessionId) return undefined;
   if (recentMeta.sessionId === currentSessionId) return undefined;
 
-  // F2: another live PID is already direct-bound to this candidate jsonl.
-  // Overriding would let two PIDs share one jsonl — the exact bug in #103.
+  // F2: the candidate jsonl is already recorded as a direct binding in the
+  // session registry — i.e. an earlier resolution (or another concurrent
+  // scan) has already claimed it as authoritative for its own sessionId.
+  // The registry has no live-PID field, so this is a "registry already
+  // claimed this jsonl" check, not a process-aliveness check. Refusing
+  // here keeps the one-jsonl-per-sessionId invariant intact and avoids
+  // the misroute in #103.
   const recentBinding = claudeSessionRegistry.get(recentMeta.sessionId);
   if (recentBinding?.binding === "direct") return undefined;
 

--- a/src/scanner/claude.ts
+++ b/src/scanner/claude.ts
@@ -517,11 +517,9 @@ async function readJsonlSessionMeta(
  *  - F1: if currentDirectPath exists and its first-line timestamp is on or
  *        after processStartedAt, the current jsonl was authored by this
  *        process — keep it, do not override.
- *  - F2: if the override-candidate sessionId is already recorded as a
- *        direct binding in claudeSessionRegistry, refuse the override. The
- *        registry stores filePath / sessionId / cwd / binding (no live-PID
- *        field), so this is "another scan has already claimed this jsonl
- *        as authoritative," not a live-process check.
+ *  - F2: if the override-candidate sessionId is already direct-bound in
+ *        claudeSessionRegistry, refuse the override. Keeps the
+ *        one-jsonl-per-sessionId invariant intact.
  *  - F3: anything ambiguous falls through to `undefined` (unresolved) —
  *        a missed match is safer than a misrouted one.
  */
@@ -585,13 +583,9 @@ async function chooseStaleSessionOverride(
   if (!recentMeta?.sessionId) return undefined;
   if (recentMeta.sessionId === currentSessionId) return undefined;
 
-  // F2: the candidate jsonl is already recorded as a direct binding in the
-  // session registry — i.e. an earlier resolution (or another concurrent
-  // scan) has already claimed it as authoritative for its own sessionId.
-  // The registry has no live-PID field, so this is a "registry already
-  // claimed this jsonl" check, not a process-aliveness check. Refusing
-  // here keeps the one-jsonl-per-sessionId invariant intact and avoids
-  // the misroute in #103.
+  // F2: the candidate sessionId is already direct-bound in the registry.
+  // Overriding would let two sessionIds share one jsonl — the exact bug
+  // in #103. Keeps the one-jsonl-per-sessionId invariant.
   const recentBinding = claudeSessionRegistry.get(recentMeta.sessionId);
   if (recentBinding?.binding === "direct") return undefined;
 

--- a/src/scanner/claude.ts
+++ b/src/scanner/claude.ts
@@ -504,9 +504,27 @@ async function readJsonlSessionMeta(
   }
 }
 
+/**
+ * Stale-session override resolver.
+ *
+ * Picks a non-current jsonl when the current sessionId's metadata is stale
+ * (e.g. just after /clear), but refuses to do so when it would conflict with
+ * an active sibling session in the same project directory. See local issue
+ * #103 / GH #56 for the misrouting case this guards.
+ *
+ * Conservative guards layered on top of the legacy mtime-lead check:
+ *  - F1: if currentDirectPath exists and its first-line timestamp is on or
+ *        after processStartedAt, the current jsonl was authored by this
+ *        process — keep it, do not override.
+ *  - F2: if the override-candidate sessionId is already direct-bound to
+ *        another live PID in claudeSessionRegistry, refuse the override.
+ *  - F3: anything ambiguous falls through to `undefined` (unresolved) —
+ *        a missed match is safer than a misrouted one.
+ */
 async function chooseStaleSessionOverride(
   processCwd: string,
   currentSessionId: string | undefined,
+  processStartedAt: number | undefined,
   config?: MarmonitorConfig,
 ): Promise<{ sessionId: string; cwd?: string; timestamp?: string; filePath: string } | undefined> {
   const projectDirName = await findClaudeProjectDir(processCwd, currentSessionId, config);
@@ -531,23 +549,42 @@ async function chooseStaleSessionOverride(
       : undefined;
 
   if (currentDirectPath) {
+    let currentStat: Awaited<ReturnType<typeof stat>>;
+    let recentStat: Awaited<ReturnType<typeof stat>>;
     try {
-      const [recentStat, currentStat] = await Promise.all([
-        stat(recentPath),
-        stat(currentDirectPath),
-      ]);
-      const minLeadMs = 5 * 60 * 1000;
-      const staleGapMs = 30 * 60 * 1000;
-      if (recentStat.mtimeMs - currentStat.mtimeMs < minLeadMs) return undefined;
-      if (Date.now() - currentStat.mtimeMs < staleGapMs) return undefined;
+      [recentStat, currentStat] = await Promise.all([stat(recentPath), stat(currentDirectPath)]);
     } catch {
       return undefined;
     }
+
+    // F1: a non-empty current jsonl whose first event is on or after the
+    // process start belongs to this process. Same-cwd sibling sessions land
+    // here and must not be routed onto another session's active jsonl.
+    if (currentStat.size > 0 && processStartedAt !== undefined) {
+      const currentMeta = await readJsonlSessionMeta(currentDirectPath);
+      if (currentMeta?.timestamp) {
+        const jsonlCreatedAtSec = new Date(currentMeta.timestamp).getTime() / 1000;
+        if (Number.isFinite(jsonlCreatedAtSec)) {
+          const CLOCK_SKEW_SEC = 60;
+          if (jsonlCreatedAtSec >= processStartedAt - CLOCK_SKEW_SEC) return undefined;
+        }
+      }
+    }
+
+    const minLeadMs = 5 * 60 * 1000;
+    const staleGapMs = 30 * 60 * 1000;
+    if (recentStat.mtimeMs - currentStat.mtimeMs < minLeadMs) return undefined;
+    if (Date.now() - currentStat.mtimeMs < staleGapMs) return undefined;
   }
 
   const recentMeta = await readJsonlSessionMeta(recentPath);
   if (!recentMeta?.sessionId) return undefined;
   if (recentMeta.sessionId === currentSessionId) return undefined;
+
+  // F2: another live PID is already direct-bound to this candidate jsonl.
+  // Overriding would let two PIDs share one jsonl — the exact bug in #103.
+  const recentBinding = claudeSessionRegistry.get(recentMeta.sessionId);
+  if (recentBinding?.binding === "direct") return undefined;
 
   return {
     sessionId: recentMeta.sessionId,
@@ -716,7 +753,12 @@ export async function parseClaudeSession(
       let resolvedStartedAt = sessionStartedAt;
 
       if (processCwd && processCwd !== "unknown") {
-        const override = await chooseStaleSessionOverride(processCwd, data.sessionId, config);
+        const override = await chooseStaleSessionOverride(
+          processCwd,
+          data.sessionId,
+          processStartedAt,
+          config,
+        );
         if (override) {
           resolvedSessionId = override.sessionId;
           resolvedCwd = override.cwd ?? processCwd;

--- a/tests/claude-session-file.test.mjs
+++ b/tests/claude-session-file.test.mjs
@@ -301,6 +301,166 @@ describe("parseClaudeSession", () => {
   });
 });
 
+describe("chooseStaleSessionOverride conservative guards (#103)", () => {
+  it("F1: does not misroute dormant same-cwd session to active sibling jsonl", async () => {
+    // Reproduces local issue #103 / GH #56 deterministically.
+    // Two Claude sessions share cwd. The dormant one (current) has its own
+    // jsonl whose first-line timestamp matches its processStartedAt. The
+    // active sibling's jsonl is newer by 56min and the dormant's mtime is
+    // older than 30min — exactly the case where the legacy mtime check would
+    // override. F1 must short-circuit on processStartedAt parity.
+    claudeSessionRegistry.clear();
+    claudeProjectDirCache.clear();
+
+    const root = join(tmpdir(), `marmonitor-claude-103-f1-${Date.now()}`);
+    const cwd = join(root, "shared");
+    const projectsRoot = join(root, "projects");
+    const sessionsRoot = join(root, "sessions");
+    const projectDir = join(projectsRoot, encodeClaudeProjectDir(cwd));
+    const dormantPid = 48477;
+    const sessionMetaPath = join(sessionsRoot, `${dormantPid}.json`);
+    const dormantPath = join(projectDir, "abd04dd5.jsonl");
+    const activePath = join(projectDir, "048c0eb5.jsonl");
+    const nowSec = Math.floor(Date.now() / 1000);
+    // Dormant process started 2h ago; its jsonl first-line carries the same
+    // creation time (well within F1's clock-skew window).
+    const dormantStartedAt = nowSec - 2 * 3600;
+    const dormantTs = new Date(dormantStartedAt * 1000).toISOString();
+    // Active sibling started 1h ago; its jsonl is the newest in the dir.
+    const activeStartedAt = nowSec - 3600;
+    const activeTs = new Date(activeStartedAt * 1000).toISOString();
+
+    await mkdir(projectDir, { recursive: true });
+    await mkdir(sessionsRoot, { recursive: true });
+    await writeFile(
+      dormantPath,
+      `${[
+        JSON.stringify({ type: "permission-mode", sessionId: "abd04dd5" }),
+        JSON.stringify({ type: "user", cwd, sessionId: "abd04dd5", timestamp: dormantTs }),
+      ].join("\n")}\n`,
+      "utf-8",
+    );
+    await writeFile(
+      activePath,
+      `${[
+        JSON.stringify({ type: "permission-mode", sessionId: "048c0eb5" }),
+        JSON.stringify({ type: "user", cwd, sessionId: "048c0eb5", timestamp: activeTs }),
+      ].join("\n")}\n`,
+      "utf-8",
+    );
+    // Dormant jsonl mtime: 1h45m ago (well past 30min staleness window).
+    const dormantMtime = new Date((nowSec - 1.75 * 3600) * 1000);
+    await utimes(dormantPath, dormantMtime, dormantMtime);
+    // Active sibling jsonl mtime: 49min ago — 56min newer than dormant.
+    const activeMtime = new Date((nowSec - 49 * 60) * 1000);
+    await utimes(activePath, activeMtime, activeMtime);
+    await writeFile(
+      sessionMetaPath,
+      JSON.stringify({
+        pid: dormantPid,
+        sessionId: "abd04dd5",
+        cwd,
+        startedAt: dormantStartedAt * 1000,
+      }),
+      "utf-8",
+    );
+
+    const defaults = getDefaults();
+    const config = {
+      ...defaults,
+      paths: {
+        ...defaults.paths,
+        claudeProjects: [projectsRoot],
+        claudeSessions: [sessionsRoot],
+      },
+    };
+
+    try {
+      const parsed = await parseClaudeSession(dormantPid, cwd, dormantStartedAt, config);
+      // Without F1, parsed.sessionId would have become "048c0eb5" (the active
+      // sibling) — exactly the misrouting reported in #103.
+      assert.equal(parsed.sessionId, "abd04dd5");
+    } finally {
+      claudeSessionRegistry.clear();
+      claudeProjectDirCache.clear();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("F2: does not override onto a sessionId already direct-bound to another live PID", async () => {
+    // Even if the dormant jsonl is missing (currentDirectPath undefined, so
+    // F1 cannot apply), F2 must still refuse when the active sibling's
+    // sessionId already has a direct binding registered.
+    claudeSessionRegistry.clear();
+    claudeProjectDirCache.clear();
+
+    const root = join(tmpdir(), `marmonitor-claude-103-f2-${Date.now()}`);
+    const cwd = join(root, "shared");
+    const projectsRoot = join(root, "projects");
+    const sessionsRoot = join(root, "sessions");
+    const projectDir = join(projectsRoot, encodeClaudeProjectDir(cwd));
+    const dormantPid = 22222;
+    const sessionMetaPath = join(sessionsRoot, `${dormantPid}.json`);
+    const activePath = join(projectDir, "active.jsonl");
+    const nowSec = Math.floor(Date.now() / 1000);
+    const activeTs = new Date((nowSec - 60) * 1000).toISOString();
+
+    await mkdir(projectDir, { recursive: true });
+    await mkdir(sessionsRoot, { recursive: true });
+    // No dormant jsonl on disk (dormant sessionId points to a missing file).
+    await writeFile(
+      activePath,
+      `${[
+        JSON.stringify({ type: "permission-mode", sessionId: "active" }),
+        JSON.stringify({ type: "user", cwd, sessionId: "active", timestamp: activeTs }),
+      ].join("\n")}\n`,
+      "utf-8",
+    );
+    await writeFile(
+      sessionMetaPath,
+      JSON.stringify({
+        pid: dormantPid,
+        sessionId: "dormant",
+        cwd,
+        startedAt: (nowSec - 3600) * 1000,
+      }),
+      "utf-8",
+    );
+
+    // Simulate another live PID already holding the active jsonl direct-bound.
+    claudeSessionRegistry.set("active", {
+      filePath: activePath,
+      sessionId: "active",
+      cwd,
+      firstSeenOffset: 0,
+      startedAt: nowSec - 60,
+      source: "claude",
+      binding: "direct",
+    });
+
+    const defaults = getDefaults();
+    const config = {
+      ...defaults,
+      paths: {
+        ...defaults.paths,
+        claudeProjects: [projectsRoot],
+        claudeSessions: [sessionsRoot],
+      },
+    };
+
+    try {
+      const parsed = await parseClaudeSession(dormantPid, cwd, nowSec - 3600, config);
+      // Override blocked by F2 → dormant session keeps its (stale) sessionId,
+      // which is the conservative outcome ("unresolved is safer than misrouted").
+      assert.equal(parsed.sessionId, "dormant");
+    } finally {
+      claudeSessionRegistry.clear();
+      claudeProjectDirCache.clear();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("matchClaudeSessionByMtime", () => {
   it("returns undefined when two files have timestamps within 5 minutes of each other (ambiguous)", async () => {
     claudeSessionRegistry.clear();


### PR DESCRIPTION
## Summary

Resolve #56

Two conservative gates layered ahead of the legacy mtime-lead check in `chooseStaleSessionOverride` prevent the override path from collapsing a dormant Claude session onto an active sibling's jsonl when both share a `cwd` — the misrouting case captured in #56 (local issue #103).

### Guards

- **F1 — processStartedAt parity**: if the current sessionId's jsonl exists, is non-empty, and its first-line `timestamp` is on or after `processStartedAt - 60s` (clock-skew tolerance), the jsonl was authored by this very process. Keep it; do not override.
- **F2 — already-claimed jsonl**: if the override-candidate `sessionId` is already recorded as a `direct` binding in `claudeSessionRegistry`, refuse the override. The registry stores `filePath / sessionId / cwd / binding` only (no live-PID field), so this is a "registry already claims this jsonl as authoritative" check — not a process-aliveness verification. Keeps the one-jsonl-per-sessionId invariant intact.
- **F3 — unresolved fallback**: anything ambiguous falls through to `undefined`. A missed match is safer than a misrouted one.

The legacy 5-minute mtime lead + 30-minute staleness check remains as the final tier so the original `/clear` recovery scenario (currentDirectPath absent, or present but created before processStartedAt) keeps working unchanged.

## Type

- [x] `[BUG]` Bug fix

## Changes

- `src/scanner/claude.ts` `chooseStaleSessionOverride`: new `processStartedAt` parameter; F1 + F2 layered ahead of the mtime-lead check.
- `src/scanner/claude.ts` `parseClaudeSession`: passes `processStartedAt` through.
- `tests/claude-session-file.test.mjs`: +2 regression cases
  - **F1 same-cwd sibling reproduction** — dormant `48477 / abd0` with its own jsonl vs an active `048c` sibling 56 min newer. Expects override skipped, parsed.sessionId stays `abd04dd5`.
  - **F2 already-bound active sibling** — dormant jsonl missing; active sibling pre-registered with `binding=\"direct\"`. Expects refusal, parsed.sessionId stays `dormant`.
- Follow-up commit (`0b4b97e`): docstring + F2 inline comment softened from \"another live PID direct-bound\" to \"registry already claimed as authoritative\" per Codex post-push review. Behaviour unchanged.

## Checklist

- [x] \`npm run build\` passes
- [x] \`npm run lint\` passes
- [x] \`npm test\` passes (305/305, +2)
- [x] New features have tests
- [ ] README updated — N/A
- [x] No hardcoded paths or environment-specific values

## Testing

- Unit: existing two \`parseClaudeSession\` tests (legacy stale-override + recent-active no-steal) still pass; +2 new regression cases for F1 and F2.
- Live reproduction is **conditional** — same-cwd Claude sessions only enter \`chooseStaleSessionOverride\` when at least one is hot or cold-promoted (i.e. full enrichment runs that cycle). Two cold dormant sessions share cached enrichment and bypass the override path entirely, so the bug becomes invisible until activity resumes. The mechanism is fully exercised in the unit tests instead.

## Risk

Low.
- F1 only fires when the current jsonl exists and carries a parseable first-line timestamp. The \`/clear\` recovery scenario (jsonl absent, or pre-process-start) bypasses F1 and falls through to the legacy tier unchanged.
- F2 only adds a refusal — it never accepts something the legacy path would have rejected.
- F3 preserves the existing \"if not provably correct, leave unmatched\" stance.

## Follow-up

- **F4 registry hygiene** (tracked as backlog item B10 in local issue #104, not in this PR): when a single PID appears in multiple sessionId histories in \`session-registry.json\`, retain it only in the most recent record and prune the others. Heals already-poisoned registries from past misroutes.