### PR TITLE
[CICD] #65 Prepare v0.2.6 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to marmonitor are documented here.
 
+## [0.2.6] - 2026-05-25
+
+### Added
+- **One-keystroke turn copy** via `marmonitor copy-latest-turn`, with agent-specific turn parsing for Claude, Codex, and Gemini.
+- **Clipboard support** for latest-turn copy on macOS/Linux (`pbcopy`, `wl-copy`, `xclip`, `xsel` fallback chain).
+- **`alerts.tokens` toggle** so token/context alerts can be disabled independently from guard-driven security alerts.
+- **Gemini sessionId-aware chat resolution** for safer same-cwd turn-copy routing.
+
+### Fixed
+- Codex Desktop / VS Code Codex `app-server` backends are no longer misdetected as real Codex CLI sessions.
+- Token/context alerts no longer misfire on cumulative Codex `inputTokens` when `lastInputTokens` is unavailable.
+- Claude stale-session override is now more conservative when multiple sessions share the same cwd, preventing sibling misrouting.
+
 ## [0.2.5] - 2026-04-12
 
 ### Added

--- a/README.ko.md
+++ b/README.ko.md
@@ -204,6 +204,7 @@ marmonitor restart      # 데몬 재시작 (예: npm 업데이트 후)
 |--------|------|
 | `prefix + a` | 어텐션 팝업 — 검토할 세션 선택 |
 | `prefix + j` | 점프 팝업 — 이동할 세션 선택 |
+| `prefix + y` | 활성 패널의 최신 AI 답변 턴 복사 |
 | `prefix + m` | 독 — 컴팩트 모니터 패널 |
 | `Option+1~5` | 어텐션 세션 #1~5로 바로 이동 |
 | `Option+`` | 이전 패널로 돌아가기 |
@@ -214,6 +215,7 @@ marmonitor restart      # 데몬 재시작 (예: npm 업데이트 후)
 marmonitor status       # 전체 세션 목록
 marmonitor attention    # 입력이 필요한 세션 확인
 marmonitor activity     # 각 세션의 활동 내역 (도구 호출 + 토큰)
+marmonitor copy-latest-turn   # 활성 tmux 패널의 최신 AI/user 턴 복사
 marmonitor watch        # 실시간 전체 화면 모니터
 marmonitor jump-back    # 마지막 점프 이전 패널로 복귀
 marmonitor help         # 모든 명령어 및 옵션
@@ -257,7 +259,7 @@ marmonitor activity --json           # JSON 출력
 [marmonitor-tmux](https://github.com/mjjo16/marmonitor-tmux) 플러그인이 tmux 설정을 자동으로 처리합니다:
 
 - 에이전트 뱃지와 어텐션 필이 포함된 2번째 상태 라인
-- 팝업, 점프, 독 키 바인딩
+- 팝업, 점프, 최신 턴 복사, 독 키 바인딩
 - Option+1~5 다이렉트 점프
 
 `@marmonitor-*` 옵션으로 원하는 대로 바꿀 수 있습니다. 자세한 내용은 [플러그인 README](https://github.com/mjjo16/marmonitor-tmux)를 참조하세요.

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ The daemon must be running for all other commands to work. `marmonitor setup tmu
 |----------|--------|
 | `prefix + a` | Attention popup — choose a session to review |
 | `prefix + j` | Jump popup — pick a session to jump to |
+| `prefix + y` | Copy the latest AI assistant turn from the active pane |
 | `prefix + m` | Dock — compact monitor pane |
 | `Option+1~5` | Direct jump to attention session #1~5 |
 | `Option+`` | Jump back to previous pane |
@@ -216,6 +217,7 @@ The daemon must be running for all other commands to work. `marmonitor setup tmu
 marmonitor status       # Full session inventory
 marmonitor attention    # What needs your input?
 marmonitor activity     # What did each session do? (tool calls + tokens)
+marmonitor copy-latest-turn   # Copy the latest AI/user turn from the active tmux pane
 marmonitor watch        # Live full-screen monitor
 marmonitor jump-back    # Return to pane before last jump
 marmonitor help         # All commands and options
@@ -259,7 +261,7 @@ Activity is collected automatically by the daemon and stored in `~/.config/marmo
 The [marmonitor-tmux](https://github.com/mjjo16/marmonitor-tmux) plugin handles all tmux setup automatically:
 
 - 2nd status line with agent badges and attention pills
-- Key bindings for popup, jump, and dock
+- Key bindings for popup, jump, latest-turn copy, and dock
 - Option+1~5 direct jump
 
 All settings are customizable via `@marmonitor-*` options. See the [plugin README](https://github.com/mjjo16/marmonitor-tmux) for details.
@@ -287,11 +289,13 @@ Useful commands:
 marmonitor alerts
 marmonitor alerts on
 marmonitor alerts off
+marmonitor alerts tokens on
+marmonitor alerts tokens off
 marmonitor alerts notify on
 marmonitor alerts notify off
 ```
 
-Desktop notifications can be enabled separately from alert collection. After changing alert settings, restart the daemon to apply them:
+Desktop notifications can be enabled separately from alert collection, and token/context alerts can be silenced without turning off security alerts. After changing alert settings, restart the daemon to apply them:
 
 ```bash
 marmonitor restart

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "marmonitor",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "marmonitor",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "hasInstallScript": true,
       "license": "MIT",
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marmonitor",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "author": "MJ JO <mjjo16@gmail.com>",
   "description": "tmux status bar monitor for AI coding agents — track Claude Code, Codex, Gemini sessions, tokens, and phases in real time",
   "type": "module",

--- a/src/node-notifier.d.ts
+++ b/src/node-notifier.d.ts
@@ -1,0 +1,13 @@
+declare module "node-notifier" {
+  interface NotificationOptions {
+    title: string;
+    message: string;
+  }
+
+  interface Notifier {
+    notify(options: NotificationOptions): void;
+  }
+
+  const notifier: Notifier;
+  export default notifier;
+}


### PR DESCRIPTION
## Summary

Resolve #65

Prepare the `v0.2.6` release metadata on `dev`.

## Type

- [ ] `[FEAT]` New feature
- [ ] `[BUG]` Bug fix
- [ ] `[HOTFIX]` Urgent fix
- [ ] `[PERF]` Performance improvement
- [ ] `[REFACTOR]` Code restructuring
- [ ] `[DOCS]` Documentation
- [ ] `[TEST]` Test coverage
- [x] `[CICD]` CI/CD or release
- [ ] `[CHORE]` Maintenance

## Changes

- bump package version from `0.2.5` to `0.2.6`
- add the `v0.2.6` changelog entry
- document `copy-latest-turn`, `prefix+y`, and `alerts tokens on|off` in `README.md` / `README.ko.md`
- add a local `node-notifier` module declaration so `npm run build` passes consistently in this repo

## Checklist

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (all tests green)
- [x] New features have tests
- [x] README updated (if user-facing changes)
- [x] No hardcoded paths or environment-specific values

## Testing

- `npm run build`
- `npm run lint`
- `npm test` (`331/331`)

## Risk

Low. This PR only updates release metadata, release-facing docs, and a local type declaration needed to keep the current `dev` branch build green.
