### PR TITLE
[FEAT] #62 copy-latest-turn — one-keystroke AI turn copy from active tmux pane

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path";
 import { createInterface } from "node:readline/promises";
 import { Command } from "commander";
 import { renderInstallBanner, renderRuntimeBanner } from "./banner/index.js";
+import { ClipboardError, writeClipboard } from "./clipboard.js";
 import {
   getConfigDir,
   getConfigSearchPaths,
@@ -43,7 +44,7 @@ import {
   selectUnmatchedTargets,
 } from "./output/utils.js";
 import { TERMINAL_RESTORE_SEQUENCE, formatProcessFailure } from "./process-safety.js";
-import { detectClaudePhase } from "./scanner/claude.js";
+import { detectClaudePhase, resolveClaudeSessionFile } from "./scanner/claude.js";
 import { detectCodexPhase, indexCodexSessions, matchCodexSession } from "./scanner/codex.js";
 import { isDaemonRunning, readDaemonPid, readDaemonSnapshot } from "./scanner/daemon-utils.js";
 import { parseGeminiSession } from "./scanner/gemini.js";
@@ -1659,6 +1660,119 @@ program
     await stopDaemon();
     await startDaemon();
     process.exit(0);
+  });
+
+// ── copy-latest-turn command ─────────────────────────────────────────────────
+
+program
+  .command("copy-latest-turn")
+  .description(
+    "Copy the most recent AI turn of the active tmux pane to the clipboard (Claude only)",
+  )
+  .option("--role <role>", "Which turn to copy: assistant (default) or user", "assistant")
+  .option("--mode <mode>", "Extraction mode: text (default) or bundle", "text")
+  .option(
+    "--pane-pid <pid>",
+    "Override active pane PID (default: tmux active pane). Useful for tmux key bindings that pass #{pane_pid}.",
+  )
+  .option("--stdout", "Print the turn to stdout instead of copying to clipboard")
+  .option("--config <path>", "Path to settings.json")
+  .action(async (opts) => {
+    const { parseClaudeConversationTurns, selectLatestTurn, turnTextForMode } = await import(
+      "./turns.js"
+    );
+
+    const role: "assistant" | "user" = opts.role === "user" ? "user" : "assistant";
+    const mode: "text" | "bundle" = opts.mode === "bundle" ? "bundle" : "text";
+
+    const agents = await requireDaemonSnapshot();
+
+    let agent: AgentSession | undefined;
+    let panePidOverridden = false;
+    if (typeof opts.panePid === "string") {
+      const panePid = Number.parseInt(opts.panePid, 10);
+      if (!Number.isFinite(panePid)) {
+        console.error(`Invalid --pane-pid value: ${opts.panePid}`);
+        process.exit(1);
+      }
+      panePidOverridden = true;
+      const agentPids = agents.map((a) => a.pid);
+      const matchedPid = await findActiveAgentPid(agentPids, panePid);
+      if (matchedPid !== undefined) {
+        agent = agents.find((a) => a.pid === matchedPid);
+      }
+    } else {
+      // Active tmux pane fallback
+      const agentPids = agents.map((a) => a.pid);
+      const matchedPid = await findActiveAgentPid(agentPids);
+      if (matchedPid !== undefined) {
+        agent = agents.find((a) => a.pid === matchedPid);
+      }
+    }
+
+    if (!agent) {
+      console.error(
+        panePidOverridden
+          ? `No AI session matched the given pane PID (${opts.panePid}).`
+          : "No AI session in this tmux pane. Switch to a Claude pane and try again.",
+      );
+      process.exit(1);
+    }
+
+    if (agent.agentName !== "Claude Code") {
+      console.error(`Turn copy is not supported for ${agent.agentName} yet.`);
+      process.exit(1);
+    }
+
+    if (!agent.sessionId) {
+      console.error("Active Claude session has no sessionId yet — try again in a moment.");
+      process.exit(1);
+    }
+
+    const config = await loadConfig(resolveConfigPath(opts));
+    const sessionFile = await resolveClaudeSessionFile(
+      agent.sessionId,
+      agent.cwd,
+      agent.startedAt,
+      config,
+    );
+    if (!sessionFile) {
+      console.error("Claude session file not found for this pane.");
+      process.exit(1);
+    }
+
+    const raw = await readFile(sessionFile, "utf-8");
+    const turns = parseClaudeConversationTurns(raw);
+    const turn = selectLatestTurn(turns, role);
+    if (!turn) {
+      console.error(`No recent ${role} turn found in this Claude session.`);
+      process.exit(1);
+    }
+
+    const text = turnTextForMode(turn, mode);
+    if (!text) {
+      console.error(`Latest ${role} turn has no ${mode === "bundle" ? "bundle" : "text"} content.`);
+      process.exit(1);
+    }
+
+    if (opts.stdout) {
+      console.log(text);
+      return;
+    }
+
+    try {
+      await writeClipboard(text);
+      const chars = text.length;
+      const label = role === "assistant" ? "AI" : "user";
+      console.log(`marmonitor: copied ${label} turn (${chars} chars)`);
+    } catch (err) {
+      if (err instanceof ClipboardError) {
+        console.error(err.message);
+      } else {
+        console.error(`Clipboard copy failed: ${(err as Error).message}. Try --stdout instead.`);
+      }
+      process.exit(1);
+    }
   });
 
 installProcessSafetyHandlers();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1667,7 +1667,7 @@ program
 program
   .command("copy-latest-turn")
   .description(
-    "Copy the most recent AI turn of the active tmux pane to the clipboard (Claude only)",
+    "Copy the most recent AI turn of the active tmux pane to the clipboard (Claude / Codex / Gemini)",
   )
   .option("--role <role>", "Which turn to copy: assistant (default) or user", "assistant")
   .option("--mode <mode>", "Extraction mode: text (default) or bundle", "text")
