### PR TITLE
[CICD] #65 Release v0.2.6 — turn copy, safer session detection, alert controls

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,108 +2,162 @@
 
 ## Overview
 
-marmonitor is a passive, local-first monitoring tool for AI coding agents. It detects running agents by scanning OS processes, enriches sessions with local data (tokens, phases, timestamps), and renders output to various terminal surfaces.
+marmonitor is a passive, local-first observer for AI coding agents. A long-running daemon scans OS processes, enriches detected agents with session data (tokens, phases, timestamps, git branch), and writes snapshots that all other surfaces (CLI output, tmux statusline, dock, attention popup) consume cheaply.
 
 ```
-Process List (OS)
-      │
-      ▼
-┌──────────┐     ┌──────────┐     ┌──────────┐
-│ Scanner  │────▶│  Output  │────▶│ Terminal │
-│          │     │          │     │ Surfaces │
-│ - detect │     │ - text   │     │ - stdout │
-│ - enrich │     │ - JSON   │     │ - tmux   │
-│ - phase  │     │ - pills  │     │ - wezterm│
-└──────────┘     └──────────┘     └──────────┘
-      │
-      ▼
-┌──────────┐     ┌──────────┐
-│  Guard   │     │  Config  │
-│          │     │          │
-│ - hooks  │     │ - XDG    │
-│ - rules  │     │ - merge  │
-└──────────┘     └──────────┘
+                              ┌──────────────────────────┐
+                              │  bin/daemon.js           │
+                              │   src/scanner/           │
+                              │   daemon-entry.ts        │
+                              │       │                  │
+ps-list ──┐                   │       ▼                  │
+pidusage ─┼─▶ scanAgents() ──▶│  daemon-loop             │
+JSONL/SQ ─┘                   │   light 2s   heavy 30s   │
+~/.claude/sessions            │       │                  │
+~/.codex/sessions/threads.db  │       ▼                  │
+~/.gemini/tmp/...             │   write snapshot/regs    │
+                              └──────────────────────────┘
+                                       │
+       ┌───────────────────────────────┼───────────────────────────────┐
+       ▼                               ▼                               ▼
+ /tmp/marmonitor/             ~/.config/marmonitor/             ~/.config/marmonitor/
+ daemon-snapshot.json         session-registry.json             activity-log/*.jsonl
+ alerts-snapshot.json         codex-binding-registry.json       alerts.log
+ statusline-*.txt cache
+       │
+       ▼
+ bin/marmonitor.js → src/cli.ts → readDaemonSnapshot → src/output/* → tmux/term
 ```
-
-## Module Responsibilities
-
-### `scanner.ts` — Process Detection & Enrichment
-
-The core module. It:
-
-1. **Detects** AI processes via `ps-list` (name match, then cmd fallback for Node scripts)
-2. **Enriches** with session data by reading agent-specific local files:
-   - Claude: `~/.claude/projects/*/sessions/*.jsonl` (tokens, phases, timestamps)
-   - Codex: session logs and stdout heuristics
-   - Gemini: process-level info only (no session files yet)
-3. **Determines status**: Active, Idle, Stalled, Dead, Unmatched
-4. **Detects phase**: thinking, tool, permission, done
-
-### `output.ts` — Rendering
-
-Formats `AgentSession[]` into various output forms:
-
-| Function | Used By |
-|----------|---------|
-| `printStatus()` | `marmonitor status` |
-| `printStatusJson()` | `marmonitor status --json` |
-| `printDock()` | `marmonitor dock` |
-| `printAttention()` | `marmonitor attention` |
-| `renderStatusline()` | `marmonitor --statusline` |
-
-### `utils.ts` — Pure Functions
-
-Stateless utilities for formatting, sorting, and building data structures:
-
-- `buildAttentionItems()` — Priority-sorted session list (permission > thinking > recent)
-- `buildStatuslineSummary()` — Compact status counts
-- `compactDirLabel()` — Path shortening for display
-- `formatElapsed()` — Human-readable time deltas
-
-### `config.ts` — Configuration
-
-Loads settings from XDG-compliant paths with deep merge:
-
-```
-Priority:
-  1. $XDG_CONFIG_HOME/marmonitor/settings.json
-  2. ~/.config/marmonitor/settings.json
-  3. ~/.marmonitor.json (legacy)
-  4. Built-in defaults
-```
-
-### `guard.ts` — Hook Evaluation
-
-Evaluates Claude Code hook payloads against intervention rules. Fail-open by design — any error returns `{"decision": "allow"}`.
-
-### `tmux.ts` — tmux Integration
-
-Discovers tmux panes, maps PIDs to pane targets, and executes `select-window`/`select-pane` for jump navigation.
-
-### `banner.ts` — Terminal Banner
-
-Renders the marmonitor banner with iTerm2 inline image protocol (pixel-perfect) or ANSI block art fallback.
 
 ## Data Flow
 
 ```
-1. CLI parses command (commander)
-2. Config loaded (XDG merge)
-3. Scanner runs:
-   a. ps-list → agent process list
-   b. For each process: read session files, parse tokens/phases
-   c. Determine status (Active/Idle/Stalled/Dead/Unmatched)
-4. Output renders the AgentSession[] array
-5. For statusline: result cached to /tmp/marmonitor/ with TTL
+1. CLI command parses (commander, src/cli.ts)
+2. For most read commands: readDaemonSnapshot() ─ ~ms.
+   For one-shot enrichment commands (debug-phase, clean): scanAgents() runs inline.
+3. src/output/* renders AgentSession[] → text / JSON / statusline / dock / attention.
+4. tmux statusline goes through a two-layer cache:
+   a) /tmp/marmonitor/statusline-<format>-<limit>-<width>.txt with TTL
+      (TTL = config.performance.statuslineTtlMs, default 2s).
+   b) For tmux-badges, the active panePid is stored in the cache header so that
+      cache hits invalidate when the focused pane changes.
+5. Inside the daemon loop:
+   - light scan: ps-list + pidusage + cached enrichment (hot/warm tier)
+   - heavy scan (every 30s): full JSONL/SQLite parse (covers cold tier and
+     promotes cold sessions when the JSONL mtime advances)
+   - guard / alerts hooks fire here (token thresholds, security trigger)
 ```
+
+## Module Responsibilities
+
+### `src/scanner/index.ts` — `scanAgents()`
+
+Entry point of the scan pipeline.
+
+1. `ps-list` → filter by per-agent `processNames` from config (Electron sub-processes and the VS Code Codex `app-server` are excluded).
+2. Batch `pidusage` for CPU/memory.
+3. For Codex, pre-resolve cwd and pre-index sessions once (SQLite `threads` + recent JSONL merge).
+4. Per process, run agent-specific enrichment (`claude.ts`, `codex.ts`, `gemini.ts`) — gated by **session tier** (`session-tier.ts`):
+   - `hot` (≤2 min activity, or live phase) — full enrich every scan.
+   - `warm` (≤10 min) — full enrich on heavy scan only.
+   - `cold` — cache reused, but JSONL mtime is checked and bumps the session back to hot when changed.
+5. `determineStatus` + `applyStatusHysteresis` (`status.ts`) decide Active/Idle/Stalled with a 30s grace window (longer for Codex).
+6. `groupByParent` (`group.ts`) merges child PIDs into the parent worker tree.
+
+### Per-agent enrichment
+
+| Module | Identity Resolver | File Binding | Phase Detection |
+|--|--|--|--|
+| `claude.ts` | `~/.claude/sessions/{pid}.json` → `sessionId` | `<encodedCwd>/<sessionId>.jsonl` direct, with `chooseStaleSessionOverride` to detect `/clear` | tail jsonl, message kinds + decay |
+| `codex.ts` + `codex-sqlite.ts` + `codex-binding-registry.ts` | `cwd + processStartedAt` against SQLite thread index | rollout JSONL via persistent binding registry (PID×start) | jsonl tail + `detectCliStdoutPhase` (tmux capture-pane heuristic) |
+| `gemini.ts` | `cwd` → `~/.gemini/tmp/<hash>/chats/session-*.json` | latest mtime | session JSON inspection + stdout heuristic |
+
+The Codex binding registry is what keeps long-lived sessions stable across `/clear`, restarts, and multiple sessions in the same `cwd`. Each record carries a confidence and `unstableCount`, and is marked `deadAt` when its PID disappears so that pruning is bounded (default 7 days).
+
+### `src/scanner/daemon-loop.ts`
+
+Long-running loop spawned by `bin/daemon.js`. Responsibilities:
+
+- Two-tier cadence (`intervalMs` light + `detailIntervalMs` heavy).
+- Snapshot file writes (`daemon-snapshot.json`, `alerts-snapshot.json`).
+- Session registry persistence (`session-registry.json`, 30-day prune).
+- Activity log: incremental JSONL cursor per session → `activity-log/YYYY-MM-DD.jsonl`, with daily cleanup.
+- Token-threshold alerts via `checkTokenAlert` (per `config.alerts`).
+- Memory monitor warns when RSS > 200 MB.
+- Graceful shutdown on SIGTERM/SIGINT: flush registries and remove pidfile.
+
+### `src/output/`
+
+Pure render layer over `AgentSession[]`. `index.ts` exposes:
+
+| Function | Used by |
+|--|--|
+| `printStatus`, `printStatusJson` | `marmonitor status` |
+| `printAttention`, `printAttentionJson` | `marmonitor attention` |
+| `printDock` | `marmonitor dock` |
+| `renderStatusline`, `renderUnavailableStatusline` | `marmonitor --statusline` |
+| `printJumpResult`, `printJumpJson`, `renderJumpAttentionChooser` | `attention --interactive` / `jump` |
+| `printCleanPlan`, `printCleanJson` | `marmonitor clean` |
+
+`utils.ts` is the side-effect-free home of `buildAttentionItems`, `buildStatuslineSummary`, phase decay helpers, path compaction, and tmux click-token builders. `badge-themes.ts` defines the six rendering styles (`basic` / `basic-mono` / `block` / `block-mono` / `text` / `text-mono`).
+
+### `src/config/index.ts`
+
+XDG-compliant loader with deep merge:
+
+```
+1. $XDG_CONFIG_HOME/marmonitor/settings.json
+2. ~/.config/marmonitor/settings.json
+3. ~/.marmonitor.json (legacy fallback)
+4. Built-in defaults
+```
+
+`resolveRuntimeDataPaths()` layers env-vars (`MARMONITOR_CLAUDE_HOME`, `MARMONITOR_CLAUDE_PROJECTS`, `MARMONITOR_CLAUDE_SESSIONS`, `MARMONITOR_CODEX_HOME`, `MARMONITOR_CODEX_SESSIONS`) over `paths.*` so users can monitor non-default install locations.
+
+### `src/guard/index.ts`
+
+Evaluates Claude Code hook payloads from stdin.
+
+- Triggers: `dangerous_command`, `prod_path_access`, `secret_access`, `out_of_cwd_write`. Detection is done with conservative regexes that require both option flags and a system path for `rm`, exact suffixes for credential files, etc., to keep false-positive noise low.
+- Outcome: `{ decision: "allow" | "block" }` derived from `intervention.rules` (or `intervention.defaultAction`).
+- **Fail-open by design** — any error returns `{"decision": "allow"}`. Today the CLI also fans out `dangerous_command` / `secret_access` events into the alerts pipeline (this fan-out is currently inlined in `cli.ts` and slated to move into the guard module).
+
+### `src/tmux/`
+
+- `index.ts` — list panes, build the PID tree from `ps -eo pid=,ppid=`, then match each agent to a pane via PID-tree first, then `cwd` fallback. `jumpToAgent` saves a jump-back anchor and runs `select-window` / `select-pane` (or `switch-client` when inside tmux).
+- `jump-anchor.ts` — per-TTY anchor file in `/tmp/marmonitor/jump-anchors.json`, used by `jump-back` and the `↩` indicator on `tmux-badges`.
+- `setup.ts` — manages the `marmonitor-tmux` block in `~/.tmux.conf`, with detection for local checkouts vs the TPM-managed plugin.
+- `status-click.ts` — parses tmux mouse status range tokens so clicking a numbered pill jumps to that session.
+
+### `src/alerts/`
+
+- `store.ts` — in-memory alerts with deterministic dedup (`type:agentPid:5min-bucket`) and per-type TTL.
+- `token.ts` — `checkTokenAlert(store, agent, thresholds)` triggers `context_warn` / `context_critical` against per-model context limits.
+- `log.ts`, `snapshot.ts`, `desktop.ts` — disk log appender, JSON snapshot writer, `node-notifier` desktop notification.
+
+The daemon is the primary producer; the guard pipeline is a secondary producer for `security` alerts.
+
+### `src/banner/`
+
+iTerm2 inline-image banner with ANSI block-art fallback. Emitted by `marmonitor banner` and during `--help`/install.
 
 ## Key Design Decisions
 
-- **No daemon**: Each invocation is a fresh scan. Caching via temp files with TTL.
-- **Fail-safe**: Every external call (ps, tmux, file reads) is wrapped in try-catch. Failures degrade silently.
-- **No network**: Zero outbound connections. All data is local.
-- **Agent-agnostic**: New agents can be added via config `processNames` + optional enrichment logic.
+- **Daemon-first.** As of 0.2.0, every read path consumes `daemon-snapshot.json` (≈1 ms). Without `marmonitor start`, most commands print `Daemon not running. Run: marmonitor start`. One-shot scans live only inside `debug-phase`, `clean`, and the daemon itself.
+- **Two-tier scanning.** Light scans keep statusline fresh on a 2-second budget; heavy scans pay the JSONL/SQLite cost. Cold sessions skip heavy work but watch JSONL mtimes so changes promote them back to hot.
+- **Persistent bindings.** Codex needs a stable PID-to-thread mapping that survives `/clear`, file-creation lag, and same-cwd parallelism. The binding registry on disk records confidence and prunes dead PIDs after 7 days.
+- **Fail-safe.** Every external call (`ps`, `lsof`, `tmux`, file IO) is wrapped in try/catch; cache writes silently swallow errors. The guard returns `allow` on any malformed input.
+- **No network.** Zero outbound connections; everything is parsed from local files and OS APIs.
+- **Agent-agnostic.** Adding a new agent means adding a `processNames` entry in config plus a `<agent>.ts` enrichment module. The current branching in `scanAgents()` is being tracked for adapter-style refactoring (see `.worklog/issues/post-review-roadmap.md`).
 
-## Adding Support for a New Agent
+## Extending
 