@@ -1678,9 +1678,13 @@ program
   .option("--stdout", "Print the turn to stdout instead of copying to clipboard")
   .option("--config <path>", "Path to settings.json")
   .action(async (opts) => {
-    const { parseClaudeConversationTurns, selectLatestTurn, turnTextForMode } = await import(
-      "./turns.js"
-    );
+    const {
+      parseClaudeConversationTurns,
+      parseCodexConversationTurns,
+      parseGeminiConversationTurns,
+      selectLatestTurn,
+      turnTextForMode,
+    } = await import("./turns.js");
 
     const role: "assistant" | "user" = opts.role === "user" ? "user" : "assistant";
     const mode: "text" | "bundle" = opts.mode === "bundle" ? "bundle" : "text";
@@ -1719,33 +1723,59 @@ program
       process.exit(1);
     }
 
-    if (agent.agentName !== "Claude Code") {
+    const config = await loadConfig(resolveConfigPath(opts));
+
+    // Resolve the agent-specific source file and parse to SessionTurn[].
+    let sessionFile: string | undefined;
+    let turns: ReturnType<typeof parseClaudeConversationTurns> = [];
+
+    if (agent.agentName === "Claude Code") {
+      if (!agent.sessionId) {
+        console.error("Active Claude session has no sessionId yet — try again in a moment.");
+        process.exit(1);
+      }
+      sessionFile = await resolveClaudeSessionFile(
+        agent.sessionId,
+        agent.cwd,
+        agent.startedAt,
+        config,
+      );
+      if (!sessionFile) {
+        console.error("Claude session file not found for this pane.");
+        process.exit(1);
+      }
+      const raw = await readFile(sessionFile, "utf-8");
+      turns = parseClaudeConversationTurns(raw);
+    } else if (agent.agentName === "Codex") {
+      // Codex sessions are indexed by cwd + processStartedAt; the rollout
+      // JSONL path comes from the indexer.
+      const codexSessions = await indexCodexSessions(config, { activeCwds: [agent.cwd] });
+      const matched = matchCodexSession(agent.cwd, agent.processStartedAt, codexSessions);
+      if (!matched?.filePath) {
+        console.error("Codex rollout file not found for this pane.");
+        process.exit(1);
+      }
+      sessionFile = matched.filePath;
+      const raw = await readFile(sessionFile, "utf-8");
+      turns = parseCodexConversationTurns(raw);
+    } else if (agent.agentName === "Gemini") {
+      // Gemini chats: parseGeminiSession returns the resolved sessionFile.
+      const gemini = await parseGeminiSession(agent.cwd);
+      if (!gemini.sessionFile) {
+        console.error("Gemini chat file not found for this pane.");
+        process.exit(1);
+      }
+      sessionFile = gemini.sessionFile;
+      const raw = await readFile(sessionFile, "utf-8");
+      turns = parseGeminiConversationTurns(raw);
+    } else {
       console.error(`Turn copy is not supported for ${agent.agentName} yet.`);
       process.exit(1);
     }
 
-    if (!agent.sessionId) {
-      console.error("Active Claude session has no sessionId yet — try again in a moment.");
-      process.exit(1);
-    }
-
-    const config = await loadConfig(resolveConfigPath(opts));
-    const sessionFile = await resolveClaudeSessionFile(
-      agent.sessionId,
-      agent.cwd,
-      agent.startedAt,
-      config,
-    );
-    if (!sessionFile) {
-      console.error("Claude session file not found for this pane.");
-      process.exit(1);
-    }
-
-    const raw = await readFile(sessionFile, "utf-8");
-    const turns = parseClaudeConversationTurns(raw);
     const turn = selectLatestTurn(turns, role);
     if (!turn) {
-      console.error(`No recent ${role} turn found in this Claude session.`);
+      console.error(`No recent ${role} turn found in this ${agent.agentName} session.`);
       process.exit(1);
     }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,11 +44,7 @@ import {
   selectUnmatchedTargets,
 } from "./output/utils.js";
 import { TERMINAL_RESTORE_SEQUENCE, formatProcessFailure } from "./process-safety.js";
-import {
-  detectClaudePhase,
-  matchClaudeSessionByMtime,
-  resolveClaudeSessionFile,
-} from "./scanner/claude.js";
+import { detectClaudePhase, resolveClaudeSessionFile } from "./scanner/claude.js";
 import { detectCodexPhase, indexCodexSessions, matchCodexSession } from "./scanner/codex.js";
 import { isDaemonRunning, readDaemonPid, readDaemonSnapshot } from "./scanner/daemon-utils.js";
 import { parseGeminiSession, resolveGeminiChatFile } from "./scanner/gemini.js";
@@ -1734,23 +1730,23 @@ program
     let turns: ReturnType<typeof parseClaudeConversationTurns> = [];
 
     if (agent.agentName === "Claude Code") {
-      // Daemon snapshot can lag heavy scan by up to 30s, so `agent.sessionId`
-      // may be stale when the user `/resume`s a different sessionId in the
-      // same PID. Re-resolve live against on-disk JSONL mtime for this pane's
-      // cwd/processStartedAt before falling back to the cached sessionId.
-      let liveSessionId: string | undefined;
-      try {
-        const live = await matchClaudeSessionByMtime(agent.cwd, agent.processStartedAt, config);
-        if (live?.sessionId) liveSessionId = live.sessionId;
-      } catch {
-        // fall through to snapshot sessionId
-      }
-      const sessionId = liveSessionId ?? agent.sessionId;
-      if (!sessionId) {
+      // Trust the daemon snapshot's per-PID sessionId. Earlier we tried a
+      // cwd-keyed live re-resolve here (F1, see #62 review), but that lost
+      // PID identity when two Claude sessions share the same cwd —
+      // `matchClaudeSessionByMtime` returned whichever jsonl scored best by
+      // cwd alone, so `prefix+y` in pane A could copy pane B's turn. The
+      // narrower `/resume` staleness concern that motivated F1 is tracked
+      // separately under #107 (daemon snapshot freshness).
+      if (!agent.sessionId) {
         console.error("Active Claude session has no sessionId yet — try again in a moment.");
         process.exit(1);
       }
-      sessionFile = await resolveClaudeSessionFile(sessionId, agent.cwd, agent.startedAt, config);
+      sessionFile = await resolveClaudeSessionFile(
+        agent.sessionId,
+        agent.cwd,
+        agent.startedAt,
+        config,
+      );
       if (!sessionFile) {
         console.error("Claude session file not found for this pane.");
         process.exit(1);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -47,7 +47,7 @@ import { TERMINAL_RESTORE_SEQUENCE, formatProcessFailure } from "./process-safet
 import { detectClaudePhase, resolveClaudeSessionFile } from "./scanner/claude.js";
 import { detectCodexPhase, indexCodexSessions, matchCodexSession } from "./scanner/codex.js";
 import { isDaemonRunning, readDaemonPid, readDaemonSnapshot } from "./scanner/daemon-utils.js";
-import { parseGeminiSession } from "./scanner/gemini.js";
+import { parseGeminiSession, resolveGeminiChatFile } from "./scanner/gemini.js";
 import { scanAgents } from "./scanner/index.js";
 import { loadRegistryFromFile } from "./scanner/session-registry.js";
 import { detectCliStdoutPhase } from "./scanner/status.js";
@@ -1747,10 +1747,27 @@ program
       const raw = await readFile(sessionFile, "utf-8");
       turns = parseClaudeConversationTurns(raw);
     } else if (agent.agentName === "Codex") {
-      // Codex sessions are indexed by cwd + processStartedAt; the rollout
-      // JSONL path comes from the indexer.
+      // Mirror scanner's session resolution priority: persistent binding
+      // registry (PID × processStartedAt → rollout) first, fallback to
+      // cwd + processStartedAt matching. Same-cwd multi-Codex environments
+      // would otherwise route to the wrong rollout file.
       const codexSessions = await indexCodexSessions(config, { activeCwds: [agent.cwd] });
-      const matched = matchCodexSession(agent.cwd, agent.processStartedAt, codexSessions);
+      const { loadCodexBindingRegistryFromFile, selectCodexBindingSession } = await import(
+        "./scanner/codex-binding-registry.js"
+      );
+      const bindingRegistry = new Map();
+      await loadCodexBindingRegistryFromFile(
+        join(getConfigDir(), "codex-binding-registry.json"),
+        bindingRegistry,
+      );
+      const matched =
+        selectCodexBindingSession(
+          bindingRegistry,
+          agent.pid,
+          agent.processStartedAt,
+          agent.cwd,
+          codexSessions,
+        ) ?? matchCodexSession(agent.cwd, agent.processStartedAt, codexSessions);
       if (!matched?.filePath) {
         console.error("Codex rollout file not found for this pane.");
         process.exit(1);
@@ -1759,13 +1776,18 @@ program
       const raw = await readFile(sessionFile, "utf-8");
       turns = parseCodexConversationTurns(raw);
     } else if (agent.agentName === "Gemini") {
-      // Gemini chats: parseGeminiSession returns the resolved sessionFile.
-      const gemini = await parseGeminiSession(agent.cwd);
-      if (!gemini.sessionFile) {
+      // Match the snapshot's sessionId against on-disk Gemini chats first so
+      // multi-session same-cwd environments don't fall back to "latest mtime
+      // wins". parseGeminiSession (latest mtime) remains as a graceful fallback.
+      sessionFile = await resolveGeminiChatFile(agent.cwd, agent.sessionId);
+      if (!sessionFile) {
+        const gemini = await parseGeminiSession(agent.cwd);
+        sessionFile = gemini.sessionFile;
+      }
+      if (!sessionFile) {
         console.error("Gemini chat file not found for this pane.");
         process.exit(1);
       }
-      sessionFile = gemini.sessionFile;
       const raw = await readFile(sessionFile, "utf-8");
       turns = parseGeminiConversationTurns(raw);
     } else {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,7 +44,11 @@ import {
   selectUnmatchedTargets,
 } from "./output/utils.js";
 import { TERMINAL_RESTORE_SEQUENCE, formatProcessFailure } from "./process-safety.js";
-import { detectClaudePhase, resolveClaudeSessionFile } from "./scanner/claude.js";
+import {
+  detectClaudePhase,
+  matchClaudeSessionByMtime,
+  resolveClaudeSessionFile,
+} from "./scanner/claude.js";
 import { detectCodexPhase, indexCodexSessions, matchCodexSession } from "./scanner/codex.js";
 import { isDaemonRunning, readDaemonPid, readDaemonSnapshot } from "./scanner/daemon-utils.js";
 import { parseGeminiSession, resolveGeminiChatFile } from "./scanner/gemini.js";
@@ -1730,16 +1734,23 @@ program
     let turns: ReturnType<typeof parseClaudeConversationTurns> = [];
 
     if (agent.agentName === "Claude Code") {
-      if (!agent.sessionId) {
+      // Daemon snapshot can lag heavy scan by up to 30s, so `agent.sessionId`
+      // may be stale when the user `/resume`s a different sessionId in the
+      // same PID. Re-resolve live against on-disk JSONL mtime for this pane's
+      // cwd/processStartedAt before falling back to the cached sessionId.
+      let liveSessionId: string | undefined;
+      try {
+        const live = await matchClaudeSessionByMtime(agent.cwd, agent.processStartedAt, config);
+        if (live?.sessionId) liveSessionId = live.sessionId;
+      } catch {
+        // fall through to snapshot sessionId
+      }
+      const sessionId = liveSessionId ?? agent.sessionId;
+      if (!sessionId) {
         console.error("Active Claude session has no sessionId yet — try again in a moment.");
         process.exit(1);
       }
-      sessionFile = await resolveClaudeSessionFile(
-        agent.sessionId,
-        agent.cwd,
-        agent.startedAt,
-        config,
-      );
+      sessionFile = await resolveClaudeSessionFile(sessionId, agent.cwd, agent.startedAt, config);
       if (!sessionFile) {
         console.error("Claude session file not found for this pane.");
         process.exit(1);

--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -1,0 +1,65 @@
+/**
+ * Cross-platform clipboard writer with fallback chain.
+ *
+ * macOS  : pbcopy
+ * Linux  : wl-copy → xclip → xsel  (in that order)
+ *
+ * Throws ClipboardError with a human-readable reason when all commands fail.
+ */
+
+import { spawn } from "node:child_process";
+
+interface ClipboardCommand {
+  command: string;
+  args: string[];
+}
+
+export class ClipboardError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ClipboardError";
+  }
+}
+
+function commandsForPlatform(): ClipboardCommand[] {
+  if (process.platform === "darwin") {
+    return [{ command: "pbcopy", args: [] }];
+  }
+  return [
+    { command: "wl-copy", args: [] },
+    { command: "xclip", args: ["-selection", "clipboard"] },
+    { command: "xsel", args: ["--clipboard", "--input"] },
+  ];
+}
+
+async function tryRun(command: string, args: string[], text: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const done = (ok: boolean) => {
+      if (settled) return;
+      settled = true;
+      resolve(ok);
+    };
+    try {
+      const child = spawn(command, args, { stdio: ["pipe", "ignore", "ignore"] });
+      child.on("error", () => done(false));
+      child.on("close", (code) => done(code === 0));
+      child.stdin.on("error", () => done(false));
+      child.stdin.end(text);
+    } catch {
+      done(false);
+    }
+  });
+}
+
+export async function writeClipboard(text: string): Promise<void> {
+  const candidates = commandsForPlatform();
+  const tried: string[] = [];
+  for (const { command, args } of candidates) {
+    tried.push(command);
+    if (await tryRun(command, args, text)) return;
+  }
+  throw new ClipboardError(
+    `Clipboard copy failed (tried: ${tried.join(", ")}). Try --stdout to print instead.`,
+  );
+}

--- a/src/scanner/gemini.ts
+++ b/src/scanner/gemini.ts
@@ -142,7 +142,30 @@ export async function resolveGeminiChatFile(
   }
   if (files.length === 0) return undefined;
 
-  // Tier 1: sessionId match — open each file, return on first hit.
+  // Tier 0: filename fast-path. Gemini chats are written as
+  //   session-<YYYY-MM-DDTHH-MM>-<sessionId first 8 chars>.json
+  // so checking the basename against the sessionId prefix avoids reading
+  // every file. Verified against ~/.gemini/tmp/*/chats/session-*.json.
+  if (sessionId && sessionId.length >= 8) {
+    const prefix = sessionId.slice(0, 8);
+    const namedHit = files.find((filePath) => filePath.includes(`-${prefix}.json`));
+    if (namedHit) {
+      // Confirm by reading the sessionId field — filenames could collide on a
+      // short prefix, and a false positive here would route to the wrong chat.
+      try {
+        const raw = await readFile(namedHit, "utf-8");
+        const data = JSON.parse(raw) as { sessionId?: unknown };
+        if (typeof data.sessionId === "string" && data.sessionId === sessionId) {
+          return namedHit;
+        }
+      } catch {
+        // fall through to the content-scan tier
+      }
+    }
+  }
+
+  // Tier 1: sessionId match — open each file, return on first hit. Reached
+  // only when the filename fast-path missed (e.g. format drift or collision).
   if (sessionId) {
     for (const filePath of files) {
       try {

--- a/src/scanner/gemini.ts
+++ b/src/scanner/gemini.ts
@@ -113,6 +113,67 @@ export async function resolveGeminiProjectDir(cwd: string): Promise<string | und
   return undefined;
 }
 
+/**
+ * Resolve a Gemini chats file by sessionId match first, then by latest mtime.
+ *
+ * Same-cwd multi-session safety: when `sessionId` is provided we scan each
+ * chats/*.json's `sessionId` field and return the matching path. Without a
+ * match we fall back to the most recently modified file (the legacy
+ * behaviour of parseGeminiSession). Returns undefined if no chats dir or
+ * no files exist.
+ */
+export async function resolveGeminiChatFile(
+  cwd: string,
+  sessionId?: string,
+): Promise<string | undefined> {
+  const projectDir = await resolveGeminiProjectDir(cwd);
+  if (!projectDir) return undefined;
+
+  const chatsDir = join(projectDir, "chats");
+  if (!existsSync(chatsDir)) return undefined;
+
+  let files: string[];
+  try {
+    files = (await readdir(chatsDir))
+      .filter((name) => name.startsWith("session-") && name.endsWith(".json"))
+      .map((name) => join(chatsDir, name));
+  } catch {
+    return undefined;
+  }
+  if (files.length === 0) return undefined;
+
+  // Tier 1: sessionId match — open each file, return on first hit.
+  if (sessionId) {
+    for (const filePath of files) {
+      try {
+        const raw = await readFile(filePath, "utf-8");
+        const data = JSON.parse(raw) as { sessionId?: unknown };
+        if (typeof data.sessionId === "string" && data.sessionId === sessionId) {
+          return filePath;
+        }
+      } catch {
+        // skip unreadable / malformed file
+      }
+    }
+  }
+
+  // Tier 2: fallback — latest mtime.
+  let latestFile: string | undefined;
+  let latestMtimeMs = -1;
+  for (const filePath of files) {
+    try {
+      const fileStat = await stat(filePath);
+      if (fileStat.mtimeMs > latestMtimeMs) {
+        latestMtimeMs = fileStat.mtimeMs;
+        latestFile = filePath;
+      }
+    } catch {
+      // skip
+    }
+  }
+  return latestFile;
+}
+
 export async function parseGeminiSession(
   cwd: string,
 ): Promise<Partial<AgentSession> & { sessionFile?: string }> {

--- a/src/tmux/index.ts
+++ b/src/tmux/index.ts
@@ -166,6 +166,36 @@ export async function getProcessTty(pid: number): Promise<string | undefined> {
   }
 }
 
+/** Batched variant of `getProcessTty` — one `lsof -p pid1,pid2,...` call
+ *  returns the controlling tty for every PID at once. Returns a Map keyed
+ *  by PID; PIDs with no tty (or lsof errors) are simply absent. lsof's `-F`
+ *  output is one field per line, with `p<pid>` markers preceding each
+ *  process's records, so we walk the lines with a running `currentPid` and
+ *  pair the next `n<path>` we see with it. */
+export async function getProcessTtys(pids: number[]): Promise<Map<number, string>> {
+  const result = new Map<number, string>();
+  if (pids.length === 0) return result;
+  try {
+    const { stdout } = await execFileAsync("lsof", ["-a", "-p", pids.join(","), "-d", "0", "-Fn"], {
+      timeout: 2000,
+    });
+    let currentPid: number | undefined;
+    for (const raw of stdout.split("\n")) {
+      const line = raw.trim();
+      if (line.startsWith("p")) {
+        const parsed = Number.parseInt(line.slice(1), 10);
+        currentPid = Number.isFinite(parsed) ? parsed : undefined;
+      } else if (currentPid !== undefined && line.startsWith("n/")) {
+        // Keep the first `n` field per pid (stdin's tty); ignore any extras.
+        if (!result.has(currentPid)) result.set(currentPid, line.slice(1));
+      }
+    }
+  } catch {
+    // partial output may still be useful if returned; otherwise empty map.
+  }
+  return result;
+}
+
 /** Find the agent PID that runs inside the currently active tmux pane.
  *
  *  Two-tier match:
@@ -192,12 +222,13 @@ export async function findActiveAgentPid(
     const treeMatch = agentPids.find((pid) => isPidInTree(activePanePid, pid, childMap));
     if (treeMatch !== undefined) return treeMatch;
 
-    // Tier 2: tty fallback
-    const paneTty = await getProcessTty(activePanePid);
+    // Tier 2: tty fallback — one batched lsof for the pane shell + all
+    // agent PIDs, instead of N+1 separate calls.
+    const ttys = await getProcessTtys([activePanePid, ...agentPids]);
+    const paneTty = ttys.get(activePanePid);
     if (!paneTty) return undefined;
     for (const agentPid of agentPids) {
-      const agentTty = await getProcessTty(agentPid);
-      if (agentTty && agentTty === paneTty) return agentPid;
+      if (ttys.get(agentPid) === paneTty) return agentPid;
     }
     return undefined;
   } catch {

--- a/src/tmux/index.ts
+++ b/src/tmux/index.ts
@@ -148,9 +148,36 @@ export async function getActiveTmuxPanePid(): Promise<number | undefined> {
   }
 }
 
+/** Get the controlling tty of a PID via lsof (`-d 0` reads stdin fd → tty).
+ *  Uses lsof instead of `ps -o tty=` because the latter returns EPERM on
+ *  macOS for processes the caller does not own in the same session. */
+export async function getProcessTty(pid: number): Promise<string | undefined> {
+  try {
+    const { stdout } = await execFileAsync("lsof", ["-a", "-p", String(pid), "-d", "0", "-Fn"], {
+      timeout: 2000,
+    });
+    const line = stdout
+      .split("\n")
+      .map((l) => l.trim())
+      .find((l) => l.startsWith("n/"));
+    return line ? line.slice(1) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /** Find the agent PID that runs inside the currently active tmux pane.
- *  When panePid is provided, skips the tmux query (useful when the caller
- *  already resolved the active pane PID for cache-key purposes). */
+ *
+ *  Two-tier match:
+ *    1. pid-tree — `panePid` is the pane's shell PID; walk its descendants
+ *       and find one matching `agentPids`. Works in most cases.
+ *    2. tty fallback — when the pid-tree walk misses (e.g. macOS denies
+ *       ps walks for some processes), compare the pane's controlling tty
+ *       with each agent process's controlling tty. The agent and the
+ *       pane's shell share a tty when they run in the same pane.
+ *
+ *  When `panePid` is provided, skips the tmux query (useful when the
+ *  caller already resolved the active pane PID for cache-key purposes). */
 export async function findActiveAgentPid(
   agentPids: number[],
   panePid?: number,
@@ -159,8 +186,20 @@ export async function findActiveAgentPid(
   try {
     const activePanePid = panePid ?? (await getActiveTmuxPanePid());
     if (!activePanePid) return undefined;
+
+    // Tier 1: pid-tree
     const childMap = await getProcessTree();
-    return agentPids.find((pid) => isPidInTree(activePanePid, pid, childMap));
+    const treeMatch = agentPids.find((pid) => isPidInTree(activePanePid, pid, childMap));
+    if (treeMatch !== undefined) return treeMatch;
+
+    // Tier 2: tty fallback
+    const paneTty = await getProcessTty(activePanePid);
+    if (!paneTty) return undefined;
+    for (const agentPid of agentPids) {
+      const agentTty = await getProcessTty(agentPid);
+      if (agentTty && agentTty === paneTty) return agentPid;
+    }
+    return undefined;
   } catch {
     return undefined;
   }

--- a/src/turns.ts
+++ b/src/turns.ts
@@ -1,0 +1,251 @@
+/**
+ * AI session turn parsing.
+ *
+ * Reads agent-local turn data (Claude jsonl for v1) and groups it into
+ * user / assistant turns. A single assistant turn bundles all `text` /
+ * `tool_use` / `tool_result` lines that follow a user prompt until the
+ * next user prompt or `stop_reason === "end_turn"`.
+ *
+ * Two extraction modes are exposed via `TurnTextMode`:
+ *   - "text" (default): assistant text blocks only. What the user saw
+ *     Claude "say" — ideal for sharing to Slack / issue / note.
+ *   - "bundle": text + tool_use input + tool_result content (thinking
+ *     excluded). Closer to the full Claude UI rendering — for handing
+ *     context to another AI or debug PRs.
+ */
+
+export type TurnRole = "user" | "assistant";
+export type TurnTextMode = "text" | "bundle";
+
+export interface SessionTurn {
+  role: TurnRole;
+  startedAt?: number; // epoch seconds
+  completedAt?: number; // epoch seconds
+  /** Assistant text-only extraction. user turns reuse this field. */
+  text: string;
+  /** Full bundle (text + tool_use + tool_result) — assistant turns only. */
+  bundle?: string;
+}
+
+function toEpochSec(timestamp: unknown): number | undefined {
+  if (typeof timestamp !== "string") return undefined;
+  const ms = new Date(timestamp).getTime();
+  return Number.isFinite(ms) ? ms / 1000 : undefined;
+}
+
+function formatToolInput(input: unknown): string {
+  if (typeof input === "string") return input.trim();
+  try {
+    return JSON.stringify(input, null, 2);
+  } catch {
+    return String(input);
+  }
+}
+
+function formatToolResult(item: Record<string, unknown>): string {
+  if (typeof item.content === "string") return item.content.trim();
+  if (Array.isArray(item.content)) {
+    return item.content
+      .map((child) => {
+        if (!child || typeof child !== "object") return String(child);
+        const c = child as Record<string, unknown>;
+        if (typeof c.text === "string") return c.text.trim();
+        return JSON.stringify(c);
+      })
+      .filter(Boolean)
+      .join("\n\n");
+  }
+  return "";
+}
+
+/** Extract assistant text-only parts from a Claude assistant message. */
+function extractAssistantText(content: unknown): string[] {
+  if (typeof content === "string") {
+    const t = content.trim();
+    return t ? [t] : [];
+  }
+  if (!Array.isArray(content)) return [];
+  return content
+    .filter(
+      (c): c is Record<string, unknown> =>
+        Boolean(c) && typeof c === "object" && (c as Record<string, unknown>).type === "text",
+    )
+    .map((c) => (typeof c.text === "string" ? c.text.trim() : ""))
+    .filter(Boolean);
+}
+
+/** Extract bundle parts (text + tool_use + tool_result) — thinking excluded. */
+function extractAssistantBundle(content: unknown): string[] {
+  if (typeof content === "string") {
+    const t = content.trim();
+    return t ? [t] : [];
+  }
+  if (!Array.isArray(content)) return [];
+  const parts: string[] = [];
+  for (const item of content) {
+    if (!item || typeof item !== "object") continue;
+    const block = item as Record<string, unknown>;
+    switch (block.type) {
+      case "text": {
+        const t = typeof block.text === "string" ? block.text.trim() : "";
+        if (t) parts.push(t);
+        break;
+      }
+      case "tool_use": {
+        const name = typeof block.name === "string" ? block.name : "unknown";
+        parts.push(`[tool_use:${name}]\n${formatToolInput(block.input)}`);
+        break;
+      }
+      case "tool_result": {
+        const body = formatToolResult(block);
+        if (body) parts.push(`[tool_result]\n${body}`);
+        break;
+      }
+      // "thinking" intentionally excluded
+    }
+  }
+  return parts;
+}
+
+/** Parse Claude user message — `tool_result`-only blocks are not real user prompts. */
+function parseClaudeUserMessage(
+  content: unknown,
+): { text: string; isToolResult: boolean } | undefined {
+  if (typeof content === "string") {
+    const t = content.trim();
+    return t ? { text: t, isToolResult: false } : undefined;
+  }
+  if (!Array.isArray(content)) return undefined;
+
+  const blockTypes = content
+    .map((c) => (c && typeof c === "object" ? (c as Record<string, unknown>).type : undefined))
+    .filter((t): t is string => typeof t === "string");
+  const onlyToolResult = blockTypes.length > 0 && blockTypes.every((t) => t === "tool_result");
+
+  // Only emit prompt text for genuine user prompts.
+  const textParts = content
+    .filter(
+      (c): c is Record<string, unknown> =>
+        Boolean(c) && typeof c === "object" && (c as Record<string, unknown>).type === "text",
+    )
+    .map((c) => (typeof c.text === "string" ? c.text.trim() : ""))
+    .filter(Boolean);
+
+  if (onlyToolResult) {
+    // bundle 모드에서 합쳐질 수 있도록 raw content를 살리되 prompt로는 안 셈
+    return { text: "", isToolResult: true };
+  }
+  return textParts.length > 0 ? { text: textParts.join("\n\n"), isToolResult: false } : undefined;
+}
+
+interface PendingAssistant {
+  texts: string[];
+  bundleParts: string[];
+  startedAt?: number;
+  completedAt?: number;
+}
+
+function flushAssistant(turns: SessionTurn[], pending: PendingAssistant): void {
+  const text = pending.texts.join("\n\n").trim();
+  const bundle = pending.bundleParts.join("\n\n").trim();
+  if (!text && !bundle) return;
+  turns.push({
+    role: "assistant",
+    startedAt: pending.startedAt,
+    completedAt: pending.completedAt ?? pending.startedAt,
+    text,
+    bundle: bundle || undefined,
+  });
+}
+
+function newPending(): PendingAssistant {
+  return { texts: [], bundleParts: [], startedAt: undefined, completedAt: undefined };
+}
+
+/**
+ * Parse a Claude session JSONL into ordered user/assistant turns.
+ * Lines without role information (file-history-snapshot, last-prompt, etc.)
+ * are ignored.
+ */
+export function parseClaudeConversationTurns(raw: string): SessionTurn[] {
+  const turns: SessionTurn[] = [];
+  let pending = newPending();
+
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let entry: Record<string, unknown>;
+    try {
+      entry = JSON.parse(trimmed) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+
+    const entryType = typeof entry.type === "string" ? entry.type : undefined;
+    if (entryType !== "user" && entryType !== "assistant") continue;
+
+    const message =
+      entry.message && typeof entry.message === "object"
+        ? (entry.message as Record<string, unknown>)
+        : undefined;
+    const ts = toEpochSec(entry.timestamp);
+
+    if (entryType === "user") {
+      const parsed = parseClaudeUserMessage(message?.content);
+      if (!parsed) continue;
+
+      if (parsed.isToolResult) {
+        // tool_result는 진행 중인 assistant turn에 묶음으로 합쳐짐
+        if (pending.bundleParts.length > 0 || pending.texts.length > 0) {
+          const body = formatToolResult(
+            // 다시 추출 — bundle 형태로
+            { content: (message?.content as unknown) ?? [] },
+          );
+          if (body) pending.bundleParts.push(`[tool_result]\n${body}`);
+          if (ts !== undefined) pending.completedAt = ts;
+        }
+        continue;
+      }
+
+      flushAssistant(turns, pending);
+      pending = newPending();
+      turns.push({ role: "user", startedAt: ts, completedAt: ts, text: parsed.text });
+      continue;
+    }
+
+    // assistant
+    const texts = extractAssistantText(message?.content);
+    const bundleParts = extractAssistantBundle(message?.content);
+    if (texts.length === 0 && bundleParts.length === 0) continue;
+
+    if (pending.startedAt === undefined) pending.startedAt = ts;
+    if (ts !== undefined) pending.completedAt = ts;
+    pending.texts.push(...texts);
+    pending.bundleParts.push(...bundleParts);
+
+    if (message?.stop_reason === "end_turn") {
+      flushAssistant(turns, pending);
+      pending = newPending();
+    }
+  }
+
+  flushAssistant(turns, pending);
+  return turns;
+}
+
+/** Pick the latest turn for a given role. */
+export function selectLatestTurn(
+  turns: SessionTurn[],
+  role: TurnRole = "assistant",
+): SessionTurn | undefined {
+  for (let i = turns.length - 1; i >= 0; i--) {
+    if (turns[i].role === role) return turns[i];
+  }
+  return undefined;
+}
+
+/** Extract the copyable text from a turn for the chosen mode. */
+export function turnTextForMode(turn: SessionTurn, mode: TurnTextMode = "text"): string {
+  if (mode === "bundle" && turn.bundle) return turn.bundle;
+  return turn.text;
+}

--- a/src/turns.ts
+++ b/src/turns.ts
@@ -435,7 +435,12 @@ export function parseGeminiConversationTurns(raw: string): SessionTurn[] {
       if (pending.startedAt === undefined) pending.startedAt = ts;
       if (ts !== undefined) pending.completedAt = ts;
       pending.texts.push(text);
-      pending.bundleParts.push(text);
+      // `bundleParts` intentionally untouched: Gemini chats JSON does not
+      // expose tool-call / tool-result as separately addressable blocks the
+      // way Claude/Codex jsonl does. Producing a "bundle" that's identical
+      // to `text` would be a dishonest no-op, so we leave `turn.bundle`
+      // undefined and let `turnTextForMode(turn, 'bundle')` fall back to
+      // `turn.text` (the documented degradation path).
     }
     // info / error / unknown — skip
   }

--- a/src/turns.ts
+++ b/src/turns.ts
@@ -233,6 +233,219 @@ export function parseClaudeConversationTurns(raw: string): SessionTurn[] {
   return turns;
 }
 
+/* ─── Codex rollout JSONL parser ─────────────────────────────────────── */
+
+function extractCodexMessageTexts(content: unknown): string[] {
+  if (typeof content === "string") {
+    const t = content.trim();
+    return t ? [t] : [];
+  }
+  if (!Array.isArray(content)) return [];
+  return content
+    .filter((c): c is Record<string, unknown> => Boolean(c) && typeof c === "object")
+    .map((c) => {
+      const t = (c as Record<string, unknown>).type;
+      // Both input_text (user/developer) and output_text (assistant) carry plain text.
+      if (t === "input_text" || t === "output_text") {
+        const text = (c as Record<string, unknown>).text;
+        return typeof text === "string" ? text.trim() : "";
+      }
+      return "";
+    })
+    .filter(Boolean);
+}
+
+function formatCodexFunctionCall(payload: Record<string, unknown>): string {
+  const name = typeof payload.name === "string" ? payload.name : "unknown";
+  const args = typeof payload.arguments === "string" ? payload.arguments : "";
+  // arguments is a stringified JSON — try to pretty-print.
+  let pretty = args;
+  try {
+    pretty = JSON.stringify(JSON.parse(args), null, 2);
+  } catch {
+    // keep as-is if not valid JSON
+  }
+  return `[function_call:${name}]\n${pretty}`.trim();
+}
+
+function formatCodexFunctionOutput(payload: Record<string, unknown>): string {
+  const output = typeof payload.output === "string" ? payload.output.trim() : "";
+  if (!output) return "";
+  return `[function_call_output]\n${output}`;
+}
+
+/**
+ * Parse a Codex rollout JSONL into ordered user/assistant turns.
+ *
+ * Rollout structure:
+ *   - `type: "session_meta"` / `"event_msg"` / `"turn_context"` — meta, ignored
+ *   - `type: "response_item"` payload:
+ *       - `type: "message"` + `role: "user"|"assistant"|"developer"`
+ *           — content is an array of `{type: "input_text"|"output_text", text}`.
+ *           `developer` is system-side, skipped.
+ *       - `type: "reasoning"` — Codex's thinking, excluded (matches option B).
+ *       - `type: "function_call"` — tool invocation (bundle-only).
+ *       - `type: "function_call_output"` — tool result (bundle-only).
+ *       - `type: "web_search_call"` — surfaced as a marker in bundle.
+ *
+ * Turn boundary: a new `user` message flushes the in-progress assistant.
+ */
+export function parseCodexConversationTurns(raw: string): SessionTurn[] {
+  const turns: SessionTurn[] = [];
+  let pending = newPending();
+
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let entry: Record<string, unknown>;
+    try {
+      entry = JSON.parse(trimmed) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+    if (entry.type !== "response_item") continue;
+
+    const payload =
+      entry.payload && typeof entry.payload === "object"
+        ? (entry.payload as Record<string, unknown>)
+        : undefined;
+    if (!payload) continue;
+
+    const ts = toEpochSec(entry.timestamp);
+    const ptype = typeof payload.type === "string" ? payload.type : "";
+
+    if (ptype === "message") {
+      const role = typeof payload.role === "string" ? payload.role : "";
+      // Developer messages are system-side scaffolding — skip.
+      if (role === "developer") continue;
+
+      const texts = extractCodexMessageTexts(payload.content);
+      if (texts.length === 0) continue;
+
+      if (role === "user") {
+        flushAssistant(turns, pending);
+        pending = newPending();
+        const text = texts.join("\n\n").trim();
+        if (text) turns.push({ role: "user", startedAt: ts, completedAt: ts, text });
+        continue;
+      }
+      if (role === "assistant") {
+        if (pending.startedAt === undefined) pending.startedAt = ts;
+        if (ts !== undefined) pending.completedAt = ts;
+        pending.texts.push(...texts);
+        pending.bundleParts.push(...texts);
+        continue;
+      }
+      continue;
+    }
+
+    if (ptype === "function_call") {
+      const piece = formatCodexFunctionCall(payload);
+      if (piece) pending.bundleParts.push(piece);
+      if (ts !== undefined) pending.completedAt = ts;
+      continue;
+    }
+
+    if (ptype === "function_call_output") {
+      const piece = formatCodexFunctionOutput(payload);
+      if (piece) pending.bundleParts.push(piece);
+      if (ts !== undefined) pending.completedAt = ts;
+      continue;
+    }
+
+    if (ptype === "web_search_call") {
+      pending.bundleParts.push("[web_search_call]");
+      if (ts !== undefined) pending.completedAt = ts;
+    }
+
+    // "reasoning" intentionally excluded (option B).
+  }
+
+  flushAssistant(turns, pending);
+  return turns;
+}
+
+/* ─── Gemini chats JSON parser ───────────────────────────────────────── */
+
+interface GeminiMessage {
+  type?: unknown;
+  content?: unknown;
+  timestamp?: unknown;
+  parts?: unknown;
+}
+
+function extractGeminiText(msg: GeminiMessage): string {
+  if (typeof msg.content === "string") return msg.content.trim();
+  // Some Gemini variants store rich content under `parts: [{ text } | { functionCall } ...]`.
+  if (Array.isArray(msg.parts)) {
+    return msg.parts
+      .map((p) => {
+        if (!p || typeof p !== "object") return "";
+        const obj = p as Record<string, unknown>;
+        if (typeof obj.text === "string") return obj.text.trim();
+        return "";
+      })
+      .filter(Boolean)
+      .join("\n\n");
+  }
+  return "";
+}
+
+/**
+ * Parse a Gemini chats JSON (`messages: [{type, content, timestamp, ...}]`)
+ * into ordered user/assistant turns.
+ *
+ * Recognised message types:
+ *   - `"user"`        — user prompt → user turn
+ *   - `"gemini"`      — assistant response → flushed as assistant turn
+ *   - everything else (`"info"`, `"error"`, etc.) — ignored as scaffolding
+ *
+ * NOTE: live verification is currently unavailable (the user does not run the
+ * Gemini CLI). Behaviour is covered by unit tests with fixture data and is
+ * expected to be conservative — unknown shapes degrade to no-turn rather than
+ * raising.
+ */
+export function parseGeminiConversationTurns(raw: string): SessionTurn[] {
+  let data: { messages?: unknown };
+  try {
+    data = JSON.parse(raw) as { messages?: unknown };
+  } catch {
+    return [];
+  }
+  if (!data || !Array.isArray(data.messages)) return [];
+
+  const turns: SessionTurn[] = [];
+  let pending = newPending();
+
+  for (const m of data.messages) {
+    if (!m || typeof m !== "object") continue;
+    const msg = m as GeminiMessage;
+    const ts = toEpochSec(msg.timestamp);
+    const type = typeof msg.type === "string" ? msg.type : "";
+    const text = extractGeminiText(msg);
+
+    if (type === "user") {
+      flushAssistant(turns, pending);
+      pending = newPending();
+      if (text) turns.push({ role: "user", startedAt: ts, completedAt: ts, text });
+      continue;
+    }
+    if (type === "gemini") {
+      if (!text) continue;
+      if (pending.startedAt === undefined) pending.startedAt = ts;
+      if (ts !== undefined) pending.completedAt = ts;
+      pending.texts.push(text);
+      pending.bundleParts.push(text);
+    }
+    // info / error / unknown — skip
+  }
+
+  flushAssistant(turns, pending);
+  return turns;
+}
+
+/* ────────────────────────────────────────────────────────────────────── */
+
 /** Pick the latest turn for a given role. */
 export function selectLatestTurn(
   turns: SessionTurn[],

--- a/src/turns.ts
+++ b/src/turns.ts
@@ -132,7 +132,7 @@ function parseClaudeUserMessage(
     .filter(Boolean);
 
   if (onlyToolResult) {
-    // bundle 모드에서 합쳐질 수 있도록 raw content를 살리되 prompt로는 안 셈
+    // Keep the raw content for bundle mode, but do not count it as a user prompt.
     return { text: "", isToolResult: true };
   }
   return textParts.length > 0 ? { text: textParts.join("\n\n"), isToolResult: false } : undefined;
@@ -195,10 +195,10 @@ export function parseClaudeConversationTurns(raw: string): SessionTurn[] {
       if (!parsed) continue;
 
       if (parsed.isToolResult) {
-        // tool_result는 진행 중인 assistant turn에 묶음으로 합쳐짐
+        // tool_result entries merge into the in-progress assistant turn.
         if (pending.bundleParts.length > 0 || pending.texts.length > 0) {
           const body = formatToolResult(
-            // 다시 추출 — bundle 형태로
+            // Re-extract the raw content into bundle form.
             { content: (message?.content as unknown) ?? [] },
           );
           if (body) pending.bundleParts.push(`[tool_result]\n${body}`);

--- a/tests/turns.test.mjs
+++ b/tests/turns.test.mjs
@@ -470,6 +470,24 @@ describe("parseGeminiConversationTurns", () => {
     assert.equal(turns[3].text, "별말씀을요.");
   });
 
+  it("does not populate bundle for assistant turns — Gemini bundle is a no-op (#62 F9)", () => {
+    // Gemini chats JSON has no separately-addressable tool_use / tool_result
+    // blocks like Claude/Codex, so a "bundle" mode would duplicate `text`.
+    // Leave turn.bundle undefined and let turnTextForMode fall back to text.
+    const raw = JSON.stringify({
+      messages: [
+        { type: "user", content: "q", timestamp: "2026-04-07T01:22:00.000Z" },
+        { type: "gemini", content: "a", timestamp: "2026-04-07T01:22:01.000Z" },
+      ],
+    });
+    const turns = parseGeminiConversationTurns(raw);
+    assert.equal(turns.length, 2);
+    assert.equal(turns[1].role, "assistant");
+    assert.equal(turns[1].text, "a");
+    assert.equal(turns[1].bundle, undefined);
+    assert.equal(turnTextForMode(turns[1], "bundle"), "a"); // falls back to text
+  });
+
   it("skips info/error/unknown message types", () => {
     const raw = JSON.stringify({
       messages: [

--- a/tests/turns.test.mjs
+++ b/tests/turns.test.mjs
@@ -1,9 +1,19 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { parseClaudeConversationTurns, selectLatestTurn, turnTextForMode } from "../dist/turns.js";
+import {
+  parseClaudeConversationTurns,
+  parseCodexConversationTurns,
+  parseGeminiConversationTurns,
+  selectLatestTurn,
+  turnTextForMode,
+} from "../dist/turns.js";
 
 function jsonl(...lines) {
   return lines.map((l) => JSON.stringify(l)).join("\n");
+}
+
+function codexLine(payload, ts = "2026-05-18T01:00:00.000Z") {
+  return JSON.stringify({ timestamp: ts, type: "response_item", payload });
 }
 
 describe("parseClaudeConversationTurns — user turn", () => {
@@ -305,5 +315,192 @@ describe("turnTextForMode", () => {
   it("falls back to text when bundle is missing", () => {
     const t = { role: "user", text: "u1" };
     assert.equal(turnTextForMode(t, "bundle"), "u1");
+  });
+});
+
+describe("parseCodexConversationTurns", () => {
+  it("groups user message + assistant message + tool cycle into a single assistant turn", () => {
+    const raw = [
+      codexLine({
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "find files" }],
+      }),
+      codexLine({
+        type: "reasoning",
+        summary: ["thinking..."],
+        content: null,
+      }),
+      codexLine({
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "파일을 찾아볼게요." }],
+      }),
+      codexLine({
+        type: "function_call",
+        name: "exec_command",
+        arguments: '{"cmd":"rg foo","workdir":"/tmp"}',
+        call_id: "call_1",
+      }),
+      codexLine({
+        type: "function_call_output",
+        call_id: "call_1",
+        output: "match1\nmatch2",
+      }),
+      codexLine({
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "두 개 찾았습니다." }],
+      }),
+    ].join("\n");
+
+    const turns = parseCodexConversationTurns(raw);
+    assert.equal(turns.length, 2);
+
+    assert.equal(turns[0].role, "user");
+    assert.equal(turns[0].text, "find files");
+
+    assert.equal(turns[1].role, "assistant");
+    // option B (text-only): reasoning + function_call + function_call_output 제외
+    assert.match(turns[1].text, /파일을 찾아볼게요/);
+    assert.match(turns[1].text, /두 개 찾았습니다/);
+    assert.doesNotMatch(turns[1].text, /function_call/);
+    assert.doesNotMatch(turns[1].text, /thinking/);
+
+    // bundle: text + function_call(arguments pretty) + function_call_output
+    const bundle = turns[1].bundle ?? "";
+    assert.match(bundle, /\[function_call:exec_command\]/);
+    assert.match(bundle, /"cmd": "rg foo"/);
+    assert.match(bundle, /\[function_call_output\]/);
+    assert.match(bundle, /match1/);
+    assert.doesNotMatch(bundle, /thinking/); // reasoning은 여전히 제외
+  });
+
+  it("separates later user messages from previous assistant turn", () => {
+    const raw = [
+      codexLine({ type: "message", role: "user", content: [{ type: "input_text", text: "q1" }] }),
+      codexLine({
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "a1" }],
+      }),
+      codexLine({ type: "message", role: "user", content: [{ type: "input_text", text: "q2" }] }),
+      codexLine({
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "a2" }],
+      }),
+    ].join("\n");
+
+    const turns = parseCodexConversationTurns(raw);
+    assert.equal(turns.length, 4);
+    assert.equal(turns[2].text, "q2");
+    assert.equal(turns[3].text, "a2");
+  });
+
+  it("skips developer messages and unknown response_item types gracefully", () => {
+    const raw = [
+      codexLine({
+        type: "message",
+        role: "developer",
+        content: [{ type: "input_text", text: "system instruction" }],
+      }),
+      codexLine({
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "hi" }],
+      }),
+      codexLine({
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "hello" }],
+      }),
+      codexLine({ type: "web_search_call", payload_extra: "..." }),
+      codexLine({ type: "unknown_future_type" }),
+    ].join("\n");
+
+    const turns = parseCodexConversationTurns(raw);
+    assert.equal(turns.length, 2);
+    assert.equal(turns[0].text, "hi");
+    assert.equal(turns[1].text, "hello");
+    assert.match(turns[1].bundle ?? "", /\[web_search_call\]/);
+  });
+
+  it("ignores non-response_item lines (session_meta, event_msg, turn_context)", () => {
+    const raw = [
+      JSON.stringify({ type: "session_meta", payload: { id: "s1" } }),
+      JSON.stringify({ type: "event_msg", payload: { kind: "..." } }),
+      JSON.stringify({ type: "turn_context", payload: { turn_id: "t1" } }),
+      codexLine({ type: "message", role: "user", content: [{ type: "input_text", text: "ok" }] }),
+      codexLine({
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "fine" }],
+      }),
+    ].join("\n");
+
+    const turns = parseCodexConversationTurns(raw);
+    assert.equal(turns.length, 2);
+  });
+
+  it("returns empty array on empty input or malformed JSON", () => {
+    assert.deepEqual(parseCodexConversationTurns(""), []);
+    assert.deepEqual(parseCodexConversationTurns("not json\n{ broken"), []);
+  });
+});
+
+describe("parseGeminiConversationTurns", () => {
+  it("groups type:user + type:gemini into ordered turns", () => {
+    const raw = JSON.stringify({
+      messages: [
+        { type: "info", content: "auth ok", timestamp: "2026-04-07T01:21:00.000Z" },
+        { type: "user", content: "안녕", timestamp: "2026-04-07T01:22:00.000Z" },
+        { type: "gemini", content: "반가워요!", timestamp: "2026-04-07T01:22:01.000Z" },
+        { type: "user", content: "고마워", timestamp: "2026-04-07T01:23:00.000Z" },
+        { type: "gemini", content: "별말씀을요.", timestamp: "2026-04-07T01:23:01.000Z" },
+      ],
+    });
+
+    const turns = parseGeminiConversationTurns(raw);
+    assert.equal(turns.length, 4);
+    assert.equal(turns[0].role, "user");
+    assert.equal(turns[0].text, "안녕");
+    assert.equal(turns[1].role, "assistant");
+    assert.equal(turns[1].text, "반가워요!");
+    assert.equal(turns[3].text, "별말씀을요.");
+  });
+
+  it("skips info/error/unknown message types", () => {
+    const raw = JSON.stringify({
+      messages: [
+        { type: "info", content: "..." },
+        { type: "error", content: "..." },
+        { type: "tool", content: "..." },
+        { type: "user", content: "hi" },
+        { type: "gemini", content: "hello" },
+      ],
+    });
+    const turns = parseGeminiConversationTurns(raw);
+    assert.equal(turns.length, 2);
+  });
+
+  it("falls back to parts[].text when content is missing", () => {
+    const raw = JSON.stringify({
+      messages: [
+        { type: "user", parts: [{ text: "from parts" }] },
+        { type: "gemini", parts: [{ text: "first part" }, { text: "second part" }] },
+      ],
+    });
+    const turns = parseGeminiConversationTurns(raw);
+    assert.equal(turns.length, 2);
+    assert.equal(turns[0].text, "from parts");
+    assert.equal(turns[1].text, "first part\n\nsecond part");
+  });
+
+  it("returns empty array on malformed JSON or missing messages", () => {
+    assert.deepEqual(parseGeminiConversationTurns(""), []);
+    assert.deepEqual(parseGeminiConversationTurns("not json"), []);
+    assert.deepEqual(parseGeminiConversationTurns("{}"), []);
+    assert.deepEqual(parseGeminiConversationTurns(JSON.stringify({ messages: null })), []);
   });
 });

--- a/tests/turns.test.mjs
+++ b/tests/turns.test.mjs
@@ -1,0 +1,309 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { parseClaudeConversationTurns, selectLatestTurn, turnTextForMode } from "../dist/turns.js";
+
+function jsonl(...lines) {
+  return lines.map((l) => JSON.stringify(l)).join("\n");
+}
+
+describe("parseClaudeConversationTurns — user turn", () => {
+  it("extracts a single user prompt with text content array", () => {
+    const raw = jsonl({
+      type: "user",
+      timestamp: "2026-05-17T01:00:00.000Z",
+      message: {
+        role: "user",
+        content: [{ type: "text", text: "hello claude" }],
+      },
+    });
+    const turns = parseClaudeConversationTurns(raw);
+    assert.equal(turns.length, 1);
+    assert.equal(turns[0].role, "user");
+    assert.equal(turns[0].text, "hello claude");
+  });
+
+  it("supports string content (legacy form)", () => {
+    const raw = jsonl({
+      type: "user",
+      timestamp: "2026-05-17T01:00:00.000Z",
+      message: { role: "user", content: "raw string prompt" },
+    });
+    const turns = parseClaudeConversationTurns(raw);
+    assert.equal(turns.length, 1);
+    assert.equal(turns[0].text, "raw string prompt");
+  });
+});
+
+describe("parseClaudeConversationTurns — assistant turn grouping", () => {
+  it("groups thinking + text + tool_use + tool_result + post-text into a single assistant turn", () => {
+    const raw = jsonl(
+      // user prompt
+      {
+        type: "user",
+        timestamp: "2026-05-17T01:00:00.000Z",
+        message: { role: "user", content: [{ type: "text", text: "list files" }] },
+      },
+      // assistant thinking (옵션 B에서는 빠짐)
+      {
+        type: "assistant",
+        timestamp: "2026-05-17T01:00:01.000Z",
+        message: {
+          role: "assistant",
+          stop_reason: "tool_use",
+          content: [{ type: "thinking", text: "내가 ls를 호출해야지" }],
+        },
+      },
+      // assistant text
+      {
+        type: "assistant",
+        timestamp: "2026-05-17T01:00:02.000Z",
+        message: {
+          role: "assistant",
+          stop_reason: "tool_use",
+          content: [{ type: "text", text: "파일 목록을 확인할게요." }],
+        },
+      },
+      // assistant tool_use
+      {
+        type: "assistant",
+        timestamp: "2026-05-17T01:00:03.000Z",
+        message: {
+          role: "assistant",
+          stop_reason: "tool_use",
+          content: [{ type: "tool_use", name: "Bash", input: { command: "ls -la" } }],
+        },
+      },
+      // user tool_result
+      {
+        type: "user",
+        timestamp: "2026-05-17T01:00:04.000Z",
+        message: { role: "user", content: [{ type: "tool_result", content: "file1\nfile2" }] },
+      },
+      // assistant final answer (end_turn)
+      {
+        type: "assistant",
+        timestamp: "2026-05-17T01:00:05.000Z",
+        message: {
+          role: "assistant",
+          stop_reason: "end_turn",
+          content: [{ type: "text", text: "두 파일이 있습니다." }],
+        },
+      },
+    );
+    const turns = parseClaudeConversationTurns(raw);
+    assert.equal(turns.length, 2, "한 user + 한 assistant turn으로 묶임");
+
+    assert.equal(turns[0].role, "user");
+    assert.equal(turns[0].text, "list files");
+
+    assert.equal(turns[1].role, "assistant");
+    // 옵션 B: text만 — thinking 빠지고 text 라인 두 개만
+    assert.match(turns[1].text, /파일 목록을 확인할게요/);
+    assert.match(turns[1].text, /두 파일이 있습니다/);
+    assert.doesNotMatch(turns[1].text, /tool_use/);
+    assert.doesNotMatch(turns[1].text, /tool_result/);
+    assert.doesNotMatch(turns[1].text, /ls를 호출/);
+
+    // 옵션 A: bundle — text + tool_use + tool_result
+    const bundle = turns[1].bundle ?? "";
+    assert.match(bundle, /\[tool_use:Bash\]/);
+    assert.match(bundle, /ls -la/);
+    assert.match(bundle, /\[tool_result\]/);
+    assert.match(bundle, /file1/);
+    assert.doesNotMatch(bundle, /ls를 호출/); // thinking 여전히 제외
+  });
+
+  it("separates later user prompts from previous assistant turn", () => {
+    const raw = jsonl(
+      {
+        type: "user",
+        timestamp: "2026-05-17T01:00:00.000Z",
+        message: { role: "user", content: [{ type: "text", text: "첫 요청" }] },
+      },
+      {
+        type: "assistant",
+        timestamp: "2026-05-17T01:00:01.000Z",
+        message: {
+          role: "assistant",
+          stop_reason: "end_turn",
+          content: [{ type: "text", text: "첫 답변" }],
+        },
+      },
+      {
+        type: "user",
+        timestamp: "2026-05-17T01:00:02.000Z",
+        message: { role: "user", content: [{ type: "text", text: "둘째 요청" }] },
+      },
+      {
+        type: "assistant",
+        timestamp: "2026-05-17T01:00:03.000Z",
+        message: {
+          role: "assistant",
+          stop_reason: "end_turn",
+          content: [{ type: "text", text: "둘째 답변" }],
+        },
+      },
+    );
+    const turns = parseClaudeConversationTurns(raw);
+    assert.equal(turns.length, 4);
+    assert.equal(turns[2].text, "둘째 요청");
+    assert.equal(turns[3].text, "둘째 답변");
+  });
+
+  it("flushes an in-progress assistant turn without end_turn at EOF", () => {
+    const raw = jsonl(
+      {
+        type: "user",
+        timestamp: "2026-05-17T01:00:00.000Z",
+        message: { role: "user", content: [{ type: "text", text: "ping" }] },
+      },
+      // stop_reason 없음, end_turn 안 옴 — flush at EOF
+      {
+        type: "assistant",
+        timestamp: "2026-05-17T01:00:01.000Z",
+        message: {
+          role: "assistant",
+          stop_reason: "tool_use",
+          content: [{ type: "text", text: "진행 중..." }],
+        },
+      },
+    );
+    const turns = parseClaudeConversationTurns(raw);
+    assert.equal(turns.length, 2);
+    assert.equal(turns[1].role, "assistant");
+    assert.equal(turns[1].text, "진행 중...");
+  });
+
+  it("joins multiple text lines with double newline", () => {
+    const raw = jsonl(
+      {
+        type: "user",
+        timestamp: "2026-05-17T01:00:00.000Z",
+        message: { role: "user", content: [{ type: "text", text: "q" }] },
+      },
+      {
+        type: "assistant",
+        timestamp: "2026-05-17T01:00:01.000Z",
+        message: {
+          role: "assistant",
+          stop_reason: "tool_use",
+          content: [{ type: "text", text: "첫 줄" }],
+        },
+      },
+      {
+        type: "assistant",
+        timestamp: "2026-05-17T01:00:02.000Z",
+        message: {
+          role: "assistant",
+          stop_reason: "end_turn",
+          content: [{ type: "text", text: "둘째 줄" }],
+        },
+      },
+    );
+    const turns = parseClaudeConversationTurns(raw);
+    assert.equal(turns[1].text, "첫 줄\n\n둘째 줄");
+  });
+});
+
+describe("parseClaudeConversationTurns — robustness", () => {
+  it("ignores meta types (system, file-history-snapshot, last-prompt, ...)", () => {
+    const raw = jsonl(
+      { type: "system", message: { content: "system info" } },
+      { type: "file-history-snapshot", snapshot: { timestamp: "2026-05-17T01:00:00.000Z" } },
+      { type: "last-prompt", content: "..." },
+      { type: "permission-mode", permissionMode: "default" },
+      {
+        type: "user",
+        timestamp: "2026-05-17T01:00:01.000Z",
+        message: { role: "user", content: [{ type: "text", text: "hi" }] },
+      },
+      {
+        type: "assistant",
+        timestamp: "2026-05-17T01:00:02.000Z",
+        message: {
+          role: "assistant",
+          stop_reason: "end_turn",
+          content: [{ type: "text", text: "hello" }],
+        },
+      },
+      { type: "ai-title", content: "..." },
+    );
+    const turns = parseClaudeConversationTurns(raw);
+    assert.equal(turns.length, 2);
+    assert.equal(turns[0].text, "hi");
+    assert.equal(turns[1].text, "hello");
+  });
+
+  it("skips malformed JSON lines", () => {
+    const raw = [
+      "not json",
+      JSON.stringify({
+        type: "user",
+        message: { role: "user", content: [{ type: "text", text: "ok" }] },
+      }),
+      "{ broken",
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          stop_reason: "end_turn",
+          content: [{ type: "text", text: "fine" }],
+        },
+      }),
+    ].join("\n");
+    const turns = parseClaudeConversationTurns(raw);
+    assert.equal(turns.length, 2);
+  });
+
+  it("returns empty array on empty input", () => {
+    assert.deepEqual(parseClaudeConversationTurns(""), []);
+    assert.deepEqual(parseClaudeConversationTurns("\n\n\n"), []);
+  });
+
+  it("returns empty array when there is no user/assistant content", () => {
+    const raw = jsonl({ type: "system" }, { type: "file-history-snapshot" });
+    assert.deepEqual(parseClaudeConversationTurns(raw), []);
+  });
+});
+
+describe("selectLatestTurn", () => {
+  const turns = [
+    { role: "user", text: "u1" },
+    { role: "assistant", text: "a1" },
+    { role: "user", text: "u2" },
+    { role: "assistant", text: "a2" },
+  ];
+
+  it("returns the latest assistant by default", () => {
+    assert.equal(selectLatestTurn(turns)?.text, "a2");
+  });
+
+  it("filters by role=user", () => {
+    assert.equal(selectLatestTurn(turns, "user")?.text, "u2");
+  });
+
+  it("returns undefined when no matching role exists", () => {
+    assert.equal(selectLatestTurn([{ role: "user", text: "only" }], "assistant"), undefined);
+  });
+});
+
+describe("turnTextForMode", () => {
+  const turn = {
+    role: "assistant",
+    text: "답변 텍스트",
+    bundle: "답변 텍스트\n\n[tool_use:Bash]\nls",
+  };
+
+  it("returns text-only by default", () => {
+    assert.equal(turnTextForMode(turn), "답변 텍스트");
+  });
+
+  it("returns bundle when mode='bundle'", () => {
+    assert.match(turnTextForMode(turn, "bundle"), /\[tool_use:Bash\]/);
+  });
+
+  it("falls back to text when bundle is missing", () => {
+    const t = { role: "user", text: "u1" };
+    assert.equal(turnTextForMode(t, "bundle"), "u1");
+  });
+});


### PR DESCRIPTION
## Summary

Resolve #62. Supersedes #61 (popup picker attempt; close on merge).

Add `marmonitor copy-latest-turn` so the active tmux pane's latest assistant
turn can be copied with a single keystroke. Supports Claude / Codex / Gemini
through agent-specific session-file parsers. The companion tmux binding ships
in `marmonitor-tmux#5`.

## Type

- [x] `[FEAT]` New feature

## Changes

- **`src/turns.ts` (new)** — Agent-specific turn parsers + selection utilities.
  - `parseClaudeConversationTurns`: jsonl → ordered user/assistant turns; assistant turn bundles thinking/text/tool_use/tool_result.
  - `parseCodexConversationTurns`: rollout JSONL `response_item` dispatch (message/reasoning/function_call/function_call_output/web_search_call).
  - `parseGeminiConversationTurns`: chats JSON `messages[]` with `type=user/gemini`. No tool_use/tool_result blocks exposed → `turn.bundle` is intentionally undefined; `turnTextForMode(turn, "bundle")` falls back to text.
  - `selectLatestTurn(turns, role)` + `turnTextForMode(turn, mode)`.
- **`src/cli.ts` `copy-latest-turn`** — agent dispatch:
  - Claude: `resolveClaudeSessionFile(agent.sessionId, agent.cwd, ...)` — trust the daemon snapshot's per-PID sessionId. An earlier F1 attempt to live-re-resolve via `matchClaudeSessionByMtime` lost PID identity when two Claude sessions shared the same cwd (review-found; reverted in `e87ea6e`).
  - Codex: `selectCodexBindingSession` (PID × processStartedAt binding registry) → fallback `matchCodexSession` (F4). Mirrors scanner priority.
  - Gemini: `resolveGeminiChatFile(cwd, sessionId)` (sessionId-aware) → fallback `parseGeminiSession` (F5).
  - Options: `--role assistant|user`, `--mode text|bundle`, `--pane-pid <pid>`, `--stdout`, `--config`. Distinct error messages for non-AI pane / `--pane-pid` miss / unsupported agent / sessionId not yet seen / 0 turns.
- **`src/clipboard.ts` (new)** — pbcopy / wl-copy / xclip / xsel fallback chain with `ClipboardError`. Surfaces "Try --stdout instead." on failure.
- **`src/tmux/index.ts`** — `findActiveAgentPid` extended with tty fallback (`getProcessTty` via `lsof -d 0 -Fn`) for macOS `ps -o tty=` EPERM cases.
- **`src/scanner/gemini.ts`** — new export `resolveGeminiChatFile(cwd, sessionId)`: tier 1 sessionId match across chats/*.json, tier 2 latest mtime.
- **`tests/turns.test.mjs` (new, 25 cases)** — Claude/Codex/Gemini parsing happy-paths + malformed/empty/role-filter/mode-fallback + F9 regression (`turn.bundle === undefined` for Gemini, bundle-mode falls back to text).

## Checklist

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (331/331, +25)
- [x] New features have tests
- [ ] README updated — companion `marmonitor-tmux#5` carries the user-facing tmux instruction
- [x] No hardcoded paths or environment-specific values

## Testing

- Unit: 25 cases covering Claude/Codex/Gemini parser + selection utility + clipboard error path + CLI option conflicts.
- Live (own machine):
  - Claude pane (`pane_pid=16200`) → text / user / bundle modes all extract correctly.
  - Codex pane (`pane_pid=54723`, `pid=96091`) → assistant turn text extracted; F4 binding-registry path verified.
  - Multi-Claude-same-cwd (`pid=20156` and `pid=82829` both in `vos-in-app-dashboard-backend`) — verified that `resolveClaudeSessionFile(snapshot.sessionId, cwd)` returns each PID's own jsonl, no cross-routing (regression check for the F1 revert).
  - Gemini — **not live-verified**: reviewer environment does not run Gemini CLI. Fixture-only via unit tests. Field issues will be tracked as follow-ups.

## Risk

Low–Medium.
- New CLI subcommand; existing surfaces (`status` / `attention` / `watch` / `statusline` / `activity` / `guard`) untouched.
- Claude path trusts the daemon snapshot's per-PID sessionId. F1 attempted a cwd-keyed live re-resolve to mitigate `/resume` staleness but lost PID identity when two Claude sessions shared a cwd — reverted. The `/resume` staleness window stays open as a snapshot-side concern (see Follow-up).
- F4/F5 align Codex/Gemini resolution with scanner's own priority, so same-cwd multi-session cases route the same way the rest of the tool already does.
- Gemini live behaviour is the largest unknown; F9 keeps `bundle` mode as an honest text fallback (no fake no-op blob).

## Follow-up (separate issues, not blocking)

- `#107` — daemon snapshot freshness for `/resume` staleness. The right fix is on the snapshot side (per-PID jsonl re-check), not the copy-latest-turn caller.
- `#64` — streaming JSONL parser for copy-latest-turn (memory). Split out from gemini-code-assist review items G1 / G5; out of scope for this PR.
- CLI dispatch + tmux script regression tests (F6 — daemon-snapshot fixture work).
- Gemini live verification once a Gemini CLI environment is available.

## Post-merge review processing

gemini-code-assist review (medium-priority):

- **G4** (`82b182b`) — translated three Korean comments in `src/turns.ts` to English per project convention.
- **G2** (`d49b7dc`) — `resolveGeminiChatFile` now uses a filename fast-path (`session-...-<sessionId first 8 chars>.json`) before falling back to full-content scan and latest-mtime tiers.
- **G3** (`3fdb1e7`) — `findActiveAgentPid` tty fallback now uses a single batched `lsof -p pid1,pid2,...` via new `getProcessTtys(pids[])` helper. Live measurement: batched 38ms vs per-pid 149ms for 4 Claude PIDs.
- **G1 / G5** — out of scope (streaming JSONL parser is a substantial refactor). Split to `#64`.