-See [CONTRIBUTING.md](CONTRIBUTING.md#adding-a-new-ai-agent) for the step-by-step guide.
+To add a new agent:
+
+1. Add an `agents.<name>` entry in `src/config/index.ts` defaults (or via `settings.json`).
+2. Implement `src/scanner/<agent>.ts` — at minimum a session resolver and a phase detector. Keep all IO behind try/catch.
+3. Wire it into `src/scanner/index.ts` `scanAgents()` enrichment branch.
+4. Extend `src/output/` labels/colors and add tests under `tests/<agent>.test.mjs`.
+5. Document the data layout in `~/.ai/projects/mjjo/works/work_mjjo_marmonitor/agent-data-spec.md`.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor guide.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to marmonitor are documented here.
 
+## [0.2.6] - 2026-05-25
+
+### Added
+- **One-keystroke turn copy** via `marmonitor copy-latest-turn`, with agent-specific turn parsing for Claude, Codex, and Gemini.
+- **Clipboard support** for latest-turn copy on macOS/Linux (`pbcopy`, `wl-copy`, `xclip`, `xsel` fallback chain).
+- **`alerts.tokens` toggle** so token/context alerts can be disabled independently from guard-driven security alerts.
+- **Gemini sessionId-aware chat resolution** for safer same-cwd turn-copy routing.
+
+### Fixed
+- Codex Desktop / VS Code Codex `app-server` backends are no longer misdetected as real Codex CLI sessions.
+- Token/context alerts no longer misfire on cumulative Codex `inputTokens` when `lastInputTokens` is unavailable.
+- Claude stale-session override is now more conservative when multiple sessions share the same cwd, preventing sibling misrouting.
+
 ## [0.2.5] - 2026-04-12
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,75 +4,181 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**marmonitor** - AI 에이전트 감시 & 모니터링 TUI 도구. 마멋이 굴 입구에서 경계 서듯이, 로컬에서 돌아가는 AI 에이전트(Claude Code, Codex, Gemini 등)를 감시한다.
+**marmonitor** — 로컬에서 돌아가는 AI 코딩 에이전트(Claude Code, Codex, Gemini)의 세션·토큰·phase·tmux 위치를 외부에서 관찰하는 도구. 마멋이 굴 입구에서 경계 서듯이 감시한다.
+
+- 배포: `marmonitor` (npm, macOS/Linux). 진입점은 `bin/marmonitor.js` (CLI), `bin/daemon.js` (백그라운드 데몬).
+- 패시브 옵저버: 외부 API/플러그인 없이 OS 프로세스와 에이전트별 로컬 세션 파일만 읽는다.
 
 ## Project Management (문서 연동)
 
-기획/검토/로드맵 등 프로젝트 관리 문서는 별도 경로에서 관리:
+기획·검토·로드맵·로컬 이슈는 별도 경로에서 관리:
 
 ```
 ~/.ai/projects/mjjo/works/work_mjjo_marmonitor/
-├── README.md              <- 문서 구조 가이드
-├── prd.md                 <- 제품 요구사항 정의서
-├── feasibility.md         <- 구현 가능성 검토 (기술 검증)
-├── agent-data-spec.md     <- 에이전트별 로컬 데이터 구조 분석
-├── roadmap.md             <- 구현 로드맵 (v0.1 ~ v1.0)
-└── ...
+├── README.md, prd.md, feasibility.md, agent-data-spec.md, roadmap.md, ...
+├── issues.md            <- 인덱스 (OPEN/IN_PROGRESS/DONE 테이블)
+└── issues/
+    ├── RULES.md         <- 이슈 작성/운영 규칙 (양식, 작성자 표기, 처리 이력)
+    ├── NNN-slug.md      <- 개별 이슈 파일 (시리얼 번호)
+    └── G001~G00N        <- GitHub 연동 그룹 이슈
 ```
 
-코드 변경 시 프로젝트 관리 문서 업데이트가 필요하면 위 경로 참조.
+리뷰 결과·작업 분담·후속 트랙은 위 `issues/`의 개별 파일로 분리. 본 레포의 `.worklog/`는 세션 로그(`activity.md`, `sessions/`)만 보관하고 이슈 파일은 두지 않는다.
 
-## Code Structure
+## High-level Architecture
+
+0.2.0부터 **데몬 + 스냅샷** 모델이다. CLI는 거의 모두 stateless reader.
+
+```
+bin/daemon.js  ──▶  src/scanner/daemon-entry.ts ─▶ runDaemonLoop()
+                       │
+                       │ light scan (default 2s)  : ps-list + pidusage + 캐시 enrich
+                       │ heavy scan (30s)         : Claude/Codex/Gemini jsonl·sqlite 풀 파싱
+                       │
+                       ├─ /tmp/marmonitor/daemon-snapshot.json   (statusline 소비자)
+                       ├─ /tmp/marmonitor/alerts-snapshot.json
+                       ├─ ~/.config/marmonitor/session-registry.json
+                       ├─ ~/.config/marmonitor/codex-binding-registry.json
+                       ├─ ~/.config/marmonitor/activity-log/YYYY-MM-DD.jsonl
+                       └─ ~/.config/marmonitor/alerts.log
+
+bin/marmonitor.js ─▶ src/cli.ts ─▶ readDaemonSnapshot() ─▶ src/output/* render
+```
+
+핵심 불변식:
+- **싱글 데이몬**: `start`는 ps-list로 중복 체크 후 fork. `stop`은 SIGTERM → 2s wait → SIGKILL.
+- **fail-safe**: `ps`/`lsof`/`tmux`/file IO 모든 외부 호출은 try/catch + 캐시 쓰기 실패 무시. guard는 fail-open(`{"decision":"allow"}`).
+- **statusline TTL 캐시**: `/tmp/marmonitor/statusline-<format>-<limit>-<width>.txt`. `tmux-badges`는 active panePid를 첫 줄에 박아 active 창이 바뀌면 즉시 invalidate.
+
+## Code Layout
 
 ```
 src/
-├── cli.ts             <- CLI 엔트리포인트 (commander)
-├── scanner.ts         <- AI 프로세스 탐지 + 세션 파싱
-├── output.ts          <- 출력 포매터 (text, json, statusline)
-└── types.ts           <- TypeScript 타입 정의
+├── cli.ts                  Commander 등록 + 모든 subcommand 액션 (1.6k LOC, 분리 예정)
+├── version.ts              릴리스 버전 상수
+├── process-safety.ts       uncaught/SIGINT 핸들러 헬퍼
+├── types.ts                AgentSession / TokenUsage / SessionStatus / SessionPhase
+│
+├── scanner/                ── 도메인 코어
+│   ├── index.ts            scanAgents() — 메인 파이프라인
+│   ├── daemon-entry.ts     데몬 main(): config 로드 → runDaemonLoop
+│   ├── daemon-loop.ts      light/heavy 두 단계 polling, snapshot/registry/activity 기록
+│   ├── daemon-utils.ts     read/writeDaemonSnapshot, pid 파일
+│   ├── process.ts          ps-list 결과 → agent 매칭, lsof로 cwd, ps -o lstart= 시작시간
+│   ├── claude.ts           ~/.claude/projects/<encodedCwd>/<sessionId>.jsonl 파싱
+│   ├── codex.ts            ~/.codex/sessions/* + SQLite 인덱스 머지
+│   ├── codex-binding-registry.ts  PID×processStartedAt → thread/rollout 영속 매핑(/clear 견딤)
+│   ├── codex-sqlite.ts     ~/.codex 의 SQLite threads 테이블 인덱싱
+│   ├── gemini.ts           ~/.gemini/tmp/<hash>/chats/session-*.json 최신 mtime 선택
+│   ├── status.ts           Active/Idle/Stalled hysteresis + stdout 휴리스틱
+│   ├── session-tier.ts     hot(≤2m)/warm(≤10m)/cold 분류 → 차등 enrichment
+│   ├── session-registry.ts sessionId 평생 이력 (PID 변경, 토큰 누적)
+│   ├── activity-log.ts     tool_use 추출, 일별 JSONL, 7일 retention
+│   ├── group.ts            부모/자식 PID 머지(워커 트리)
+│   ├── cache.ts            BoundedMap LRU 인스턴스 모음 + TTL 상수
+│   ├── bounded-map.ts      LRU Map
+│   ├── concurrency.ts      promiseAllLimited
+│   ├── perf.ts             MARMONITOR_PERF=1 일 때 perfStart/perfEnd
+│   └── types.ts            ScanOptions
+│
+├── output/                 ── 렌더러 (text/json/statusline/dock/attention/jump)
+│   ├── index.ts            printStatus / renderStatusline / printAttention / printDock 등
+│   ├── utils.ts            buildAttentionItems / buildStatuslineSummary / phase decay 등 순수 함수
+│   └── badge-themes.ts     basic / basic-mono / block / block-mono / text / text-mono
+│
+├── config/index.ts         XDG 우선 settings.json + MARMONITOR_* 환경변수 + 기본값 deep merge
+│
+├── guard/index.ts          Claude hook stdin → trigger 검출(dangerous_command/secret_access/...)
+│                           → intervention 룰 매칭 → allow/block 결정
+│
+├── tmux/                   ── tmux 통합
+│   ├── index.ts            list-panes, pid-tree → cwd 우선 매칭, switch-client/select-pane
+│   ├── jump-anchor.ts      jump-back 앵커 (TTY 단위)
+│   ├── setup.ts            ~/.tmux.conf 에 marmonitor-tmux 플러그인 추가/제거
+│   └── status-click.ts     tmux 상태바 mouse range token 파싱
+│
+├── alerts/                 ── 알림 시스템(0.2.5+)
+│   ├── store.ts            5분 dedup 버킷 in-memory 스토어
+│   ├── token.ts            컨텍스트 사용량 임계치 검사 (model별 한도)
+│   ├── log.ts / snapshot.ts / desktop.ts (node-notifier)
+│   └── types.ts            Alert / AlertSeverity / AlertType
+│
+└── banner/index.ts         iTerm2 inline image / ANSI block 폴백
+
 bin/
-└── marmonitor.js      <- CLI 바이너리 엔트리
+├── marmonitor.js           dist/cli.js dynamic import
+├── daemon.js               dist/scanner/daemon-entry.js dynamic import
+├── postinstall.cjs         실행 중 데몬 재시작 + update-integration --quiet
+└── preuninstall.cjs        잔여 정리
+
+tests/                      node --test 기반 *.test.mjs (25개+)
 ```
 
 ## Commands
 
 ```bash
-# 의존성 설치
+# 의존성
 npm install
 
-# 빌드
-npm run build
+# 빌드 / 워치
+npm run build            # tsc → dist/
+npm run dev              # tsc --watch
 
-# 실행
-marmonitor status              # one-shot 텍스트 출력
-marmonitor status --json       # JSON 출력
-marmonitor --statusline        # tmux 상태바용 한 줄 출력
-marmonitor                     # TUI 대시보드 (v0.3+)
+# 품질
+npm run lint             # biome check src tests
+npm test                 # node --test tests/*.test.mjs
+node --test tests/scanner.test.mjs    # 단일 테스트
 
-# 개발
-npm run dev                    # tsc --watch
-npm test                       # node --test
-npm run lint                   # eslint
+# 실행 (데몬이 먼저 떠 있어야 함)
+marmonitor start                       # 데몬 fork
+marmonitor stop / restart
+marmonitor status [--json]             # daemon snapshot 한방 출력
+marmonitor attention [--interactive|--pid|--attention-index]
+marmonitor activity [--pid|--session|--days|--lines|--order|--json]
+marmonitor watch / dock                # live 갱신
+marmonitor --statusline --statusline-format <compact|standard|extended|tmux-badges>
+marmonitor jump-back                   # 직전 pane 복귀
+marmonitor debug-phase --pid <pid>     # phase/세션/stdout/tmux/Codex binding 종합 진단
+marmonitor clean [--kill] [--pid ...]  # Unmatched 프로세스 SIGTERM
+marmonitor guard                       # stdin Claude hook 평가 (fail-open)
+marmonitor alerts [on|off|notify on|off]
+marmonitor settings-{path,show,init [--advanced]}
+marmonitor setup tmux | update-integration | uninstall-integration
 ```
 
-## Architecture
+## Environment & Paths
 
-- **scanner.ts**: ps-list + pidusage로 프로세스 스캔, 에이전트별 세션 데이터 파싱
-- **output.ts**: 스캐너 결과를 다양한 포맷으로 출력 (chalk 컬러, json, statusline)
-- **cli.ts**: commander 기반 CLI, 실행 모드 분기 (status, TUI, statusline)
+```
+~/.config/marmonitor/settings.json     XDG 우선 (legacy: ~/.marmonitor.json)
+~/.config/marmonitor/{session-registry,codex-binding-registry,alerts.log}
+~/.config/marmonitor/activity-log/YYYY-MM-DD.jsonl
+/tmp/marmonitor/{daemon.pid,daemon-snapshot.json,alerts-snapshot.json,statusline-*.txt,jump-anchors.json}
 
-에이전트 추가 시 `scanner.ts`의 `AGENT_SIGNATURES`에 탐지 규칙 추가, 필요 시 전용 파서 함수 작성.
+MARMONITOR_CLAUDE_HOME / MARMONITOR_CODEX_HOME    경로 루트 오버라이드
+MARMONITOR_CLAUDE_PROJECTS / _CLAUDE_SESSIONS / _CODEX_SESSIONS    PATH 형식 다중 경로
+MARMONITOR_PERF=1                                  scan 단계별 timing 출력
+```
 
-## Key Dependencies
+## Adding a New Agent
 
-- `ps-list`: 프로세스 목록 조회
-- `pidusage`: 프로세스별 CPU/메모리
-- `systeminformation`: 시스템 리소스 (CPU, MEM, 배터리, GPU)
-- `chalk`: 터미널 컬러 출력
-- `commander`: CLI 파서
+1. `src/config/index.ts` DEFAULTS.agents에 `processNames` 추가.
+2. `src/scanner/<agent>.ts`에 세션 파서·phase 검출 함수 작성.
+3. `src/scanner/index.ts` `scanAgents()`에서 agentName 분기 추가(현재 if/else 구조 — 어댑터화 예정).
+4. 필요 시 `src/types.ts`의 `RuntimeSource` union 확장, output 라벨/색상 추가.
+5. tests/scanner.test.mjs 또는 전용 *.test.mjs 추가.
 
 ## Conventions
 
-- TypeScript strict mode, ESM (type: module)
-- 한국어 문서, 영어 코드/커밋
-- 에이전트별 파서는 실패 시 graceful degradation (프로세스 스캔 폴백)
+- TypeScript strict mode, ESM only (`"type": "module"`).
+- Lint/format은 biome (`biome.json`). PR 전에 `npm run lint && npm test`.
+- 한국어 문서, 영어 코드/주석/커밋. 커밋 메시지는 `~` 라 끝맺는 명령형(예: "exclude vscode codex app-server").
+- 외부 호출은 모두 fail-safe로 감싼다. 캐시 쓰기 실패는 무시(스타일 일관).
+- 새 기능을 데몬 사이클에 끼울 땐 light vs heavy 분류를 먼저 결정한다(JSONL/SQLite read는 heavy).
+
+## Branching & Release
+
+자세한 흐름은 `~/.claude/projects/-Users-macrent-Documents-mjjo-marmonitor/memory/project_branch_strategy.md` 참조.
+
+- `feature/* → dev → main`. PR은 항상 `dev` 대상.
+- `main`에 push되면 npm 자동 배포(OIDC Trusted Publisher). 따라서 main 직접 push는 금지.
+- postinstall이 실행 중 데몬을 자동 재시작하므로 새 버전 배포 후 추가 작업 불필요.

--- a/README.ko.md
+++ b/README.ko.md
@@ -204,6 +204,7 @@ marmonitor restart      # 데몬 재시작 (예: npm 업데이트 후)
 |--------|------|
 | `prefix + a` | 어텐션 팝업 — 검토할 세션 선택 |
 | `prefix + j` | 점프 팝업 — 이동할 세션 선택 |
+| `prefix + y` | 활성 패널의 최신 AI 답변 턴 복사 |
 | `prefix + m` | 독 — 컴팩트 모니터 패널 |
 | `Option+1~5` | 어텐션 세션 #1~5로 바로 이동 |
 | `Option+`` | 이전 패널로 돌아가기 |
@@ -214,6 +215,7 @@ marmonitor restart      # 데몬 재시작 (예: npm 업데이트 후)
 marmonitor status       # 전체 세션 목록
 marmonitor attention    # 입력이 필요한 세션 확인
 marmonitor activity     # 각 세션의 활동 내역 (도구 호출 + 토큰)
+marmonitor copy-latest-turn   # 활성 tmux 패널의 최신 AI/user 턴 복사
 marmonitor watch        # 실시간 전체 화면 모니터
 marmonitor jump-back    # 마지막 점프 이전 패널로 복귀
 marmonitor help         # 모든 명령어 및 옵션
@@ -257,7 +259,7 @@ marmonitor activity --json           # JSON 출력
 [marmonitor-tmux](https://github.com/mjjo16/marmonitor-tmux) 플러그인이 tmux 설정을 자동으로 처리합니다:
 
 - 에이전트 뱃지와 어텐션 필이 포함된 2번째 상태 라인
-- 팝업, 점프, 독 키 바인딩
+- 팝업, 점프, 최신 턴 복사, 독 키 바인딩
 - Option+1~5 다이렉트 점프
 
 `@marmonitor-*` 옵션으로 원하는 대로 바꿀 수 있습니다. 자세한 내용은 [플러그인 README](https://github.com/mjjo16/marmonitor-tmux)를 참조하세요.

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ The daemon must be running for all other commands to work. `marmonitor setup tmu
 |----------|--------|
 | `prefix + a` | Attention popup — choose a session to review |
 | `prefix + j` | Jump popup — pick a session to jump to |
+| `prefix + y` | Copy the latest AI assistant turn from the active pane |
 | `prefix + m` | Dock — compact monitor pane |
 | `Option+1~5` | Direct jump to attention session #1~5 |
 | `Option+`` | Jump back to previous pane |
@@ -216,6 +217,7 @@ The daemon must be running for all other commands to work. `marmonitor setup tmu
 marmonitor status       # Full session inventory
 marmonitor attention    # What needs your input?
 marmonitor activity     # What did each session do? (tool calls + tokens)
+marmonitor copy-latest-turn   # Copy the latest AI/user turn from the active tmux pane
 marmonitor watch        # Live full-screen monitor
 marmonitor jump-back    # Return to pane before last jump
 marmonitor help         # All commands and options
@@ -259,7 +261,7 @@ Activity is collected automatically by the daemon and stored in `~/.config/marmo
 The [marmonitor-tmux](https://github.com/mjjo16/marmonitor-tmux) plugin handles all tmux setup automatically:
 
 - 2nd status line with agent badges and attention pills
-- Key bindings for popup, jump, and dock
+- Key bindings for popup, jump, latest-turn copy, and dock
 - Option+1~5 direct jump
 
 All settings are customizable via `@marmonitor-*` options. See the [plugin README](https://github.com/mjjo16/marmonitor-tmux) for details.
@@ -287,11 +289,13 @@ Useful commands:
 marmonitor alerts
 marmonitor alerts on
 marmonitor alerts off
+marmonitor alerts tokens on
+marmonitor alerts tokens off
 marmonitor alerts notify on
 marmonitor alerts notify off
 ```
 
-Desktop notifications can be enabled separately from alert collection. After changing alert settings, restart the daemon to apply them:
+Desktop notifications can be enabled separately from alert collection, and token/context alerts can be silenced without turning off security alerts. After changing alert settings, restart the daemon to apply them:
 
 ```bash
 marmonitor restart

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "marmonitor",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "marmonitor",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "hasInstallScript": true,
       "license": "MIT",
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marmonitor",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "author": "MJ JO <mjjo16@gmail.com>",
   "description": "tmux status bar monitor for AI coding agents — track Claude Code, Codex, Gemini sessions, tokens, and phases in real time",
   "type": "module",

--- a/src/alerts/token.ts
+++ b/src/alerts/token.ts
@@ -53,8 +53,13 @@ export function checkTokenAlert(
   if (!usage) return undefined;
 
   // lastInputTokens = most recent API call's input_tokens = actual current context size.
-  // Fall back to cumulative inputTokens only if lastInputTokens is unavailable.
-  const used = usage.lastInputTokens ?? usage.inputTokens;
+  // Only fire when this definitive signal is available. Falling back to the
+  // cumulative inputTokens (which grows unboundedly across a session) would
+  // massively overstate the context % for agents that do not populate
+  // lastInputTokens — most notably Codex. Tracked as GitHub #55 / local #102
+  // (root fix: split TokenUsage into cumulative vs context-window fields).
+  if (usage.lastInputTokens === undefined) return undefined;
+  const used = usage.lastInputTokens;
   const limit = contextLimit(agent.model);
   const ratio = used / limit;
 

--- a/src/alerts/token.ts
+++ b/src/alerts/token.ts
@@ -53,13 +53,15 @@ export function checkTokenAlert(
   if (!usage) return undefined;
 
   // lastInputTokens = most recent API call's input_tokens = actual current context size.
-  // Only fire when this definitive signal is available. Falling back to the
-  // cumulative inputTokens (which grows unboundedly across a session) would
-  // massively overstate the context % for agents that do not populate
-  // lastInputTokens — most notably Codex. Tracked as GitHub #55 / local #102
-  // (root fix: split TokenUsage into cumulative vs context-window fields).
-  if (usage.lastInputTokens === undefined) return undefined;
-  const used = usage.lastInputTokens;
+  // Only fire when this definitive signal is available as a finite number.
+  // `Number.isFinite` rejects undefined / null (e.g. from external JSON) / NaN /
+  // Infinity in one check. Falling back to the cumulative inputTokens (which
+  // grows unboundedly across a session) would massively overstate the context %
+  // for agents that do not populate lastInputTokens — most notably Codex.
+  // Tracked as GitHub #55 / local #102 (root fix: split TokenUsage into
+  // cumulative vs context-window fields).
+  if (!Number.isFinite(usage.lastInputTokens)) return undefined;
+  const used = usage.lastInputTokens as number;
   const limit = contextLimit(agent.model);
   const ratio = used / limit;
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path";
 import { createInterface } from "node:readline/promises";
 import { Command } from "commander";
 import { renderInstallBanner, renderRuntimeBanner } from "./banner/index.js";
+import { ClipboardError, writeClipboard } from "./clipboard.js";
 import {
   getConfigDir,
   getConfigSearchPaths,
@@ -43,7 +44,7 @@ import {
   selectUnmatchedTargets,
 } from "./output/utils.js";
 import { TERMINAL_RESTORE_SEQUENCE, formatProcessFailure } from "./process-safety.js";
-import { detectClaudePhase } from "./scanner/claude.js";
+import { detectClaudePhase, resolveClaudeSessionFile } from "./scanner/claude.js";
 import { detectCodexPhase, indexCodexSessions, matchCodexSession } from "./scanner/codex.js";
 import { isDaemonRunning, readDaemonPid, readDaemonSnapshot } from "./scanner/daemon-utils.js";
 import { parseGeminiSession } from "./scanner/gemini.js";
@@ -1659,6 +1660,119 @@ program
     await stopDaemon();
     await startDaemon();
     process.exit(0);
+  });
+
+// ── copy-latest-turn command ─────────────────────────────────────────────────
+
+program
+  .command("copy-latest-turn")
+  .description(
+    "Copy the most recent AI turn of the active tmux pane to the clipboard (Claude only)",
+  )
+  .option("--role <role>", "Which turn to copy: assistant (default) or user", "assistant")
+  .option("--mode <mode>", "Extraction mode: text (default) or bundle", "text")
+  .option(
+    "--pane-pid <pid>",
+    "Override active pane PID (default: tmux active pane). Useful for tmux key bindings that pass #{pane_pid}.",
+  )
+  .option("--stdout", "Print the turn to stdout instead of copying to clipboard")
+  .option("--config <path>", "Path to settings.json")
+  .action(async (opts) => {
+    const { parseClaudeConversationTurns, selectLatestTurn, turnTextForMode } = await import(
+      "./turns.js"
+    );
+
+    const role: "assistant" | "user" = opts.role === "user" ? "user" : "assistant";
+    const mode: "text" | "bundle" = opts.mode === "bundle" ? "bundle" : "text";
+
+    const agents = await requireDaemonSnapshot();
+
+    let agent: AgentSession | undefined;
+    let panePidOverridden = false;
+    if (typeof opts.panePid === "string") {
+      const panePid = Number.parseInt(opts.panePid, 10);
+      if (!Number.isFinite(panePid)) {
+        console.error(`Invalid --pane-pid value: ${opts.panePid}`);
+        process.exit(1);
+      }
+      panePidOverridden = true;
+      const agentPids = agents.map((a) => a.pid);
+      const matchedPid = await findActiveAgentPid(agentPids, panePid);
+      if (matchedPid !== undefined) {
+        agent = agents.find((a) => a.pid === matchedPid);
+      }
+    } else {
+      // Active tmux pane fallback
+      const agentPids = agents.map((a) => a.pid);
+      const matchedPid = await findActiveAgentPid(agentPids);
+      if (matchedPid !== undefined) {
+        agent = agents.find((a) => a.pid === matchedPid);
+      }
+    }
+
+    if (!agent) {
+      console.error(
+        panePidOverridden
+          ? `No AI session matched the given pane PID (${opts.panePid}).`
+          : "No AI session in this tmux pane. Switch to a Claude pane and try again.",
+      );
+      process.exit(1);
+    }
+
+    if (agent.agentName !== "Claude Code") {
+      console.error(`Turn copy is not supported for ${agent.agentName} yet.`);
+      process.exit(1);
+    }
+
+    if (!agent.sessionId) {
+      console.error("Active Claude session has no sessionId yet — try again in a moment.");
+      process.exit(1);
+    }
+
+    const config = await loadConfig(resolveConfigPath(opts));
+    const sessionFile = await resolveClaudeSessionFile(
+      agent.sessionId,
+      agent.cwd,
+      agent.startedAt,
+      config,
+    );
+    if (!sessionFile) {
+      console.error("Claude session file not found for this pane.");
+      process.exit(1);
+    }
+
+    const raw = await readFile(sessionFile, "utf-8");
+    const turns = parseClaudeConversationTurns(raw);
+    const turn = selectLatestTurn(turns, role);
+    if (!turn) {
+      console.error(`No recent ${role} turn found in this Claude session.`);
+      process.exit(1);
+    }
+
+    const text = turnTextForMode(turn, mode);
+    if (!text) {
+      console.error(`Latest ${role} turn has no ${mode === "bundle" ? "bundle" : "text"} content.`);
+      process.exit(1);
+    }
+
+    if (opts.stdout) {
+      console.log(text);
+      return;
+    }
+
+    try {
+      await writeClipboard(text);
+      const chars = text.length;
+      const label = role === "assistant" ? "AI" : "user";
+      console.log(`marmonitor: copied ${label} turn (${chars} chars)`);
+    } catch (err) {
+      if (err instanceof ClipboardError) {
+        console.error(err.message);
+      } else {
+        console.error(`Clipboard copy failed: ${(err as Error).message}. Try --stdout instead.`);
+      }
+      process.exit(1);
+    }
   });
 
 installProcessSafetyHandlers();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -907,7 +907,7 @@ program
 
 async function patchAlertsConfig(
   configPath: string,
-  patch: Partial<{ enabled: boolean; desktop: boolean; log: boolean }>,
+  patch: Partial<{ enabled: boolean; desktop: boolean; log: boolean; tokens: boolean }>,
 ): Promise<void> {
   await mkdir(dirname(configPath), { recursive: true });
   let current: Record<string, unknown> = {};
@@ -936,6 +936,7 @@ const alertsCmd = program
     console.log(`alerts.enabled  : ${a.enabled}`);
     console.log(`alerts.desktop  : ${a.desktop}`);
     console.log(`alerts.log      : ${a.log}`);
+    console.log(`alerts.tokens   : ${a.tokens} (token/context threshold alerts)`);
     console.log(
       `alerts.contextCritThreshold: ${a.contextCritThreshold} (${Math.round(a.contextCritThreshold * 100)}%)`,
     );
@@ -977,6 +978,22 @@ alertsCmd
     await patchAlertsConfig(p, { desktop: toggle === "on" });
     console.log(
       `Desktop notifications ${toggle === "on" ? "enabled" : "disabled"}. Restart daemon to apply: marmonitor restart`,
+    );
+  });
+
+alertsCmd
+  .command("tokens <on|off>")
+  .description("Toggle token/context threshold alerts (security alerts unaffected)")
+  .option("--config <path>", "Path to settings.json")
+  .action(async (toggle, opts) => {
+    if (toggle !== "on" && toggle !== "off") {
+      console.error("Usage: marmonitor alerts tokens on|off");
+      process.exit(1);
+    }
+    const p = resolveConfigPath(opts) ?? getDefaultConfigPath();
+    await patchAlertsConfig(p, { tokens: toggle === "on" });
+    console.log(
+      `Token/context alerts ${toggle === "on" ? "enabled" : "disabled"}. Restart daemon to apply: marmonitor restart`,
     );
   });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1667,7 +1667,7 @@ program
 program
   .command("copy-latest-turn")
   .description(
-    "Copy the most recent AI turn of the active tmux pane to the clipboard (Claude only)",
+    "Copy the most recent AI turn of the active tmux pane to the clipboard (Claude / Codex / Gemini)",
   )
   .option("--role <role>", "Which turn to copy: assistant (default) or user", "assistant")
   .option("--mode <mode>", "Extraction mode: text (default) or bundle", "text")
@@ -1678,9 +1678,13 @@ program
   .option("--stdout", "Print the turn to stdout instead of copying to clipboard")
   .option("--config <path>", "Path to settings.json")
   .action(async (opts) => {
-    const { parseClaudeConversationTurns, selectLatestTurn, turnTextForMode } = await import(
-      "./turns.js"
-    );
+    const {
+      parseClaudeConversationTurns,
+      parseCodexConversationTurns,
+      parseGeminiConversationTurns,
+      selectLatestTurn,
+      turnTextForMode,
+    } = await import("./turns.js");
 
     const role: "assistant" | "user" = opts.role === "user" ? "user" : "assistant";
     const mode: "text" | "bundle" = opts.mode === "bundle" ? "bundle" : "text";
@@ -1719,33 +1723,59 @@ program
       process.exit(1);
     }
 
-    if (agent.agentName !== "Claude Code") {
+    const config = await loadConfig(resolveConfigPath(opts));
+
+    // Resolve the agent-specific source file and parse to SessionTurn[].
+    let sessionFile: string | undefined;
+    let turns: ReturnType<typeof parseClaudeConversationTurns> = [];
+
+    if (agent.agentName === "Claude Code") {
+      if (!agent.sessionId) {
+        console.error("Active Claude session has no sessionId yet — try again in a moment.");
+        process.exit(1);
+      }
+      sessionFile = await resolveClaudeSessionFile(
+        agent.sessionId,
+        agent.cwd,
+        agent.startedAt,
+        config,
+      );
+      if (!sessionFile) {
+        console.error("Claude session file not found for this pane.");
+        process.exit(1);
+      }
+      const raw = await readFile(sessionFile, "utf-8");
+      turns = parseClaudeConversationTurns(raw);
+    } else if (agent.agentName === "Codex") {
+      // Codex sessions are indexed by cwd + processStartedAt; the rollout
+      // JSONL path comes from the indexer.
+      const codexSessions = await indexCodexSessions(config, { activeCwds: [agent.cwd] });
+      const matched = matchCodexSession(agent.cwd, agent.processStartedAt, codexSessions);
+      if (!matched?.filePath) {
+        console.error("Codex rollout file not found for this pane.");
+        process.exit(1);
+      }
+      sessionFile = matched.filePath;
+      const raw = await readFile(sessionFile, "utf-8");
+      turns = parseCodexConversationTurns(raw);
+    } else if (agent.agentName === "Gemini") {
+      // Gemini chats: parseGeminiSession returns the resolved sessionFile.
+      const gemini = await parseGeminiSession(agent.cwd);
+      if (!gemini.sessionFile) {
+        console.error("Gemini chat file not found for this pane.");
+        process.exit(1);
+      }
+      sessionFile = gemini.sessionFile;
+      const raw = await readFile(sessionFile, "utf-8");
+      turns = parseGeminiConversationTurns(raw);
+    } else {
       console.error(`Turn copy is not supported for ${agent.agentName} yet.`);
       process.exit(1);
     }
 
-    if (!agent.sessionId) {
-      console.error("Active Claude session has no sessionId yet — try again in a moment.");
-      process.exit(1);
-    }
-
-    const config = await loadConfig(resolveConfigPath(opts));
-    const sessionFile = await resolveClaudeSessionFile(
-      agent.sessionId,
-      agent.cwd,
-      agent.startedAt,
-      config,
-    );
-    if (!sessionFile) {
-      console.error("Claude session file not found for this pane.");
-      process.exit(1);
-    }
-
-    const raw = await readFile(sessionFile, "utf-8");
-    const turns = parseClaudeConversationTurns(raw);
     const turn = selectLatestTurn(turns, role);
     if (!turn) {
-      console.error(`No recent ${role} turn found in this Claude session.`);
+      console.error(`No recent ${role} turn found in this ${agent.agentName} session.`);
       process.exit(1);
     }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,11 +44,7 @@ import {
   selectUnmatchedTargets,
 } from "./output/utils.js";
 import { TERMINAL_RESTORE_SEQUENCE, formatProcessFailure } from "./process-safety.js";
-import {
-  detectClaudePhase,
-  matchClaudeSessionByMtime,
-  resolveClaudeSessionFile,
-} from "./scanner/claude.js";
+import { detectClaudePhase, resolveClaudeSessionFile } from "./scanner/claude.js";
 import { detectCodexPhase, indexCodexSessions, matchCodexSession } from "./scanner/codex.js";
 import { isDaemonRunning, readDaemonPid, readDaemonSnapshot } from "./scanner/daemon-utils.js";
 import { parseGeminiSession, resolveGeminiChatFile } from "./scanner/gemini.js";
@@ -1734,23 +1730,23 @@ program
     let turns: ReturnType<typeof parseClaudeConversationTurns> = [];
 
     if (agent.agentName === "Claude Code") {
-      // Daemon snapshot can lag heavy scan by up to 30s, so `agent.sessionId`
-      // may be stale when the user `/resume`s a different sessionId in the
-      // same PID. Re-resolve live against on-disk JSONL mtime for this pane's
-      // cwd/processStartedAt before falling back to the cached sessionId.
-      let liveSessionId: string | undefined;
-      try {
-        const live = await matchClaudeSessionByMtime(agent.cwd, agent.processStartedAt, config);
-        if (live?.sessionId) liveSessionId = live.sessionId;
-      } catch {
-        // fall through to snapshot sessionId
-      }
-      const sessionId = liveSessionId ?? agent.sessionId;
-      if (!sessionId) {
+      // Trust the daemon snapshot's per-PID sessionId. Earlier we tried a
+      // cwd-keyed live re-resolve here (F1, see #62 review), but that lost
+      // PID identity when two Claude sessions share the same cwd —
+      // `matchClaudeSessionByMtime` returned whichever jsonl scored best by
+      // cwd alone, so `prefix+y` in pane A could copy pane B's turn. The
+      // narrower `/resume` staleness concern that motivated F1 is tracked
+      // separately under #107 (daemon snapshot freshness).
+      if (!agent.sessionId) {
         console.error("Active Claude session has no sessionId yet — try again in a moment.");
         process.exit(1);
       }
-      sessionFile = await resolveClaudeSessionFile(sessionId, agent.cwd, agent.startedAt, config);
+      sessionFile = await resolveClaudeSessionFile(
+        agent.sessionId,
+        agent.cwd,
+        agent.startedAt,
+        config,
+      );
       if (!sessionFile) {
         console.error("Claude session file not found for this pane.");
         process.exit(1);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -47,7 +47,7 @@ import { TERMINAL_RESTORE_SEQUENCE, formatProcessFailure } from "./process-safet
 import { detectClaudePhase, resolveClaudeSessionFile } from "./scanner/claude.js";
 import { detectCodexPhase, indexCodexSessions, matchCodexSession } from "./scanner/codex.js";
 import { isDaemonRunning, readDaemonPid, readDaemonSnapshot } from "./scanner/daemon-utils.js";
-import { parseGeminiSession } from "./scanner/gemini.js";
+import { parseGeminiSession, resolveGeminiChatFile } from "./scanner/gemini.js";
 import { scanAgents } from "./scanner/index.js";
 import { loadRegistryFromFile } from "./scanner/session-registry.js";
 import { detectCliStdoutPhase } from "./scanner/status.js";
@@ -1747,10 +1747,27 @@ program
       const raw = await readFile(sessionFile, "utf-8");
       turns = parseClaudeConversationTurns(raw);
     } else if (agent.agentName === "Codex") {
-      // Codex sessions are indexed by cwd + processStartedAt; the rollout
-      // JSONL path comes from the indexer.
+      // Mirror scanner's session resolution priority: persistent binding
+      // registry (PID × processStartedAt → rollout) first, fallback to
+      // cwd + processStartedAt matching. Same-cwd multi-Codex environments
+      // would otherwise route to the wrong rollout file.
       const codexSessions = await indexCodexSessions(config, { activeCwds: [agent.cwd] });
-      const matched = matchCodexSession(agent.cwd, agent.processStartedAt, codexSessions);
+      const { loadCodexBindingRegistryFromFile, selectCodexBindingSession } = await import(
+        "./scanner/codex-binding-registry.js"
+      );
+      const bindingRegistry = new Map();
+      await loadCodexBindingRegistryFromFile(
+        join(getConfigDir(), "codex-binding-registry.json"),
+        bindingRegistry,
+      );
+      const matched =
+        selectCodexBindingSession(
+          bindingRegistry,
+          agent.pid,
+          agent.processStartedAt,
+          agent.cwd,
+          codexSessions,
+        ) ?? matchCodexSession(agent.cwd, agent.processStartedAt, codexSessions);
       if (!matched?.filePath) {
         console.error("Codex rollout file not found for this pane.");
         process.exit(1);
@@ -1759,13 +1776,18 @@ program
       const raw = await readFile(sessionFile, "utf-8");
       turns = parseCodexConversationTurns(raw);
     } else if (agent.agentName === "Gemini") {
-      // Gemini chats: parseGeminiSession returns the resolved sessionFile.
-      const gemini = await parseGeminiSession(agent.cwd);
-      if (!gemini.sessionFile) {
+      // Match the snapshot's sessionId against on-disk Gemini chats first so
+      // multi-session same-cwd environments don't fall back to "latest mtime
+      // wins". parseGeminiSession (latest mtime) remains as a graceful fallback.
+      sessionFile = await resolveGeminiChatFile(agent.cwd, agent.sessionId);
+      if (!sessionFile) {
+        const gemini = await parseGeminiSession(agent.cwd);
+        sessionFile = gemini.sessionFile;
+      }
+      if (!sessionFile) {
         console.error("Gemini chat file not found for this pane.");
         process.exit(1);
       }
-      sessionFile = gemini.sessionFile;
       const raw = await readFile(sessionFile, "utf-8");
       turns = parseGeminiConversationTurns(raw);
     } else {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,7 +44,11 @@ import {
   selectUnmatchedTargets,
 } from "./output/utils.js";
 import { TERMINAL_RESTORE_SEQUENCE, formatProcessFailure } from "./process-safety.js";
-import { detectClaudePhase, resolveClaudeSessionFile } from "./scanner/claude.js";
+import {
+  detectClaudePhase,
+  matchClaudeSessionByMtime,
+  resolveClaudeSessionFile,
+} from "./scanner/claude.js";
 import { detectCodexPhase, indexCodexSessions, matchCodexSession } from "./scanner/codex.js";
 import { isDaemonRunning, readDaemonPid, readDaemonSnapshot } from "./scanner/daemon-utils.js";
 import { parseGeminiSession, resolveGeminiChatFile } from "./scanner/gemini.js";
@@ -1730,16 +1734,23 @@ program
     let turns: ReturnType<typeof parseClaudeConversationTurns> = [];
 
     if (agent.agentName === "Claude Code") {
-      if (!agent.sessionId) {
+      // Daemon snapshot can lag heavy scan by up to 30s, so `agent.sessionId`
+      // may be stale when the user `/resume`s a different sessionId in the
+      // same PID. Re-resolve live against on-disk JSONL mtime for this pane's
+      // cwd/processStartedAt before falling back to the cached sessionId.
+      let liveSessionId: string | undefined;
+      try {
+        const live = await matchClaudeSessionByMtime(agent.cwd, agent.processStartedAt, config);
+        if (live?.sessionId) liveSessionId = live.sessionId;
+      } catch {
+        // fall through to snapshot sessionId
+      }
+      const sessionId = liveSessionId ?? agent.sessionId;
+      if (!sessionId) {
         console.error("Active Claude session has no sessionId yet — try again in a moment.");
         process.exit(1);
       }
-      sessionFile = await resolveClaudeSessionFile(
-        agent.sessionId,
-        agent.cwd,
-        agent.startedAt,
-        config,
-      );
+      sessionFile = await resolveClaudeSessionFile(sessionId, agent.cwd, agent.startedAt, config);
       if (!sessionFile) {
         console.error("Claude session file not found for this pane.");
         process.exit(1);

--- a/src/clipboard.ts
+++ b/src/clipboard.ts
@@ -1,0 +1,65 @@
+/**
+ * Cross-platform clipboard writer with fallback chain.
+ *
+ * macOS  : pbcopy
+ * Linux  : wl-copy → xclip → xsel  (in that order)
+ *
+ * Throws ClipboardError with a human-readable reason when all commands fail.
+ */
+
+import { spawn } from "node:child_process";
+
+interface ClipboardCommand {
+  command: string;
+  args: string[];
+}
+
+export class ClipboardError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ClipboardError";
+  }
+}
+
+function commandsForPlatform(): ClipboardCommand[] {
+  if (process.platform === "darwin") {
+    return [{ command: "pbcopy", args: [] }];
+  }
+  return [
+    { command: "wl-copy", args: [] },
+    { command: "xclip", args: ["-selection", "clipboard"] },
+    { command: "xsel", args: ["--clipboard", "--input"] },
+  ];
+}
+
+async function tryRun(command: string, args: string[], text: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const done = (ok: boolean) => {
+      if (settled) return;
+      settled = true;
+      resolve(ok);
+    };
+    try {
+      const child = spawn(command, args, { stdio: ["pipe", "ignore", "ignore"] });
+      child.on("error", () => done(false));
+      child.on("close", (code) => done(code === 0));
+      child.stdin.on("error", () => done(false));
+      child.stdin.end(text);
+    } catch {
+      done(false);
+    }
+  });
+}
+
+export async function writeClipboard(text: string): Promise<void> {
+  const candidates = commandsForPlatform();
+  const tried: string[] = [];
+  for (const { command, args } of candidates) {
+    tried.push(command);
+    if (await tryRun(command, args, text)) return;
+  }
+  throw new ClipboardError(
+    `Clipboard copy failed (tried: ${tried.join(", ")}). Try --stdout to print instead.`,
+  );
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -191,9 +191,9 @@ const DEFAULTS: MarmonitorConfig = {
     activityRetentionDays: 7,
   },
   alerts: {
-    enabled: true,
-    desktop: true,
-    log: true,
+    enabled: false,
+    desktop: false,
+    log: false,
     contextWarnThreshold: 1.0, // 기본 비활성 (0.70으로 설정 시 활성화)
     contextCritThreshold: 0.85,
   },

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -102,6 +102,8 @@ export interface MarmonitorConfig {
     desktop: boolean;
     /** alerts.log 파일 기록 */
     log: boolean;
+    /** 토큰/컨텍스트 임계 알림 카테고리 토글. 보안 알림과 분리 가능. 기본 true */
+    tokens: boolean;
     /** 컨텍스트 경고 임계값 (0~1). 0 = 비활성화. 기본 1.0 (비활성) */
     contextWarnThreshold: number;
     /** 컨텍스트 위험 임계값 (0~1). 기본 0.85 */
@@ -194,6 +196,7 @@ const DEFAULTS: MarmonitorConfig = {
     enabled: false,
     desktop: false,
     log: false,
+    tokens: true, // 활성 시 토큰/컨텍스트 임계 알림 발사. 보안 알림은 별도 게이트 없음
     contextWarnThreshold: 1.0, // 기본 비활성 (0.70으로 설정 시 활성화)
     contextCritThreshold: 0.85,
   },

--- a/src/node-notifier.d.ts
+++ b/src/node-notifier.d.ts
@@ -1,0 +1,13 @@
+declare module "node-notifier" {
+  interface NotificationOptions {
+    title: string;
+    message: string;
+  }
+
+  interface Notifier {
+    notify(options: NotificationOptions): void;
+  }
+
+  const notifier: Notifier;
+  export default notifier;
+}

--- a/src/scanner/claude.ts
+++ b/src/scanner/claude.ts
@@ -508,16 +508,20 @@ async function readJsonlSessionMeta(
  * Stale-session override resolver.
  *
  * Picks a non-current jsonl when the current sessionId's metadata is stale
- * (e.g. just after /clear), but refuses to do so when it would conflict with
- * an active sibling session in the same project directory. See local issue
- * #103 / GH #56 for the misrouting case this guards.
+ * (e.g. just after /clear), but refuses to do so when the current jsonl
+ * clearly belongs to this process or when the candidate jsonl is already
+ * claimed in the registry. See local issue #103 / GH #56 for the misrouting
+ * case this guards.
  *
  * Conservative guards layered on top of the legacy mtime-lead check:
  *  - F1: if currentDirectPath exists and its first-line timestamp is on or
  *        after processStartedAt, the current jsonl was authored by this
  *        process — keep it, do not override.
- *  - F2: if the override-candidate sessionId is already direct-bound to
- *        another live PID in claudeSessionRegistry, refuse the override.
+ *  - F2: if the override-candidate sessionId is already recorded as a
+ *        direct binding in claudeSessionRegistry, refuse the override. The
+ *        registry stores filePath / sessionId / cwd / binding (no live-PID
+ *        field), so this is "another scan has already claimed this jsonl
+ *        as authoritative," not a live-process check.
  *  - F3: anything ambiguous falls through to `undefined` (unresolved) —
  *        a missed match is safer than a misrouted one.
  */
@@ -581,8 +585,13 @@ async function chooseStaleSessionOverride(
   if (!recentMeta?.sessionId) return undefined;
   if (recentMeta.sessionId === currentSessionId) return undefined;
 
-  // F2: another live PID is already direct-bound to this candidate jsonl.
-  // Overriding would let two PIDs share one jsonl — the exact bug in #103.
+  // F2: the candidate jsonl is already recorded as a direct binding in the
+  // session registry — i.e. an earlier resolution (or another concurrent
+  // scan) has already claimed it as authoritative for its own sessionId.
+  // The registry has no live-PID field, so this is a "registry already
+  // claimed this jsonl" check, not a process-aliveness check. Refusing
+  // here keeps the one-jsonl-per-sessionId invariant intact and avoids
+  // the misroute in #103.
   const recentBinding = claudeSessionRegistry.get(recentMeta.sessionId);
   if (recentBinding?.binding === "direct") return undefined;
 

--- a/src/scanner/claude.ts
+++ b/src/scanner/claude.ts
@@ -517,11 +517,9 @@ async function readJsonlSessionMeta(
  *  - F1: if currentDirectPath exists and its first-line timestamp is on or
  *        after processStartedAt, the current jsonl was authored by this
  *        process — keep it, do not override.
- *  - F2: if the override-candidate sessionId is already recorded as a
- *        direct binding in claudeSessionRegistry, refuse the override. The
- *        registry stores filePath / sessionId / cwd / binding (no live-PID
- *        field), so this is "another scan has already claimed this jsonl
- *        as authoritative," not a live-process check.
+ *  - F2: if the override-candidate sessionId is already direct-bound in
+ *        claudeSessionRegistry, refuse the override. Keeps the
+ *        one-jsonl-per-sessionId invariant intact.
  *  - F3: anything ambiguous falls through to `undefined` (unresolved) —
  *        a missed match is safer than a misrouted one.
  */
@@ -585,13 +583,9 @@ async function chooseStaleSessionOverride(
   if (!recentMeta?.sessionId) return undefined;
   if (recentMeta.sessionId === currentSessionId) return undefined;
 
-  // F2: the candidate jsonl is already recorded as a direct binding in the
-  // session registry — i.e. an earlier resolution (or another concurrent
-  // scan) has already claimed it as authoritative for its own sessionId.
-  // The registry has no live-PID field, so this is a "registry already
-  // claimed this jsonl" check, not a process-aliveness check. Refusing
-  // here keeps the one-jsonl-per-sessionId invariant intact and avoids
-  // the misroute in #103.
+  // F2: the candidate sessionId is already direct-bound in the registry.
+  // Overriding would let two sessionIds share one jsonl — the exact bug
+  // in #103. Keeps the one-jsonl-per-sessionId invariant.
   const recentBinding = claudeSessionRegistry.get(recentMeta.sessionId);
   if (recentBinding?.binding === "direct") return undefined;
 

--- a/src/scanner/claude.ts
+++ b/src/scanner/claude.ts
@@ -504,9 +504,27 @@ async function readJsonlSessionMeta(
   }
 }
 
+/**
+ * Stale-session override resolver.
+ *
+ * Picks a non-current jsonl when the current sessionId's metadata is stale
+ * (e.g. just after /clear), but refuses to do so when it would conflict with
+ * an active sibling session in the same project directory. See local issue
+ * #103 / GH #56 for the misrouting case this guards.
+ *
+ * Conservative guards layered on top of the legacy mtime-lead check:
+ *  - F1: if currentDirectPath exists and its first-line timestamp is on or
+ *        after processStartedAt, the current jsonl was authored by this
+ *        process — keep it, do not override.
+ *  - F2: if the override-candidate sessionId is already direct-bound to
+ *        another live PID in claudeSessionRegistry, refuse the override.
+ *  - F3: anything ambiguous falls through to `undefined` (unresolved) —
+ *        a missed match is safer than a misrouted one.
+ */
 async function chooseStaleSessionOverride(
   processCwd: string,
   currentSessionId: string | undefined,
+  processStartedAt: number | undefined,
   config?: MarmonitorConfig,
 ): Promise<{ sessionId: string; cwd?: string; timestamp?: string; filePath: string } | undefined> {
   const projectDirName = await findClaudeProjectDir(processCwd, currentSessionId, config);
@@ -531,23 +549,42 @@ async function chooseStaleSessionOverride(
       : undefined;
 
   if (currentDirectPath) {
+    let currentStat: Awaited<ReturnType<typeof stat>>;
+    let recentStat: Awaited<ReturnType<typeof stat>>;
     try {
-      const [recentStat, currentStat] = await Promise.all([
-        stat(recentPath),
-        stat(currentDirectPath),
-      ]);
-      const minLeadMs = 5 * 60 * 1000;
-      const staleGapMs = 30 * 60 * 1000;
-      if (recentStat.mtimeMs - currentStat.mtimeMs < minLeadMs) return undefined;
-      if (Date.now() - currentStat.mtimeMs < staleGapMs) return undefined;
+      [recentStat, currentStat] = await Promise.all([stat(recentPath), stat(currentDirectPath)]);
     } catch {
       return undefined;
     }
+
+    // F1: a non-empty current jsonl whose first event is on or after the
+    // process start belongs to this process. Same-cwd sibling sessions land
+    // here and must not be routed onto another session's active jsonl.
+    if (currentStat.size > 0 && processStartedAt !== undefined) {
+      const currentMeta = await readJsonlSessionMeta(currentDirectPath);
+      if (currentMeta?.timestamp) {
+        const jsonlCreatedAtSec = new Date(currentMeta.timestamp).getTime() / 1000;
+        if (Number.isFinite(jsonlCreatedAtSec)) {
+          const CLOCK_SKEW_SEC = 60;
+          if (jsonlCreatedAtSec >= processStartedAt - CLOCK_SKEW_SEC) return undefined;
+        }
+      }
+    }
+
+    const minLeadMs = 5 * 60 * 1000;
+    const staleGapMs = 30 * 60 * 1000;
+    if (recentStat.mtimeMs - currentStat.mtimeMs < minLeadMs) return undefined;
+    if (Date.now() - currentStat.mtimeMs < staleGapMs) return undefined;
   }
 
   const recentMeta = await readJsonlSessionMeta(recentPath);
   if (!recentMeta?.sessionId) return undefined;
   if (recentMeta.sessionId === currentSessionId) return undefined;
+
+  // F2: another live PID is already direct-bound to this candidate jsonl.
+  // Overriding would let two PIDs share one jsonl — the exact bug in #103.
+  const recentBinding = claudeSessionRegistry.get(recentMeta.sessionId);
+  if (recentBinding?.binding === "direct") return undefined;
 
   return {
     sessionId: recentMeta.sessionId,
@@ -716,7 +753,12 @@ export async function parseClaudeSession(
       let resolvedStartedAt = sessionStartedAt;
 
       if (processCwd && processCwd !== "unknown") {
-        const override = await chooseStaleSessionOverride(processCwd, data.sessionId, config);
+        const override = await chooseStaleSessionOverride(
+          processCwd,
+          data.sessionId,
+          processStartedAt,
+          config,
+        );
         if (override) {
           resolvedSessionId = override.sessionId;
           resolvedCwd = override.cwd ?? processCwd;

--- a/src/scanner/codex.ts
+++ b/src/scanner/codex.ts
@@ -35,6 +35,43 @@ export type { CodexSessionMeta } from "./cache.js";
 
 const CODEX_SQLITE_RECENT_DAYS = 7;
 
+function mergeCodexIndexedSessions(
+  baseSessions: CodexSessionMeta[],
+  incomingSessions: CodexSessionMeta[],
+): CodexSessionMeta[] {
+  const merged = new Map<string, CodexSessionMeta>();
+
+  for (const session of baseSessions) {
+    merged.set(session.id, session);
+  }
+
+  for (const session of incomingSessions) {
+    const existing = merged.get(session.id);
+    if (!existing) {
+      merged.set(session.id, session);
+      continue;
+    }
+
+    merged.set(session.id, {
+      ...existing,
+      ...session,
+      filePath: session.filePath || existing.filePath,
+      cwd: session.cwd || existing.cwd,
+      timestamp: Math.min(existing.timestamp || session.timestamp, session.timestamp || existing.timestamp),
+      lastActivityAt: Math.max(existing.lastActivityAt ?? 0, session.lastActivityAt ?? 0) || undefined,
+      totalTokenUsage:
+        session.totalTokenUsage?.total_tokens !== undefined
+          ? session.totalTokenUsage
+          : existing.totalTokenUsage,
+      model: session.model ?? existing.model,
+    });
+  }
+
+  return [...merged.values()].sort((a, b) => (b.lastActivityAt ?? b.timestamp) - (a.lastActivityAt ?? a.timestamp));
+}
+
+export { mergeCodexIndexedSessions };
+
 export function getCodexSessionRoots(config?: MarmonitorConfig): string[] {
   return config
     ? resolveRuntimeDataPaths(config).codexSessions
@@ -174,16 +211,18 @@ export async function indexCodexSessions(
 
   const hasExplicitSessionRoots = Boolean(config?.paths.codexSessions?.length);
 
+  const sqliteSessions: CodexSessionMeta[] = [];
+
   // Primary: SQLite threads table
   const dbPath = hasExplicitSessionRoots ? undefined : findCodexStateDb();
   if (dbPath) {
-    const sqliteSessions = await indexCodexSessionsFromSqlite(dbPath, {
+    const indexed = await indexCodexSessionsFromSqlite(dbPath, {
       recentUpdatedAfter: Math.floor(Date.now() / 1000) - CODEX_SQLITE_RECENT_DAYS * 86400,
       includeCwds: activeCwds,
     });
-    if (sqliteSessions.length > 0) {
+    if (indexed.length > 0) {
       // Register sessions for phase detection and cwd lookup
-      for (const s of sqliteSessions) {
+      for (const s of indexed) {
         codexSessionFileCache.set(s.filePath, { ...s, mtimeMs: undefined, size: undefined });
         upsertSessionRegistryEntry(codexSessionRegistry, {
           filePath: s.filePath,
@@ -196,10 +235,7 @@ export async function indexCodexSessions(
           binding: "direct",
         });
       }
-      if (!hasTargetedFilter) {
-        setCodexIndexCache({ builtAt: Date.now(), sessions: sqliteSessions });
-      }
-      return sqliteSessions;
+      sqliteSessions.push(...indexed);
     }
   }
 
@@ -272,6 +308,9 @@ export async function indexCodexSessions(
             }
 
             if (meta.id && meta.cwd && meta.timestamp) {
+              if (hasTargetedFilter && !activeCwds.includes(meta.cwd)) {
+                continue;
+              }
               const parsed = {
                 filePath,
                 id: meta.id,
@@ -306,11 +345,13 @@ export async function indexCodexSessions(
     // sessions dir error
   }
 
+  const sessions = mergeCodexIndexedSessions(sqliteSessions, metas);
+
   setCodexIndexCache({
     builtAt: Date.now(),
-    sessions: metas,
+    sessions,
   });
-  return metas;
+  return sessions;
 }
 
 /** Match a Codex process to a session by cwd + closest timestamp */

--- a/src/scanner/codex.ts
+++ b/src/scanner/codex.ts
@@ -57,8 +57,12 @@ function mergeCodexIndexedSessions(
       ...session,
       filePath: session.filePath || existing.filePath,
       cwd: session.cwd || existing.cwd,
-      timestamp: Math.min(existing.timestamp || session.timestamp, session.timestamp || existing.timestamp),
-      lastActivityAt: Math.max(existing.lastActivityAt ?? 0, session.lastActivityAt ?? 0) || undefined,
+      timestamp: Math.min(
+        existing.timestamp || session.timestamp,
+        session.timestamp || existing.timestamp,
+      ),
+      lastActivityAt:
+        Math.max(existing.lastActivityAt ?? 0, session.lastActivityAt ?? 0) || undefined,
       totalTokenUsage:
         session.totalTokenUsage?.total_tokens !== undefined
           ? session.totalTokenUsage
@@ -67,7 +71,9 @@ function mergeCodexIndexedSessions(
     });
   }
 
-  return [...merged.values()].sort((a, b) => (b.lastActivityAt ?? b.timestamp) - (a.lastActivityAt ?? a.timestamp));
+  return [...merged.values()].sort(
+    (a, b) => (b.lastActivityAt ?? b.timestamp) - (a.lastActivityAt ?? a.timestamp),
+  );
 }
 
 export { mergeCodexIndexedSessions };

--- a/src/scanner/daemon-loop.ts
+++ b/src/scanner/daemon-loop.ts
@@ -55,6 +55,11 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/** Token/context threshold alerts fire only when both master and category toggles are on. */
+export function shouldRunTokenAlerts(config: MarmonitorConfig): boolean {
+  return Boolean(config.alerts.enabled && config.alerts.tokens);
+}
+
 export async function runDaemonLoop(
   config: MarmonitorConfig,
   options: DaemonOptions,
@@ -136,8 +141,8 @@ export async function runDaemonLoop(
       // Write snapshot for statusline consumers
       await writeDaemonSnapshot(snapshotPath, agents);
 
-      // Check token thresholds and fire alerts (alerts.enabled 확인)
-      if (config.alerts.enabled) {
+      // Check token thresholds and fire alerts (alerts.enabled + alerts.tokens 확인)
+      if (shouldRunTokenAlerts(config)) {
         const thresholds = {
           warnAt: config.alerts.contextWarnThreshold,
           critAt: config.alerts.contextCritThreshold,

--- a/src/scanner/gemini.ts
+++ b/src/scanner/gemini.ts
@@ -142,7 +142,30 @@ export async function resolveGeminiChatFile(
   }
   if (files.length === 0) return undefined;
 
-  // Tier 1: sessionId match — open each file, return on first hit.
+  // Tier 0: filename fast-path. Gemini chats are written as
+  //   session-<YYYY-MM-DDTHH-MM>-<sessionId first 8 chars>.json
+  // so checking the basename against the sessionId prefix avoids reading
+  // every file. Verified against ~/.gemini/tmp/*/chats/session-*.json.
+  if (sessionId && sessionId.length >= 8) {
+    const prefix = sessionId.slice(0, 8);
+    const namedHit = files.find((filePath) => filePath.includes(`-${prefix}.json`));
+    if (namedHit) {
+      // Confirm by reading the sessionId field — filenames could collide on a
+      // short prefix, and a false positive here would route to the wrong chat.
+      try {
+        const raw = await readFile(namedHit, "utf-8");
+        const data = JSON.parse(raw) as { sessionId?: unknown };
+        if (typeof data.sessionId === "string" && data.sessionId === sessionId) {
+          return namedHit;
+        }
+      } catch {
+        // fall through to the content-scan tier
+      }
+    }
+  }
+
+  // Tier 1: sessionId match — open each file, return on first hit. Reached
+  // only when the filename fast-path missed (e.g. format drift or collision).
   if (sessionId) {
     for (const filePath of files) {
       try {

--- a/src/scanner/gemini.ts
+++ b/src/scanner/gemini.ts
@@ -113,6 +113,67 @@ export async function resolveGeminiProjectDir(cwd: string): Promise<string | und
   return undefined;
 }
 
+/**
+ * Resolve a Gemini chats file by sessionId match first, then by latest mtime.
+ *
+ * Same-cwd multi-session safety: when `sessionId` is provided we scan each
+ * chats/*.json's `sessionId` field and return the matching path. Without a
+ * match we fall back to the most recently modified file (the legacy
+ * behaviour of parseGeminiSession). Returns undefined if no chats dir or
+ * no files exist.
+ */
+export async function resolveGeminiChatFile(
+  cwd: string,
+  sessionId?: string,
+): Promise<string | undefined> {
+  const projectDir = await resolveGeminiProjectDir(cwd);
+  if (!projectDir) return undefined;
+
+  const chatsDir = join(projectDir, "chats");
+  if (!existsSync(chatsDir)) return undefined;
+
+  let files: string[];
+  try {
+    files = (await readdir(chatsDir))
+      .filter((name) => name.startsWith("session-") && name.endsWith(".json"))
+      .map((name) => join(chatsDir, name));
+  } catch {
+    return undefined;
+  }
+  if (files.length === 0) return undefined;
+
+  // Tier 1: sessionId match — open each file, return on first hit.
+  if (sessionId) {
+    for (const filePath of files) {
+      try {
+        const raw = await readFile(filePath, "utf-8");
+        const data = JSON.parse(raw) as { sessionId?: unknown };
+        if (typeof data.sessionId === "string" && data.sessionId === sessionId) {
+          return filePath;
+        }
+      } catch {
+        // skip unreadable / malformed file
+      }
+    }
+  }
+
+  // Tier 2: fallback — latest mtime.
+  let latestFile: string | undefined;
+  let latestMtimeMs = -1;
+  for (const filePath of files) {
+    try {
+      const fileStat = await stat(filePath);
+      if (fileStat.mtimeMs > latestMtimeMs) {
+        latestMtimeMs = fileStat.mtimeMs;
+        latestFile = filePath;
+      }
+    } catch {
+      // skip
+    }
+  }
+  return latestFile;
+}
+
 export async function parseGeminiSession(
   cwd: string,
 ): Promise<Partial<AgentSession> & { sessionFile?: string }> {

--- a/src/scanner/process.ts
+++ b/src/scanner/process.ts
@@ -76,7 +76,7 @@ export function detectRuntimeSource(agentName: string, cmd?: string): RuntimeSou
   if (agentName !== "Codex") return undefined;
   const normalized = (cmd ?? "").toLowerCase();
   if (!normalized) return "unknown";
-  if (normalized.includes(".vscode/extensions") || normalized.includes("app-server")) {
+  if (normalized.includes(".vscode/extensions")) {
     return "vscode";
   }
   return "cli";
@@ -90,6 +90,9 @@ export function matchesProcessCommand(command: string, processName: string): boo
 /** Electron sub-process flags that indicate a desktop GUI helper, not a CLI agent. */
 const ELECTRON_TYPE_RE = /--type=(utility|renderer|gpu-process|zygote|broker)/;
 
+/** Codex `app-server` mode is an IDE/Desktop embedded RPC backend, not an interactive CLI session. */
+const CODEX_APP_SERVER_RE = /\bcodex\b[\s\S]*\bapp-server\b/i;
+
 /** Match a process against agent signatures using process name first, then cmd fallback. */
 export function detectAgentFromProcessSignature(
   proc: { name: string; cmd?: string },
@@ -98,6 +101,9 @@ export function detectAgentFromProcessSignature(
   // Skip Electron sub-processes (renderer, utility, gpu, zygote) to avoid
   // false-positive detection of desktop apps (e.g. Claude Desktop) as CLI agents.
   if (proc.cmd && ELECTRON_TYPE_RE.test(proc.cmd)) return null;
+  // Skip `codex app-server` backends spawned by Codex Desktop or the VS Code
+  // Codex extension — these are RPC backends, not interactive CLI sessions.
+  if (proc.cmd && CODEX_APP_SERVER_RE.test(proc.cmd)) return null;
 
   const name = proc.name.toLowerCase();
   const command = (proc.cmd ?? "").toLowerCase();

--- a/src/scanner/process.ts
+++ b/src/scanner/process.ts
@@ -89,6 +89,7 @@ export function matchesProcessCommand(command: string, processName: string): boo
 
 /** Electron sub-process flags that indicate a desktop GUI helper, not a CLI agent. */
 const ELECTRON_TYPE_RE = /--type=(utility|renderer|gpu-process|zygote|broker)/;
+const CODEX_VSCODE_APP_SERVER_RE = /[/\\]codex\s+app-server(?:\s|$)/i;
 
 /** Match a process against agent signatures using process name first, then cmd fallback. */
 export function detectAgentFromProcessSignature(
@@ -101,6 +102,9 @@ export function detectAgentFromProcessSignature(
 
   const name = proc.name.toLowerCase();
   const command = (proc.cmd ?? "").toLowerCase();
+  if (command.includes(".vscode/extensions") && CODEX_VSCODE_APP_SERVER_RE.test(proc.cmd ?? "")) {
+    return null;
+  }
   for (const [agentName, agentConfig] of Object.entries(config.agents)) {
     for (const pname of agentConfig.processNames) {
       if (name === pname) return agentName;

--- a/src/tmux/index.ts
+++ b/src/tmux/index.ts
@@ -166,6 +166,36 @@ export async function getProcessTty(pid: number): Promise<string | undefined> {
   }
 }
 
+/** Batched variant of `getProcessTty` — one `lsof -p pid1,pid2,...` call
+ *  returns the controlling tty for every PID at once. Returns a Map keyed
+ *  by PID; PIDs with no tty (or lsof errors) are simply absent. lsof's `-F`
+ *  output is one field per line, with `p<pid>` markers preceding each
+ *  process's records, so we walk the lines with a running `currentPid` and
+ *  pair the next `n<path>` we see with it. */
+export async function getProcessTtys(pids: number[]): Promise<Map<number, string>> {
+  const result = new Map<number, string>();
+  if (pids.length === 0) return result;
+  try {
+    const { stdout } = await execFileAsync("lsof", ["-a", "-p", pids.join(","), "-d", "0", "-Fn"], {
+      timeout: 2000,
+    });
+    let currentPid: number | undefined;
+    for (const raw of stdout.split("\n")) {
+      const line = raw.trim();
+      if (line.startsWith("p")) {
+        const parsed = Number.parseInt(line.slice(1), 10);
+        currentPid = Number.isFinite(parsed) ? parsed : undefined;
+      } else if (currentPid !== undefined && line.startsWith("n/")) {
+        // Keep the first `n` field per pid (stdin's tty); ignore any extras.
+        if (!result.has(currentPid)) result.set(currentPid, line.slice(1));
+      }
+    }
+  } catch {
+    // partial output may still be useful if returned; otherwise empty map.
+  }
+  return result;
+}
+
 /** Find the agent PID that runs inside the currently active tmux pane.
  *
  *  Two-tier match:
@@ -192,12 +222,13 @@ export async function findActiveAgentPid(
     const treeMatch = agentPids.find((pid) => isPidInTree(activePanePid, pid, childMap));
     if (treeMatch !== undefined) return treeMatch;
 
-    // Tier 2: tty fallback
-    const paneTty = await getProcessTty(activePanePid);
+    // Tier 2: tty fallback — one batched lsof for the pane shell + all
+    // agent PIDs, instead of N+1 separate calls.
+    const ttys = await getProcessTtys([activePanePid, ...agentPids]);
+    const paneTty = ttys.get(activePanePid);
     if (!paneTty) return undefined;
     for (const agentPid of agentPids) {
-      const agentTty = await getProcessTty(agentPid);
-      if (agentTty && agentTty === paneTty) return agentPid;
+      if (ttys.get(agentPid) === paneTty) return agentPid;
     }
     return undefined;
   } catch {

--- a/src/tmux/index.ts
+++ b/src/tmux/index.ts
@@ -148,9 +148,36 @@ export async function getActiveTmuxPanePid(): Promise<number | undefined> {
   }
 }
 
+/** Get the controlling tty of a PID via lsof (`-d 0` reads stdin fd → tty).
+ *  Uses lsof instead of `ps -o tty=` because the latter returns EPERM on
+ *  macOS for processes the caller does not own in the same session. */
+export async function getProcessTty(pid: number): Promise<string | undefined> {
+  try {
+    const { stdout } = await execFileAsync("lsof", ["-a", "-p", String(pid), "-d", "0", "-Fn"], {
+      timeout: 2000,
+    });
+    const line = stdout
+      .split("\n")
+      .map((l) => l.trim())
+      .find((l) => l.startsWith("n/"));
+    return line ? line.slice(1) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /** Find the agent PID that runs inside the currently active tmux pane.
- *  When panePid is provided, skips the tmux query (useful when the caller
- *  already resolved the active pane PID for cache-key purposes). */
+ *
+ *  Two-tier match:
+ *    1. pid-tree — `panePid` is the pane's shell PID; walk its descendants
+ *       and find one matching `agentPids`. Works in most cases.
+ *    2. tty fallback — when the pid-tree walk misses (e.g. macOS denies
+ *       ps walks for some processes), compare the pane's controlling tty
+ *       with each agent process's controlling tty. The agent and the
+ *       pane's shell share a tty when they run in the same pane.
+ *
+ *  When `panePid` is provided, skips the tmux query (useful when the
+ *  caller already resolved the active pane PID for cache-key purposes). */
 export async function findActiveAgentPid(
   agentPids: number[],
   panePid?: number,
@@ -159,8 +186,20 @@ export async function findActiveAgentPid(
   try {
     const activePanePid = panePid ?? (await getActiveTmuxPanePid());
     if (!activePanePid) return undefined;
+
+    // Tier 1: pid-tree
     const childMap = await getProcessTree();
-    return agentPids.find((pid) => isPidInTree(activePanePid, pid, childMap));
+    const treeMatch = agentPids.find((pid) => isPidInTree(activePanePid, pid, childMap));
+    if (treeMatch !== undefined) return treeMatch;
+
+    // Tier 2: tty fallback
+    const paneTty = await getProcessTty(activePanePid);
+    if (!paneTty) return undefined;
+    for (const agentPid of agentPids) {
+      const agentTty = await getProcessTty(agentPid);
+      if (agentTty && agentTty === paneTty) return agentPid;
+    }
+    return undefined;
   } catch {
     return undefined;
   }

--- a/src/turns.ts
+++ b/src/turns.ts
@@ -1,0 +1,251 @@
+/**
+ * AI session turn parsing.
+ *
+ * Reads agent-local turn data (Claude jsonl for v1) and groups it into
+ * user / assistant turns. A single assistant turn bundles all `text` /
+ * `tool_use` / `tool_result` lines that follow a user prompt until the
+ * next user prompt or `stop_reason === "end_turn"`.
+ *
+ * Two extraction modes are exposed via `TurnTextMode`:
+ *   - "text" (default): assistant text blocks only. What the user saw
+ *     Claude "say" — ideal for sharing to Slack / issue / note.
+ *   - "bundle": text + tool_use input + tool_result content (thinking
+ *     excluded). Closer to the full Claude UI rendering — for handing
+ *     context to another AI or debug PRs.
+ */
+
+export type TurnRole = "user" | "assistant";
+export type TurnTextMode = "text" | "bundle";
+
+export interface SessionTurn {
+  role: TurnRole;
+  startedAt?: number; // epoch seconds
+  completedAt?: number; // epoch seconds
+  /** Assistant text-only extraction. user turns reuse this field. */
+  text: string;
+  /** Full bundle (text + tool_use + tool_result) — assistant turns only. */
+  bundle?: string;
+}
+
+function toEpochSec(timestamp: unknown): number | undefined {
+  if (typeof timestamp !== "string") return undefined;
+  const ms = new Date(timestamp).getTime();
+  return Number.isFinite(ms) ? ms / 1000 : undefined;
+}
+
+function formatToolInput(input: unknown): string {
+  if (typeof input === "string") return input.trim();
+  try {
+    return JSON.stringify(input, null, 2);
+  } catch {
+    return String(input);
+  }
+}
+
+function formatToolResult(item: Record<string, unknown>): string {
+  if (typeof item.content === "string") return item.content.trim();
+  if (Array.isArray(item.content)) {
+    return item.content
+      .map((child) => {
+        if (!child || typeof child !== "object") return String(child);
+        const c = child as Record<string, unknown>;
+        if (typeof c.text === "string") return c.text.trim();
+        return JSON.stringify(c);
+      })
+      .filter(Boolean)
+      .join("\n\n");
+  }
+  return "";
+}
+
+/** Extract assistant text-only parts from a Claude assistant message. */
+function extractAssistantText(content: unknown): string[] {
+  if (typeof content === "string") {
+    const t = content.trim();
+    return t ? [t] : [];
+  }
+  if (!Array.isArray(content)) return [];
+  return content
+    .filter(
+      (c): c is Record<string, unknown> =>
+        Boolean(c) && typeof c === "object" && (c as Record<string, unknown>).type === "text",
+    )
+    .map((c) => (typeof c.text === "string" ? c.text.trim() : ""))
+    .filter(Boolean);
+}
+
+/** Extract bundle parts (text + tool_use + tool_result) — thinking excluded. */
+function extractAssistantBundle(content: unknown): string[] {
+  if (typeof content === "string") {
+    const t = content.trim();
+    return t ? [t] : [];
+  }
+  if (!Array.isArray(content)) return [];
+  const parts: string[] = [];
+  for (const item of content) {
+    if (!item || typeof item !== "object") continue;
+    const block = item as Record<string, unknown>;
+    switch (block.type) {
+      case "text": {
+        const t = typeof block.text === "string" ? block.text.trim() : "";
+        if (t) parts.push(t);
+        break;
+      }
+      case "tool_use": {
+        const name = typeof block.name === "string" ? block.name : "unknown";
+        parts.push(`[tool_use:${name}]\n${formatToolInput(block.input)}`);
+        break;
+      }
+      case "tool_result": {
+        const body = formatToolResult(block);
+        if (body) parts.push(`[tool_result]\n${body}`);
+        break;
+      }
+      // "thinking" intentionally excluded
+    }
+  }
+  return parts;
+}
+
+/** Parse Claude user message — `tool_result`-only blocks are not real user prompts. */
+function parseClaudeUserMessage(
+  content: unknown,
+): { text: string; isToolResult: boolean } | undefined {
+  if (typeof content === "string") {
+    const t = content.trim();
+    return t ? { text: t, isToolResult: false } : undefined;
+  }
+  if (!Array.isArray(content)) return undefined;
+
+  const blockTypes = content
+    .map((c) => (c && typeof c === "object" ? (c as Record<string, unknown>).type : undefined))
+    .filter((t): t is string => typeof t === "string");
+  const onlyToolResult = blockTypes.length > 0 && blockTypes.every((t) => t === "tool_result");
+
+  // Only emit prompt text for genuine user prompts.
+  const textParts = content
+    .filter(
+      (c): c is Record<string, unknown> =>
+        Boolean(c) && typeof c === "object" && (c as Record<string, unknown>).type === "text",
+    )
+    .map((c) => (typeof c.text === "string" ? c.text.trim() : ""))
+    .filter(Boolean);
+
+  if (onlyToolResult) {
+    // bundle 모드에서 합쳐질 수 있도록 raw content를 살리되 prompt로는 안 셈
+    return { text: "", isToolResult: true };
+  }
+  return textParts.length > 0 ? { text: textParts.join("\n\n"), isToolResult: false } : undefined;
+}
+
+interface PendingAssistant {
+  texts: string[];
+  bundleParts: string[];
+  startedAt?: number;
+  completedAt?: number;
+}
+
+function flushAssistant(turns: SessionTurn[], pending: PendingAssistant): void {
+  const text = pending.texts.join("\n\n").trim();
+  const bundle = pending.bundleParts.join("\n\n").trim();
+  if (!text && !bundle) return;
+  turns.push({
+    role: "assistant",
+    startedAt: pending.startedAt,
+    completedAt: pending.completedAt ?? pending.startedAt,
+    text,
+    bundle: bundle || undefined,
+  });
+}
+
+function newPending(): PendingAssistant {
+  return { texts: [], bundleParts: [], startedAt: undefined, completedAt: undefined };
+}
+
+/**
+ * Parse a Claude session JSONL into ordered user/assistant turns.
+ * Lines without role information (file-history-snapshot, last-prompt, etc.)
+ * are ignored.
+ */
+export function parseClaudeConversationTurns(raw: string): SessionTurn[] {
+  const turns: SessionTurn[] = [];
+  let pending = newPending();
+
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let entry: Record<string, unknown>;
+    try {
+      entry = JSON.parse(trimmed) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+
+    const entryType = typeof entry.type === "string" ? entry.type : undefined;
+    if (entryType !== "user" && entryType !== "assistant") continue;
+
+    const message =
+      entry.message && typeof entry.message === "object"
+        ? (entry.message as Record<string, unknown>)
+        : undefined;
+    const ts = toEpochSec(entry.timestamp);
+
+    if (entryType === "user") {
+      const parsed = parseClaudeUserMessage(message?.content);
+      if (!parsed) continue;
+
+      if (parsed.isToolResult) {
+        // tool_result는 진행 중인 assistant turn에 묶음으로 합쳐짐
+        if (pending.bundleParts.length > 0 || pending.texts.length > 0) {
+          const body = formatToolResult(
+            // 다시 추출 — bundle 형태로
+            { content: (message?.content as unknown) ?? [] },
+          );
+          if (body) pending.bundleParts.push(`[tool_result]\n${body}`);
+          if (ts !== undefined) pending.completedAt = ts;
+        }
+        continue;
+      }
+
+      flushAssistant(turns, pending);
+      pending = newPending();
+      turns.push({ role: "user", startedAt: ts, completedAt: ts, text: parsed.text });
+      continue;
+    }
+
+    // assistant
+    const texts = extractAssistantText(message?.content);
+    const bundleParts = extractAssistantBundle(message?.content);
+    if (texts.length === 0 && bundleParts.length === 0) continue;
+
+    if (pending.startedAt === undefined) pending.startedAt = ts;
+    if (ts !== undefined) pending.completedAt = ts;
+    pending.texts.push(...texts);
+    pending.bundleParts.push(...bundleParts);
+
+    if (message?.stop_reason === "end_turn") {
+      flushAssistant(turns, pending);
+      pending = newPending();
+    }
+  }
+
+  flushAssistant(turns, pending);
+  return turns;
+}
+
+/** Pick the latest turn for a given role. */
+export function selectLatestTurn(
+  turns: SessionTurn[],
+  role: TurnRole = "assistant",
+): SessionTurn | undefined {
+  for (let i = turns.length - 1; i >= 0; i--) {
+    if (turns[i].role === role) return turns[i];
+  }
+  return undefined;
+}
+
+/** Extract the copyable text from a turn for the chosen mode. */
+export function turnTextForMode(turn: SessionTurn, mode: TurnTextMode = "text"): string {
+  if (mode === "bundle" && turn.bundle) return turn.bundle;
+  return turn.text;
+}

--- a/src/turns.ts
+++ b/src/turns.ts
@@ -435,7 +435,12 @@ export function parseGeminiConversationTurns(raw: string): SessionTurn[] {
       if (pending.startedAt === undefined) pending.startedAt = ts;
       if (ts !== undefined) pending.completedAt = ts;
       pending.texts.push(text);
-      pending.bundleParts.push(text);
+      // `bundleParts` intentionally untouched: Gemini chats JSON does not
+      // expose tool-call / tool-result as separately addressable blocks the
+      // way Claude/Codex jsonl does. Producing a "bundle" that's identical
+      // to `text` would be a dishonest no-op, so we leave `turn.bundle`
+      // undefined and let `turnTextForMode(turn, 'bundle')` fall back to
+      // `turn.text` (the documented degradation path).
     }
     // info / error / unknown — skip
   }

--- a/src/turns.ts
+++ b/src/turns.ts
@@ -233,6 +233,219 @@ export function parseClaudeConversationTurns(raw: string): SessionTurn[] {
   return turns;
 }
 
+/* ─── Codex rollout JSONL parser ─────────────────────────────────────── */
+
+function extractCodexMessageTexts(content: unknown): string[] {
+  if (typeof content === "string") {
+    const t = content.trim();
+    return t ? [t] : [];
+  }
+  if (!Array.isArray(content)) return [];
+  return content
+    .filter((c): c is Record<string, unknown> => Boolean(c) && typeof c === "object")
+    .map((c) => {
+      const t = (c as Record<string, unknown>).type;
+      // Both input_text (user/developer) and output_text (assistant) carry plain text.
+      if (t === "input_text" || t === "output_text") {
+        const text = (c as Record<string, unknown>).text;
+        return typeof text === "string" ? text.trim() : "";
+      }
+      return "";
+    })
+    .filter(Boolean);
+}
+
+function formatCodexFunctionCall(payload: Record<string, unknown>): string {
+  const name = typeof payload.name === "string" ? payload.name : "unknown";
+  const args = typeof payload.arguments === "string" ? payload.arguments : "";
+  // arguments is a stringified JSON — try to pretty-print.
+  let pretty = args;
+  try {
+    pretty = JSON.stringify(JSON.parse(args), null, 2);
+  } catch {
+    // keep as-is if not valid JSON
+  }
+  return `[function_call:${name}]\n${pretty}`.trim();
+}
+
+function formatCodexFunctionOutput(payload: Record<string, unknown>): string {
+  const output = typeof payload.output === "string" ? payload.output.trim() : "";
+  if (!output) return "";
+  return `[function_call_output]\n${output}`;
+}
+
+/**
+ * Parse a Codex rollout JSONL into ordered user/assistant turns.
+ *
+ * Rollout structure:
+ *   - `type: "session_meta"` / `"event_msg"` / `"turn_context"` — meta, ignored
+ *   - `type: "response_item"` payload:
+ *       - `type: "message"` + `role: "user"|"assistant"|"developer"`
+ *           — content is an array of `{type: "input_text"|"output_text", text}`.
+ *           `developer` is system-side, skipped.
+ *       - `type: "reasoning"` — Codex's thinking, excluded (matches option B).
+ *       - `type: "function_call"` — tool invocation (bundle-only).
+ *       - `type: "function_call_output"` — tool result (bundle-only).
+ *       - `type: "web_search_call"` — surfaced as a marker in bundle.
+ *
+ * Turn boundary: a new `user` message flushes the in-progress assistant.
+ */
+export function parseCodexConversationTurns(raw: string): SessionTurn[] {
+  const turns: SessionTurn[] = [];
+  let pending = newPending();
+
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let entry: Record<string, unknown>;
+    try {
+      entry = JSON.parse(trimmed) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+    if (entry.type !== "response_item") continue;
+
+    const payload =
+      entry.payload && typeof entry.payload === "object"
+        ? (entry.payload as Record<string, unknown>)
+        : undefined;
+    if (!payload) continue;
+
+    const ts = toEpochSec(entry.timestamp);
+    const ptype = typeof payload.type === "string" ? payload.type : "";
+
+    if (ptype === "message") {
+      const role = typeof payload.role === "string" ? payload.role : "";
+      // Developer messages are system-side scaffolding — skip.
+      if (role === "developer") continue;
+
+      const texts = extractCodexMessageTexts(payload.content);
+      if (texts.length === 0) continue;
+
+      if (role === "user") {
+        flushAssistant(turns, pending);
+        pending = newPending();
+        const text = texts.join("\n\n").trim();
+        if (text) turns.push({ role: "user", startedAt: ts, completedAt: ts, text });
+        continue;
+      }
+      if (role === "assistant") {
+        if (pending.startedAt === undefined) pending.startedAt = ts;
+        if (ts !== undefined) pending.completedAt = ts;
+        pending.texts.push(...texts);
+        pending.bundleParts.push(...texts);
+        continue;
+      }
+      continue;
+    }
+
+    if (ptype === "function_call") {
+      const piece = formatCodexFunctionCall(payload);
+      if (piece) pending.bundleParts.push(piece);
+      if (ts !== undefined) pending.completedAt = ts;
+      continue;
+    }
+
+    if (ptype === "function_call_output") {
+      const piece = formatCodexFunctionOutput(payload);
+      if (piece) pending.bundleParts.push(piece);
+      if (ts !== undefined) pending.completedAt = ts;
+      continue;
+    }
+
+    if (ptype === "web_search_call") {
+      pending.bundleParts.push("[web_search_call]");
+      if (ts !== undefined) pending.completedAt = ts;
+    }
+
+    // "reasoning" intentionally excluded (option B).
+  }
+
+  flushAssistant(turns, pending);
+  return turns;
+}
+
+/* ─── Gemini chats JSON parser ───────────────────────────────────────── */
+
+interface GeminiMessage {
+  type?: unknown;
+  content?: unknown;
+  timestamp?: unknown;
+  parts?: unknown;
+}
+
+function extractGeminiText(msg: GeminiMessage): string {
+  if (typeof msg.content === "string") return msg.content.trim();
+  // Some Gemini variants store rich content under `parts: [{ text } | { functionCall } ...]`.
+  if (Array.isArray(msg.parts)) {
+    return msg.parts
+      .map((p) => {
+        if (!p || typeof p !== "object") return "";
+        const obj = p as Record<string, unknown>;
+        if (typeof obj.text === "string") return obj.text.trim();
+        return "";
+      })
+      .filter(Boolean)
+      .join("\n\n");
+  }
+  return "";
+}
+
+/**
+ * Parse a Gemini chats JSON (`messages: [{type, content, timestamp, ...}]`)
+ * into ordered user/assistant turns.
+ *
+ * Recognised message types:
+ *   - `"user"`        — user prompt → user turn
+ *   - `"gemini"`      — assistant response → flushed as assistant turn
+ *   - everything else (`"info"`, `"error"`, etc.) — ignored as scaffolding
+ *
+ * NOTE: live verification is currently unavailable (the user does not run the
+ * Gemini CLI). Behaviour is covered by unit tests with fixture data and is
+ * expected to be conservative — unknown shapes degrade to no-turn rather than
+ * raising.
+ */
+export function parseGeminiConversationTurns(raw: string): SessionTurn[] {
+  let data: { messages?: unknown };
+  try {
+    data = JSON.parse(raw) as { messages?: unknown };
+  } catch {
+    return [];
+  }
+  if (!data || !Array.isArray(data.messages)) return [];
+
+  const turns: SessionTurn[] = [];
+  let pending = newPending();
+
+  for (const m of data.messages) {
+    if (!m || typeof m !== "object") continue;
+    const msg = m as GeminiMessage;
+    const ts = toEpochSec(msg.timestamp);
+    const type = typeof msg.type === "string" ? msg.type : "";
+    const text = extractGeminiText(msg);
+
+    if (type === "user") {
+      flushAssistant(turns, pending);
+      pending = newPending();
+      if (text) turns.push({ role: "user", startedAt: ts, completedAt: ts, text });
+      continue;
+    }
+    if (type === "gemini") {
+      if (!text) continue;
+      if (pending.startedAt === undefined) pending.startedAt = ts;
+      if (ts !== undefined) pending.completedAt = ts;
+      pending.texts.push(text);
+      pending.bundleParts.push(text);
+    }
+    // info / error / unknown — skip
+  }
+
+  flushAssistant(turns, pending);
+  return turns;
+}
+
+/* ────────────────────────────────────────────────────────────────────── */
+
 /** Pick the latest turn for a given role. */
 export function selectLatestTurn(
   turns: SessionTurn[],

--- a/src/turns.ts
+++ b/src/turns.ts
@@ -132,7 +132,7 @@ function parseClaudeUserMessage(
     .filter(Boolean);
 
   if (onlyToolResult) {
-    // bundle 모드에서 합쳐질 수 있도록 raw content를 살리되 prompt로는 안 셈
+    // Keep the raw content for bundle mode, but do not count it as a user prompt.
     return { text: "", isToolResult: true };
   }
   return textParts.length > 0 ? { text: textParts.join("\n\n"), isToolResult: false } : undefined;
@@ -195,10 +195,10 @@ export function parseClaudeConversationTurns(raw: string): SessionTurn[] {
       if (!parsed) continue;
 
       if (parsed.isToolResult) {
-        // tool_result는 진행 중인 assistant turn에 묶음으로 합쳐짐
+        // tool_result entries merge into the in-progress assistant turn.
         if (pending.bundleParts.length > 0 || pending.texts.length > 0) {
           const body = formatToolResult(
-            // 다시 추출 — bundle 형태로
+            // Re-extract the raw content into bundle form.
             { content: (message?.content as unknown) ?? [] },
           );
           if (body) pending.bundleParts.push(`[tool_result]\n${body}`);

--- a/tests/alerts-token.test.mjs
+++ b/tests/alerts-token.test.mjs
@@ -62,6 +62,42 @@ describe("checkTokenAlert (context-size gate, #102 G2)", () => {
     assert.equal(alert, undefined);
   });
 
+  it("does not fire when lastInputTokens is null (external JSON null)", () => {
+    // gemini-code-assist review on PR #59: external JSON parsing can yield
+    // `null` instead of `undefined`. Number.isFinite guard handles both.
+    const store = new AlertStore();
+    const alert = checkTokenAlert(
+      store,
+      makeAgent({
+        inputTokens: 2_000_000,
+        outputTokens: 0,
+        cacheCreationTokens: 0,
+        cacheReadTokens: 0,
+        totalTokens: 2_000_000,
+        lastInputTokens: null,
+      }),
+    );
+    assert.equal(alert, undefined);
+  });
+
+  it("does not fire when lastInputTokens is NaN or non-finite", () => {
+    const store = new AlertStore();
+    for (const bad of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+      const alert = checkTokenAlert(
+        store,
+        makeAgent({
+          inputTokens: 0,
+          outputTokens: 0,
+          cacheCreationTokens: 0,
+          cacheReadTokens: 0,
+          totalTokens: 0,
+          lastInputTokens: bad,
+        }),
+      );
+      assert.equal(alert, undefined, `bad value ${bad} should not fire`);
+    }
+  });
+
   it("does not fire when lastInputTokens is below thresholds", () => {
     const store = new AlertStore();
     const alert = checkTokenAlert(

--- a/tests/alerts-token.test.mjs
+++ b/tests/alerts-token.test.mjs
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { AlertStore, checkTokenAlert } from "../dist/alerts/index.js";
+
+function makeAgent(tokenUsage, overrides = {}) {
+  return {
+    agentName: "Claude Code",
+    pid: 1234,
+    cwd: "/tmp/agent",
+    cpuPercent: 0,
+    memoryMb: 0,
+    status: "Active",
+    model: "claude-opus-4-7",
+    tokenUsage,
+    ...overrides,
+  };
+}
+
+describe("checkTokenAlert (context-size gate, #102 G2)", () => {
+  it("fires context_critical when lastInputTokens crosses critAt (Claude normal path)", () => {
+    const store = new AlertStore();
+    const alert = checkTokenAlert(
+      store,
+      makeAgent({
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheCreationTokens: 0,
+        cacheReadTokens: 0,
+        totalTokens: 0,
+        lastInputTokens: 180_000, // 90% of 200K
+      }),
+    );
+    assert.ok(alert, "alert should be created");
+    assert.equal(alert?.type, "context_critical");
+  });
+
+  it("does NOT fire when lastInputTokens is missing — Codex cumulative regression (#102)", () => {
+    // Reproduces the production case at 2026-05-08: Codex sessions arrive
+    // with a multi-million cumulative inputTokens but no lastInputTokens,
+    // which previously fell back to cumulative and produced 8983%/15700% alerts.
+    const store = new AlertStore();
+    const alert = checkTokenAlert(
+      store,
+      makeAgent(
+        {
+          inputTokens: 1_500_000, // cumulative across the session
+          outputTokens: 12_000,
+          cacheCreationTokens: 0,
+          cacheReadTokens: 0,
+          totalTokens: 1_512_000,
+          // lastInputTokens intentionally omitted
+        },
+        { agentName: "Codex", model: "gpt-5.4", pid: 2222 },
+      ),
+    );
+    assert.equal(alert, undefined);
+  });
+
+  it("does not fire when tokenUsage is absent", () => {
+    const store = new AlertStore();
+    const alert = checkTokenAlert(store, makeAgent(undefined));
+    assert.equal(alert, undefined);
+  });
+
+  it("does not fire when lastInputTokens is below thresholds", () => {
+    const store = new AlertStore();
+    const alert = checkTokenAlert(
+      store,
+      makeAgent({
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheCreationTokens: 0,
+        cacheReadTokens: 0,
+        totalTokens: 0,
+        lastInputTokens: 50_000, // 25%
+      }),
+    );
+    assert.equal(alert, undefined);
+  });
+});

--- a/tests/claude-session-file.test.mjs
+++ b/tests/claude-session-file.test.mjs
@@ -301,6 +301,166 @@ describe("parseClaudeSession", () => {
   });
 });
 
+describe("chooseStaleSessionOverride conservative guards (#103)", () => {
+  it("F1: does not misroute dormant same-cwd session to active sibling jsonl", async () => {
+    // Reproduces local issue #103 / GH #56 deterministically.
+    // Two Claude sessions share cwd. The dormant one (current) has its own
+    // jsonl whose first-line timestamp matches its processStartedAt. The
+    // active sibling's jsonl is newer by 56min and the dormant's mtime is
+    // older than 30min — exactly the case where the legacy mtime check would
+    // override. F1 must short-circuit on processStartedAt parity.
+    claudeSessionRegistry.clear();
+    claudeProjectDirCache.clear();
+
+    const root = join(tmpdir(), `marmonitor-claude-103-f1-${Date.now()}`);
+    const cwd = join(root, "shared");
+    const projectsRoot = join(root, "projects");
+    const sessionsRoot = join(root, "sessions");
+    const projectDir = join(projectsRoot, encodeClaudeProjectDir(cwd));
+    const dormantPid = 48477;
+    const sessionMetaPath = join(sessionsRoot, `${dormantPid}.json`);
+    const dormantPath = join(projectDir, "abd04dd5.jsonl");
+    const activePath = join(projectDir, "048c0eb5.jsonl");
+    const nowSec = Math.floor(Date.now() / 1000);
+    // Dormant process started 2h ago; its jsonl first-line carries the same
+    // creation time (well within F1's clock-skew window).
+    const dormantStartedAt = nowSec - 2 * 3600;
+    const dormantTs = new Date(dormantStartedAt * 1000).toISOString();
+    // Active sibling started 1h ago; its jsonl is the newest in the dir.
+    const activeStartedAt = nowSec - 3600;
+    const activeTs = new Date(activeStartedAt * 1000).toISOString();
+
+    await mkdir(projectDir, { recursive: true });
+    await mkdir(sessionsRoot, { recursive: true });
+    await writeFile(
+      dormantPath,
+      `${[
+        JSON.stringify({ type: "permission-mode", sessionId: "abd04dd5" }),
+        JSON.stringify({ type: "user", cwd, sessionId: "abd04dd5", timestamp: dormantTs }),
+      ].join("\n")}\n`,
+      "utf-8",
+    );
+    await writeFile(
+      activePath,
+      `${[
+        JSON.stringify({ type: "permission-mode", sessionId: "048c0eb5" }),
+        JSON.stringify({ type: "user", cwd, sessionId: "048c0eb5", timestamp: activeTs }),
+      ].join("\n")}\n`,
+      "utf-8",
+    );
+    // Dormant jsonl mtime: 1h45m ago (well past 30min staleness window).
+    const dormantMtime = new Date((nowSec - 1.75 * 3600) * 1000);
+    await utimes(dormantPath, dormantMtime, dormantMtime);
+    // Active sibling jsonl mtime: 49min ago — 56min newer than dormant.
+    const activeMtime = new Date((nowSec - 49 * 60) * 1000);
+    await utimes(activePath, activeMtime, activeMtime);
+    await writeFile(
+      sessionMetaPath,
+      JSON.stringify({
+        pid: dormantPid,
+        sessionId: "abd04dd5",
+        cwd,
+        startedAt: dormantStartedAt * 1000,
+      }),
+      "utf-8",
+    );
+
+    const defaults = getDefaults();
+    const config = {
+      ...defaults,
+      paths: {
+        ...defaults.paths,
+        claudeProjects: [projectsRoot],
+        claudeSessions: [sessionsRoot],
+      },
+    };
+
+    try {
+      const parsed = await parseClaudeSession(dormantPid, cwd, dormantStartedAt, config);
+      // Without F1, parsed.sessionId would have become "048c0eb5" (the active
+      // sibling) — exactly the misrouting reported in #103.
+      assert.equal(parsed.sessionId, "abd04dd5");
+    } finally {
+      claudeSessionRegistry.clear();
+      claudeProjectDirCache.clear();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("F2: does not override onto a sessionId already direct-bound to another live PID", async () => {
+    // Even if the dormant jsonl is missing (currentDirectPath undefined, so
+    // F1 cannot apply), F2 must still refuse when the active sibling's
+    // sessionId already has a direct binding registered.
+    claudeSessionRegistry.clear();
+    claudeProjectDirCache.clear();
+
+    const root = join(tmpdir(), `marmonitor-claude-103-f2-${Date.now()}`);
+    const cwd = join(root, "shared");
+    const projectsRoot = join(root, "projects");
+    const sessionsRoot = join(root, "sessions");
+    const projectDir = join(projectsRoot, encodeClaudeProjectDir(cwd));
+    const dormantPid = 22222;
+    const sessionMetaPath = join(sessionsRoot, `${dormantPid}.json`);
+    const activePath = join(projectDir, "active.jsonl");
+    const nowSec = Math.floor(Date.now() / 1000);
+    const activeTs = new Date((nowSec - 60) * 1000).toISOString();
+
+    await mkdir(projectDir, { recursive: true });
+    await mkdir(sessionsRoot, { recursive: true });
+    // No dormant jsonl on disk (dormant sessionId points to a missing file).
+    await writeFile(
+      activePath,
+      `${[
+        JSON.stringify({ type: "permission-mode", sessionId: "active" }),
+        JSON.stringify({ type: "user", cwd, sessionId: "active", timestamp: activeTs }),
+      ].join("\n")}\n`,
+      "utf-8",
+    );
+    await writeFile(
+      sessionMetaPath,
+      JSON.stringify({
+        pid: dormantPid,
+        sessionId: "dormant",
+        cwd,
+        startedAt: (nowSec - 3600) * 1000,
+      }),
+      "utf-8",
+    );
+
+    // Simulate another live PID already holding the active jsonl direct-bound.
+    claudeSessionRegistry.set("active", {
+      filePath: activePath,
+      sessionId: "active",
+      cwd,
+      firstSeenOffset: 0,
+      startedAt: nowSec - 60,
+      source: "claude",
+      binding: "direct",
+    });
+
+    const defaults = getDefaults();
+    const config = {
+      ...defaults,
+      paths: {
+        ...defaults.paths,
+        claudeProjects: [projectsRoot],
+        claudeSessions: [sessionsRoot],
+      },
+    };
+
+    try {
+      const parsed = await parseClaudeSession(dormantPid, cwd, nowSec - 3600, config);
+      // Override blocked by F2 → dormant session keeps its (stale) sessionId,
+      // which is the conservative outcome ("unresolved is safer than misrouted").
+      assert.equal(parsed.sessionId, "dormant");
+    } finally {
+      claudeSessionRegistry.clear();
+      claudeProjectDirCache.clear();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("matchClaudeSessionByMtime", () => {
   it("returns undefined when two files have timestamps within 5 minutes of each other (ambiguous)", async () => {
     claudeSessionRegistry.clear();

--- a/tests/config.test.mjs
+++ b/tests/config.test.mjs
@@ -60,6 +60,14 @@ describe("getDefaults", () => {
     assert.equal(config.performance.stdoutHeuristicTtlMs, 2000);
   });
 
+  it("defaults alerts.tokens=true and master toggles=false", () => {
+    const config = getDefaults();
+    assert.equal(config.alerts.enabled, false);
+    assert.equal(config.alerts.desktop, false);
+    assert.equal(config.alerts.log, false);
+    assert.equal(config.alerts.tokens, true);
+  });
+
   it("includes all three default agents", () => {
     const config = getDefaults();
     assert.ok(config.agents["Claude Code"]);
@@ -165,6 +173,29 @@ describe("loadConfig", () => {
       assert.deepEqual(config.paths.extraRoots, []);
       assert.equal(config.performance.snapshotTtlMs, 2000);
       assert.deepEqual(config.agents.Codex.processNames, ["codex"]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("merges alerts.tokens override (security alerts unaffected)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "marmonitor-config-"));
+    const path = join(dir, "settings.json");
+    await writeFile(
+      path,
+      JSON.stringify({
+        alerts: { enabled: true, desktop: true, tokens: false },
+      }),
+    );
+
+    try {
+      const config = await loadConfig(path);
+      assert.equal(config.alerts.enabled, true);
+      assert.equal(config.alerts.desktop, true);
+      assert.equal(config.alerts.tokens, false);
+      // unspecified fields fall back to defaults
+      assert.equal(config.alerts.log, false);
+      assert.equal(config.alerts.contextCritThreshold, 0.85);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/tests/daemon-token-gate.test.mjs
+++ b/tests/daemon-token-gate.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { getDefaults } from "../dist/config/index.js";
+import { shouldRunTokenAlerts } from "../dist/scanner/daemon-loop.js";
+
+describe("shouldRunTokenAlerts (daemon token-alert gate)", () => {
+  it("fires only when both enabled and tokens are true", () => {
+    const cfg = getDefaults();
+    cfg.alerts.enabled = true;
+    cfg.alerts.tokens = true;
+    assert.equal(shouldRunTokenAlerts(cfg), true);
+  });
+
+  it("skips when alerts.tokens is false (security path stays on master toggle)", () => {
+    const cfg = getDefaults();
+    cfg.alerts.enabled = true;
+    cfg.alerts.tokens = false;
+    assert.equal(shouldRunTokenAlerts(cfg), false);
+  });
+
+  it("skips when master alerts.enabled is false even if tokens is true", () => {
+    const cfg = getDefaults();
+    cfg.alerts.enabled = false;
+    cfg.alerts.tokens = true;
+    assert.equal(shouldRunTokenAlerts(cfg), false);
+  });
+
+  it("skips when both toggles are off (default state)", () => {
+    const cfg = getDefaults();
+    cfg.alerts.enabled = false;
+    cfg.alerts.tokens = false;
+    assert.equal(shouldRunTokenAlerts(cfg), false);
+  });
+});

--- a/tests/scanner.test.mjs
+++ b/tests/scanner.test.mjs
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { describe, it } from "node:test";
 import { getDefaults } from "../dist/config/index.js";
 import { setCodexIndexCache } from "../dist/scanner/cache.js";
-import { indexCodexSessions } from "../dist/scanner/codex.js";
+import { indexCodexSessions, mergeCodexIndexedSessions } from "../dist/scanner/codex.js";
 import {
   detectAgentFromProcessSignature,
   parseGeminiSessionContent,
@@ -249,6 +249,67 @@ describe("propagateWorkerStateToParent", () => {
 });
 
 describe("indexCodexSessions", () => {
+  it("merges sqlite and jsonl Codex sessions so fresh rollout-only sessions are preserved", () => {
+    const merged = mergeCodexIndexedSessions(
+      [
+        {
+          id: "sqlite-only",
+          cwd: "/tmp/sqlite-only",
+          filePath: "/tmp/sqlite-only.jsonl",
+          timestamp: 100,
+          lastActivityAt: 130,
+        },
+        {
+          id: "shared",
+          cwd: "/tmp/shared",
+          filePath: "/tmp/shared-sqlite.jsonl",
+          timestamp: 200,
+          lastActivityAt: 220,
+          totalTokenUsage: {
+            input_tokens: 0,
+            cached_input_tokens: 0,
+            output_tokens: 0,
+            total_tokens: 10,
+          },
+        },
+      ],
+      [
+        {
+          id: "shared",
+          cwd: "/tmp/shared",
+          filePath: "/tmp/shared-jsonl.jsonl",
+          timestamp: 180,
+          lastActivityAt: 240,
+          totalTokenUsage: {
+            input_tokens: 11,
+            cached_input_tokens: 2,
+            output_tokens: 3,
+            total_tokens: 16,
+          },
+          model: "gpt-5.4",
+        },
+        {
+          id: "jsonl-only",
+          cwd: "/tmp/jsonl-only",
+          filePath: "/tmp/jsonl-only.jsonl",
+          timestamp: 300,
+          lastActivityAt: 310,
+        },
+      ],
+    );
+
+    assert.deepEqual(
+      merged.map((session) => session.id),
+      ["jsonl-only", "shared", "sqlite-only"],
+    );
+    assert.equal(merged.find((session) => session.id === "shared")?.filePath, "/tmp/shared-jsonl.jsonl");
+    assert.equal(merged.find((session) => session.id === "shared")?.timestamp, 180);
+    assert.equal(
+      merged.find((session) => session.id === "shared")?.totalTokenUsage?.total_tokens,
+      16,
+    );
+  });
+
   it("records lastActivityAt from the session file mtime", async () => {
     const now = new Date();
     const yyyy = now.getFullYear().toString();

--- a/tests/scanner.test.mjs
+++ b/tests/scanner.test.mjs
@@ -90,6 +90,19 @@ describe("detectAgentFromProcessSignature", () => {
       null,
     );
   });
+
+  it("does not treat VS Code Codex app-server processes as trackable agent sessions", () => {
+    assert.equal(
+      detectAgentFromProcessSignature(
+        {
+          name: "codex",
+          cmd: "/Users/me/.vscode/extensions/openai.chatgpt/bin/macos-aarch64/codex app-server --analytics-default-enabled",
+        },
+        config,
+      ),
+      null,
+    );
+  });
 });
 
 describe("parseGeminiSessionContent", () => {
@@ -302,7 +315,10 @@ describe("indexCodexSessions", () => {
       merged.map((session) => session.id),
       ["jsonl-only", "shared", "sqlite-only"],
     );
-    assert.equal(merged.find((session) => session.id === "shared")?.filePath, "/tmp/shared-jsonl.jsonl");
+    assert.equal(
+      merged.find((session) => session.id === "shared")?.filePath,
+      "/tmp/shared-jsonl.jsonl",
+    );
     assert.equal(merged.find((session) => session.id === "shared")?.timestamp, 180);
     assert.equal(
       merged.find((session) => session.id === "shared")?.totalTokenUsage?.total_tokens,

--- a/tests/scanner.test.mjs
+++ b/tests/scanner.test.mjs
@@ -74,6 +74,32 @@ describe("detectAgentFromProcessSignature", () => {
     );
   });
 
+  it("does not match Codex `app-server` backends from Desktop or VS Code", () => {
+    // Codex Desktop and the VS Code Codex extension spawn the real codex
+    // binary in `app-server` mode as an RPC backend — not an interactive
+    // session — so it must not show up as a CLI agent.
+    assert.equal(
+      detectAgentFromProcessSignature(
+        {
+          name: "node",
+          cmd: "/home/sam/.asdf/installs/nodejs/24.13.0/bin/node /home/sam/.npm-global/bin/codex app-server --analytics-default-enabled",
+        },
+        config,
+      ),
+      null,
+    );
+    assert.equal(
+      detectAgentFromProcessSignature(
+        {
+          name: "codex",
+          cmd: "/home/sam/.npm-global/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/codex/codex app-server --analytics-default-enabled",
+        },
+        config,
+      ),
+      null,
+    );
+  });
+
   it("does not falsely match unrelated node processes", () => {
     assert.equal(
       detectAgentFromProcessSignature(

--- a/tests/turns.test.mjs
+++ b/tests/turns.test.mjs
@@ -470,6 +470,24 @@ describe("parseGeminiConversationTurns", () => {
     assert.equal(turns[3].text, "별말씀을요.");
   });
 
+  it("does not populate bundle for assistant turns — Gemini bundle is a no-op (#62 F9)", () => {
+    // Gemini chats JSON has no separately-addressable tool_use / tool_result
+    // blocks like Claude/Codex, so a "bundle" mode would duplicate `text`.
+    // Leave turn.bundle undefined and let turnTextForMode fall back to text.
+    const raw = JSON.stringify({
+      messages: [
+        { type: "user", content: "q", timestamp: "2026-04-07T01:22:00.000Z" },
+        { type: "gemini", content: "a", timestamp: "2026-04-07T01:22:01.000Z" },
+      ],
+    });
+    const turns = parseGeminiConversationTurns(raw);
+    assert.equal(turns.length, 2);
+    assert.equal(turns[1].role, "assistant");
+    assert.equal(turns[1].text, "a");
+    assert.equal(turns[1].bundle, undefined);
+    assert.equal(turnTextForMode(turns[1], "bundle"), "a"); // falls back to text
+  });
+
   it("skips info/error/unknown message types", () => {
     const raw = JSON.stringify({
       messages: [

--- a/tests/turns.test.mjs
+++ b/tests/turns.test.mjs
@@ -1,9 +1,19 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { parseClaudeConversationTurns, selectLatestTurn, turnTextForMode } from "../dist/turns.js";
+import {
+  parseClaudeConversationTurns,
+  parseCodexConversationTurns,
+  parseGeminiConversationTurns,
+  selectLatestTurn,
+  turnTextForMode,
+} from "../dist/turns.js";
 
 function jsonl(...lines) {
   return lines.map((l) => JSON.stringify(l)).join("\n");
+}
+
+function codexLine(payload, ts = "2026-05-18T01:00:00.000Z") {
+  return JSON.stringify({ timestamp: ts, type: "response_item", payload });
 }
 
 describe("parseClaudeConversationTurns — user turn", () => {
@@ -305,5 +315,192 @@ describe("turnTextForMode", () => {
   it("falls back to text when bundle is missing", () => {
     const t = { role: "user", text: "u1" };
     assert.equal(turnTextForMode(t, "bundle"), "u1");
+  });
+});
+
+describe("parseCodexConversationTurns", () => {
+  it("groups user message + assistant message + tool cycle into a single assistant turn", () => {
+    const raw = [
+      codexLine({
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "find files" }],
+      }),
+      codexLine({
+        type: "reasoning",
+        summary: ["thinking..."],
+        content: null,
+      }),
+      codexLine({
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "파일을 찾아볼게요." }],
+      }),
+      codexLine({
+        type: "function_call",
+        name: "exec_command",
+        arguments: '{"cmd":"rg foo","workdir":"/tmp"}',
+        call_id: "call_1",
+      }),
+      codexLine({
+        type: "function_call_output",
+        call_id: "call_1",
+        output: "match1\nmatch2",
+      }),
+      codexLine({
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "두 개 찾았습니다." }],
+      }),
+    ].join("\n");
+
+    const turns = parseCodexConversationTurns(raw);
+    assert.equal(turns.length, 2);
+
+    assert.equal(turns[0].role, "user");
+    assert.equal(turns[0].text, "find files");
+
+    assert.equal(turns[1].role, "assistant");
+    // option B (text-only): reasoning + function_call + function_call_output 제외
+    assert.match(turns[1].text, /파일을 찾아볼게요/);
+    assert.match(turns[1].text, /두 개 찾았습니다/);
+    assert.doesNotMatch(turns[1].text, /function_call/);
+    assert.doesNotMatch(turns[1].text, /thinking/);
+
+    // bundle: text + function_call(arguments pretty) + function_call_output
+    const bundle = turns[1].bundle ?? "";
+    assert.match(bundle, /\[function_call:exec_command\]/);
+    assert.match(bundle, /"cmd": "rg foo"/);
+    assert.match(bundle, /\[function_call_output\]/);
+    assert.match(bundle, /match1/);
+    assert.doesNotMatch(bundle, /thinking/); // reasoning은 여전히 제외
+  });
+
+  it("separates later user messages from previous assistant turn", () => {
+    const raw = [
+      codexLine({ type: "message", role: "user", content: [{ type: "input_text", text: "q1" }] }),
+      codexLine({
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "a1" }],
+      }),
+      codexLine({ type: "message", role: "user", content: [{ type: "input_text", text: "q2" }] }),
+      codexLine({
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "a2" }],
+      }),
+    ].join("\n");
+
+    const turns = parseCodexConversationTurns(raw);
+    assert.equal(turns.length, 4);
+    assert.equal(turns[2].text, "q2");
+    assert.equal(turns[3].text, "a2");
+  });
+
+  it("skips developer messages and unknown response_item types gracefully", () => {
+    const raw = [
+      codexLine({
+        type: "message",
+        role: "developer",
+        content: [{ type: "input_text", text: "system instruction" }],
+      }),
+      codexLine({
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "hi" }],
+      }),
+      codexLine({
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "hello" }],
+      }),
+      codexLine({ type: "web_search_call", payload_extra: "..." }),
+      codexLine({ type: "unknown_future_type" }),
+    ].join("\n");
+
+    const turns = parseCodexConversationTurns(raw);
+    assert.equal(turns.length, 2);
+    assert.equal(turns[0].text, "hi");
+    assert.equal(turns[1].text, "hello");
+    assert.match(turns[1].bundle ?? "", /\[web_search_call\]/);
+  });
+
+  it("ignores non-response_item lines (session_meta, event_msg, turn_context)", () => {
+    const raw = [
+      JSON.stringify({ type: "session_meta", payload: { id: "s1" } }),
+      JSON.stringify({ type: "event_msg", payload: { kind: "..." } }),
+      JSON.stringify({ type: "turn_context", payload: { turn_id: "t1" } }),
+      codexLine({ type: "message", role: "user", content: [{ type: "input_text", text: "ok" }] }),
+      codexLine({
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "fine" }],
+      }),
+    ].join("\n");
+
+    const turns = parseCodexConversationTurns(raw);
+    assert.equal(turns.length, 2);
+  });
+
+  it("returns empty array on empty input or malformed JSON", () => {
+    assert.deepEqual(parseCodexConversationTurns(""), []);
+    assert.deepEqual(parseCodexConversationTurns("not json\n{ broken"), []);
+  });
+});
+
+describe("parseGeminiConversationTurns", () => {
+  it("groups type:user + type:gemini into ordered turns", () => {
+    const raw = JSON.stringify({
+      messages: [
+        { type: "info", content: "auth ok", timestamp: "2026-04-07T01:21:00.000Z" },
+        { type: "user", content: "안녕", timestamp: "2026-04-07T01:22:00.000Z" },
+        { type: "gemini", content: "반가워요!", timestamp: "2026-04-07T01:22:01.000Z" },
+        { type: "user", content: "고마워", timestamp: "2026-04-07T01:23:00.000Z" },
+        { type: "gemini", content: "별말씀을요.", timestamp: "2026-04-07T01:23:01.000Z" },
+      ],
+    });
+
+    const turns = parseGeminiConversationTurns(raw);
+    assert.equal(turns.length, 4);
+    assert.equal(turns[0].role, "user");
+    assert.equal(turns[0].text, "안녕");
+    assert.equal(turns[1].role, "assistant");
+    assert.equal(turns[1].text, "반가워요!");
+    assert.equal(turns[3].text, "별말씀을요.");
+  });
+
+  it("skips info/error/unknown message types", () => {
+    const raw = JSON.stringify({
+      messages: [
+        { type: "info", content: "..." },
+        { type: "error", content: "..." },
+        { type: "tool", content: "..." },
+        { type: "user", content: "hi" },
+        { type: "gemini", content: "hello" },
+      ],
+    });
+    const turns = parseGeminiConversationTurns(raw);
+    assert.equal(turns.length, 2);
+  });
+
+  it("falls back to parts[].text when content is missing", () => {
+    const raw = JSON.stringify({
+      messages: [
+        { type: "user", parts: [{ text: "from parts" }] },
+        { type: "gemini", parts: [{ text: "first part" }, { text: "second part" }] },
+      ],
+    });
+    const turns = parseGeminiConversationTurns(raw);
+    assert.equal(turns.length, 2);
+    assert.equal(turns[0].text, "from parts");
+    assert.equal(turns[1].text, "first part\n\nsecond part");
+  });
+
+  it("returns empty array on malformed JSON or missing messages", () => {
+    assert.deepEqual(parseGeminiConversationTurns(""), []);
+    assert.deepEqual(parseGeminiConversationTurns("not json"), []);
+    assert.deepEqual(parseGeminiConversationTurns("{}"), []);
+    assert.deepEqual(parseGeminiConversationTurns(JSON.stringify({ messages: null })), []);
   });
 });

--- a/tests/turns.test.mjs
+++ b/tests/turns.test.mjs
@@ -1,0 +1,309 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { parseClaudeConversationTurns, selectLatestTurn, turnTextForMode } from "../dist/turns.js";
+
+function jsonl(...lines) {
+  return lines.map((l) => JSON.stringify(l)).join("\n");
+}
+
+describe("parseClaudeConversationTurns — user turn", () => {
+  it("extracts a single user prompt with text content array", () => {
+    const raw = jsonl({
+      type: "user",
+      timestamp: "2026-05-17T01:00:00.000Z",
+      message: {
+        role: "user",
+        content: [{ type: "text", text: "hello claude" }],
+      },
+    });
+    const turns = parseClaudeConversationTurns(raw);
+    assert.equal(turns.length, 1);
+    assert.equal(turns[0].role, "user");
+    assert.equal(turns[0].text, "hello claude");
+  });
+
+  it("supports string content (legacy form)", () => {
+    const raw = jsonl({
+      type: "user",
+      timestamp: "2026-05-17T01:00:00.000Z",
+      message: { role: "user", content: "raw string prompt" },
+    });
+    const turns = parseClaudeConversationTurns(raw);
+    assert.equal(turns.length, 1);
+    assert.equal(turns[0].text, "raw string prompt");
+  });
+});
+
+describe("parseClaudeConversationTurns — assistant turn grouping", () => {
+  it("groups thinking + text + tool_use + tool_result + post-text into a single assistant turn", () => {
+    const raw = jsonl(
+      // user prompt
+      {
+        type: "user",
+        timestamp: "2026-05-17T01:00:00.000Z",
+        message: { role: "user", content: [{ type: "text", text: "list files" }] },
+      },
+      // assistant thinking (옵션 B에서는 빠짐)
+      {
+        type: "assistant",
+        timestamp: "2026-05-17T01:00:01.000Z",
+        message: {
+          role: "assistant",
+          stop_reason: "tool_use",
+          content: [{ type: "thinking", text: "내가 ls를 호출해야지" }],
+        },
+      },
+      // assistant text
+      {
+        type: "assistant",
+        timestamp: "2026-05-17T01:00:02.000Z",
+        message: {
+          role: "assistant",
+          stop_reason: "tool_use",
+          content: [{ type: "text", text: "파일 목록을 확인할게요." }],
+        },
+      },
+      // assistant tool_use
+      {
+        type: "assistant",
+        timestamp: "2026-05-17T01:00:03.000Z",
+        message: {
+          role: "assistant",
+          stop_reason: "tool_use",
+          content: [{ type: "tool_use", name: "Bash", input: { command: "ls -la" } }],
+        },
+      },
+      // user tool_result
+      {
+        type: "user",
+        timestamp: "2026-05-17T01:00:04.000Z",
+        message: { role: "user", content: [{ type: "tool_result", content: "file1\nfile2" }] },
+      },
+      // assistant final answer (end_turn)
+      {
+        type: "assistant",
+        timestamp: "2026-05-17T01:00:05.000Z",
+        message: {
+          role: "assistant",
+          stop_reason: "end_turn",
+          content: [{ type: "text", text: "두 파일이 있습니다." }],
+        },
+      },
+    );
+    const turns = parseClaudeConversationTurns(raw);
+    assert.equal(turns.length, 2, "한 user + 한 assistant turn으로 묶임");
+
+    assert.equal(turns[0].role, "user");
+    assert.equal(turns[0].text, "list files");
+
+    assert.equal(turns[1].role, "assistant");
+    // 옵션 B: text만 — thinking 빠지고 text 라인 두 개만
+    assert.match(turns[1].text, /파일 목록을 확인할게요/);
+    assert.match(turns[1].text, /두 파일이 있습니다/);
+    assert.doesNotMatch(turns[1].text, /tool_use/);
+    assert.doesNotMatch(turns[1].text, /tool_result/);
+    assert.doesNotMatch(turns[1].text, /ls를 호출/);
+
+    // 옵션 A: bundle — text + tool_use + tool_result
+    const bundle = turns[1].bundle ?? "";
+    assert.match(bundle, /\[tool_use:Bash\]/);
+    assert.match(bundle, /ls -la/);
+    assert.match(bundle, /\[tool_result\]/);
+    assert.match(bundle, /file1/);
+    assert.doesNotMatch(bundle, /ls를 호출/); // thinking 여전히 제외
+  });
+
+  it("separates later user prompts from previous assistant turn", () => {
+    const raw = jsonl(
+      {
+        type: "user",
+        timestamp: "2026-05-17T01:00:00.000Z",
+        message: { role: "user", content: [{ type: "text", text: "첫 요청" }] },
+      },
+      {
+        type: "assistant",
+        timestamp: "2026-05-17T01:00:01.000Z",
+        message: {
+          role: "assistant",
+          stop_reason: "end_turn",
+          content: [{ type: "text", text: "첫 답변" }],
+        },
+      },
+      {
+        type: "user",
+        timestamp: "2026-05-17T01:00:02.000Z",
+        message: { role: "user", content: [{ type: "text", text: "둘째 요청" }] },
+      },
+      {
+        type: "assistant",
+        timestamp: "2026-05-17T01:00:03.000Z",
+        message: {
+          role: "assistant",
+          stop_reason: "end_turn",
+          content: [{ type: "text", text: "둘째 답변" }],
+        },
+      },
+    );
+    const turns = parseClaudeConversationTurns(raw);
+    assert.equal(turns.length, 4);
+    assert.equal(turns[2].text, "둘째 요청");
+    assert.equal(turns[3].text, "둘째 답변");
+  });
+
+  it("flushes an in-progress assistant turn without end_turn at EOF", () => {
+    const raw = jsonl(
+      {
+        type: "user",
+        timestamp: "2026-05-17T01:00:00.000Z",
+        message: { role: "user", content: [{ type: "text", text: "ping" }] },
+      },
+      // stop_reason 없음, end_turn 안 옴 — flush at EOF
+      {
+        type: "assistant",
+        timestamp: "2026-05-17T01:00:01.000Z",
+        message: {
+          role: "assistant",
+          stop_reason: "tool_use",
+          content: [{ type: "text", text: "진행 중..." }],
+        },
+      },
+    );
+    const turns = parseClaudeConversationTurns(raw);
+    assert.equal(turns.length, 2);
+    assert.equal(turns[1].role, "assistant");
+    assert.equal(turns[1].text, "진행 중...");
+  });
+
+  it("joins multiple text lines with double newline", () => {
+    const raw = jsonl(
+      {
+        type: "user",
+        timestamp: "2026-05-17T01:00:00.000Z",
+        message: { role: "user", content: [{ type: "text", text: "q" }] },
+      },
+      {
+        type: "assistant",
+        timestamp: "2026-05-17T01:00:01.000Z",
+        message: {
+          role: "assistant",
+          stop_reason: "tool_use",
+          content: [{ type: "text", text: "첫 줄" }],
+        },
+      },
+      {
+        type: "assistant",
+        timestamp: "2026-05-17T01:00:02.000Z",
+        message: {
+          role: "assistant",
+          stop_reason: "end_turn",
+          content: [{ type: "text", text: "둘째 줄" }],
+        },
+      },
+    );
+    const turns = parseClaudeConversationTurns(raw);
+    assert.equal(turns[1].text, "첫 줄\n\n둘째 줄");
+  });
+});
+
+describe("parseClaudeConversationTurns — robustness", () => {
+  it("ignores meta types (system, file-history-snapshot, last-prompt, ...)", () => {
+    const raw = jsonl(
+      { type: "system", message: { content: "system info" } },
+      { type: "file-history-snapshot", snapshot: { timestamp: "2026-05-17T01:00:00.000Z" } },
+      { type: "last-prompt", content: "..." },
+      { type: "permission-mode", permissionMode: "default" },
+      {
+        type: "user",
+        timestamp: "2026-05-17T01:00:01.000Z",
+        message: { role: "user", content: [{ type: "text", text: "hi" }] },
+      },
+      {
+        type: "assistant",
+        timestamp: "2026-05-17T01:00:02.000Z",
+        message: {
+          role: "assistant",
+          stop_reason: "end_turn",
+          content: [{ type: "text", text: "hello" }],
+        },
+      },
+      { type: "ai-title", content: "..." },
+    );
+    const turns = parseClaudeConversationTurns(raw);
+    assert.equal(turns.length, 2);
+    assert.equal(turns[0].text, "hi");
+    assert.equal(turns[1].text, "hello");
+  });
+
+  it("skips malformed JSON lines", () => {
+    const raw = [
+      "not json",
+      JSON.stringify({
+        type: "user",
+        message: { role: "user", content: [{ type: "text", text: "ok" }] },
+      }),
+      "{ broken",
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          stop_reason: "end_turn",
+          content: [{ type: "text", text: "fine" }],
+        },
+      }),
+    ].join("\n");
+    const turns = parseClaudeConversationTurns(raw);
+    assert.equal(turns.length, 2);
+  });
+
+  it("returns empty array on empty input", () => {
+    assert.deepEqual(parseClaudeConversationTurns(""), []);
+    assert.deepEqual(parseClaudeConversationTurns("\n\n\n"), []);
+  });
+
+  it("returns empty array when there is no user/assistant content", () => {
+    const raw = jsonl({ type: "system" }, { type: "file-history-snapshot" });
+    assert.deepEqual(parseClaudeConversationTurns(raw), []);
+  });
+});
+
+describe("selectLatestTurn", () => {
+  const turns = [
+    { role: "user", text: "u1" },
+    { role: "assistant", text: "a1" },
+    { role: "user", text: "u2" },
+    { role: "assistant", text: "a2" },
+  ];
+
+  it("returns the latest assistant by default", () => {
+    assert.equal(selectLatestTurn(turns)?.text, "a2");
+  });
+
+  it("filters by role=user", () => {
+    assert.equal(selectLatestTurn(turns, "user")?.text, "u2");
+  });
+
+  it("returns undefined when no matching role exists", () => {
+    assert.equal(selectLatestTurn([{ role: "user", text: "only" }], "assistant"), undefined);
+  });
+});
+
+describe("turnTextForMode", () => {
+  const turn = {
+    role: "assistant",
+    text: "답변 텍스트",
+    bundle: "답변 텍스트\n\n[tool_use:Bash]\nls",
+  };
+
+  it("returns text-only by default", () => {
+    assert.equal(turnTextForMode(turn), "답변 텍스트");
+  });
+
+  it("returns bundle when mode='bundle'", () => {
+    assert.match(turnTextForMode(turn, "bundle"), /\[tool_use:Bash\]/);
+  });
+
+  it("falls back to text when bundle is missing", () => {
+    const t = { role: "user", text: "u1" };
+    assert.equal(turnTextForMode(t, "bundle"), "u1");
+  });
+});


### PR DESCRIPTION
## Summary

Resolve #65

Release the current `dev` branch to `main` as `v0.2.6`.

This release packages the work completed after `v0.2.5`, including one-keystroke AI turn copy from the active tmux pane, safer Codex / Claude same-cwd session resolution, and token-alert control / false-positive suppression improvements.

## Type

- [ ] `[FEAT]` New feature
- [ ] `[BUG]` Bug fix
- [ ] `[HOTFIX]` Urgent fix
- [ ] `[PERF]` Performance improvement
- [ ] `[REFACTOR]` Code restructuring
- [ ] `[DOCS]` Documentation
- [ ] `[TEST]` Test coverage
- [x] `[CICD]` CI/CD or release
- [ ] `[CHORE]` Maintenance

## Changes

- release `v0.2.6` from `dev` to `main`
- include post-`v0.2.5` merged work:
  - `#57` add `alerts.tokens` toggle and docs sync
  - `#58` skip Codex `app-server` backends in agent detection
  - `#59` guard token alerts against cumulative `inputTokens` fallback
  - `#60` guard Claude stale-session override against same-cwd sibling misrouting
  - `#63` add `copy-latest-turn` for Claude / Codex / Gemini
- include release metadata updates from `#66`:
  - bump version to `0.2.6`
  - add changelog entry
  - document `copy-latest-turn`, `prefix+y`, and `alerts tokens on|off`
  - keep build green with local `node-notifier` module declaration

## Checklist

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (all tests green)
- [x] New features have tests
- [x] README updated (if user-facing changes)
- [x] No hardcoded paths or environment-specific values

## Testing

- `npm run build`
- `npm run lint`
- `npm test` (`331/331`)

## Risk

Low–Medium.
- Main user-facing addition is `copy-latest-turn`, which adds new parsing / clipboard code paths without modifying existing `status`, `attention`, `watch`, `dock`, or guard flows.
- Gemini turn-copy support is still lower-confidence than Claude/Codex because it is fixture-tested but not deeply live-verified in the release-prep environment.
- Session-resolution fixes are intentionally conservative: unmatched is preferred over cross-session misrouting in same-cwd environments.
