### PR TITLE
[FIX] prevent same-cwd Claude session collisions (#68)

### DIFF
--- a/src/scanner/cache.ts
+++ b/src/scanner/cache.ts
@@ -15,6 +15,12 @@ export const PROCESS_START_TTL_MS = 300_000;
 export const CODEX_INDEX_TTL_MS = 30_000;
 export const CLAUDE_SESSION_MTIME_MATCH_SEC = 120;
 export const CLAUDE_SESSION_AMBIGUITY_GAP_SEC = 300;
+// Dual-threshold for matchClaudeSessionByMtime: a jsonl must be (a) authored
+// close enough to processStartedAt AND (b) clearly closer than the runner-up.
+// See local issue #108 — without (b), two near-simultaneous Claude starts in
+// the same cwd collapse onto the same sessionId in the daemon snapshot.
+export const CLAUDE_MATCH_TOP_DELTA_SEC = 10;
+export const CLAUDE_MATCH_GAP_SEC = 5;
 export const CLAUDE_PHASE_RECENT_LINES = 50;
 export const CODEX_PHASE_RECENT_LINES = 30;
 export const RECENT_ACTIVITY_ACTIVE_SEC = 180;

--- a/src/scanner/claude.ts
+++ b/src/scanner/claude.ts
@@ -530,6 +530,8 @@ async function chooseStaleSessionOverride(
   currentSessionId: string | undefined,
   processStartedAt: number | undefined,
   config?: MarmonitorConfig,
+  cycleClaimedSessionIds?: Set<string>,
+  reservedSessionIds?: ReadonlySet<string>,
 ): Promise<{ sessionId: string; cwd?: string; timestamp?: string; filePath: string } | undefined> {
   const projectDirName = await findClaudeProjectDir(processCwd, currentSessionId, config);
   if (!projectDirName) return undefined;
@@ -585,6 +587,16 @@ async function chooseStaleSessionOverride(
   if (!recentMeta?.sessionId) return undefined;
   if (recentMeta.sessionId === currentSessionId) return undefined;
 
+  // #108: a session chosen by the stale override is just as capable of
+  // collapsing two PIDs as a direct mtime match. The per-cycle ownership
+  // check must therefore cover this legacy path as well.
+  if (cycleClaimedSessionIds?.has(recentMeta.sessionId)) return undefined;
+
+  // Active PID metadata and batch-selected mtime matches are reserved before
+  // individual parsing begins. A stale legacy record must not steal one of
+  // those sibling sessions merely because it acquired the mutex first.
+  if (reservedSessionIds?.has(recentMeta.sessionId)) return undefined;
+
   // F2: the candidate sessionId is already direct-bound in the registry.
   // Overriding would let two sessionIds share one jsonl — the exact bug
   // in #103. Keeps the one-jsonl-per-sessionId invariant.
@@ -597,6 +609,186 @@ async function chooseStaleSessionOverride(
     timestamp: recentMeta.timestamp,
     filePath: recentPath,
   };
+}
+
+export interface ClaudeMtimeMatchRequest {
+  pid: number;
+  cwd?: string;
+  processStartedAt?: number;
+}
+
+export interface ClaudeMtimeMatch {
+  filePath: string;
+  sessionId: string;
+  cwd: string;
+  startedAt?: number;
+  lastActivityAt: number;
+}
+
+type ClaudeMtimeCandidate = {
+  path: string;
+  mtimeMs: number;
+  sessionId: string;
+  cwd?: string;
+  timestamp: string;
+};
+
+async function listClaudeMtimeCandidates(
+  cwd: string,
+  config?: MarmonitorConfig,
+): Promise<ClaudeMtimeCandidate[]> {
+  const projectDirName = await findClaudeProjectDir(cwd, undefined, config);
+  if (!projectDirName) return [];
+
+  const candidates = await listClaudeSessionCandidates(
+    projectDirName,
+    getClaudeProjectRoots(config),
+  ).catch(() => []);
+  const result: ClaudeMtimeCandidate[] = [];
+
+  for (const candidate of candidates) {
+    const meta = await readJsonlSessionMeta(candidate.path);
+    if (!meta?.sessionId || !meta.timestamp) continue;
+    const timestampMs = new Date(meta.timestamp).getTime();
+    if (!Number.isFinite(timestampMs)) continue;
+    result.push({
+      ...candidate,
+      sessionId: meta.sessionId,
+      cwd: meta.cwd,
+      timestamp: meta.timestamp,
+    });
+  }
+
+  return result;
+}
+
+function scoreClaudeMtimeCandidates(
+  candidates: ClaudeMtimeCandidate[],
+  processStartedAt: number,
+): Array<ClaudeMtimeCandidate & { deltaSec: number }> {
+  const startMs = processStartedAt * 1000;
+  const active = candidates.filter(
+    (candidate) => candidate.mtimeMs >= startMs - CLAUDE_SESSION_MTIME_MATCH_SEC * 1000,
+  );
+  const pool = active.length > 0 ? active : candidates;
+
+  return pool
+    .map((candidate) => ({
+      ...candidate,
+      deltaSec: Math.abs(new Date(candidate.timestamp).getTime() / 1000 - processStartedAt),
+    }))
+    .sort((a, b) => a.deltaSec - b.deltaSec);
+}
+
+function isConfidentClaudeMtimeMatch(
+  scored: Array<ClaudeMtimeCandidate & { deltaSec: number }>,
+): boolean {
+  const top = scored[0];
+  if (!top || top.deltaSec > CLAUDE_MATCH_TOP_DELTA_SEC) return false;
+  const second = scored[1];
+  return !second || second.deltaSec - top.deltaSec >= CLAUDE_MATCH_GAP_SEC;
+}
+
+function toClaudeMtimeMatch(
+  candidate: ClaudeMtimeCandidate,
+  fallbackCwd: string,
+): ClaudeMtimeMatch {
+  return {
+    filePath: candidate.path,
+    sessionId: candidate.sessionId,
+    cwd: candidate.cwd ?? fallbackCwd,
+    startedAt: new Date(candidate.timestamp).getTime() / 1000,
+    lastActivityAt: candidate.mtimeMs / 1000,
+  };
+}
+
+async function hydrateClaudeMtimeMatch(
+  match: ClaudeMtimeMatch,
+  config?: MarmonitorConfig,
+): Promise<Partial<AgentSession>> {
+  upsertSessionRegistryEntry(claudeSessionRegistry, {
+    filePath: match.filePath,
+    sessionId: match.sessionId,
+    cwd: match.cwd,
+    firstSeenOffset: 0,
+    startedAt: match.startedAt,
+    source: "claude",
+    binding: basename(match.filePath).includes(match.sessionId) ? "direct" : "provisional",
+  });
+
+  const tokenData = await parseClaudeTokens(match.sessionId, match.cwd, match.startedAt, config);
+  return {
+    cwd: match.cwd,
+    sessionId: match.sessionId,
+    startedAt: match.startedAt,
+    lastActivityAt: match.lastActivityAt,
+    sessionMatched: true,
+    tokenUsage: tokenData.tokenUsage,
+    model: tokenData.model,
+  };
+}
+
+/**
+ * Select mtime matches for all same-cwd Claude PIDs in one scan cycle.
+ *
+ * A one-PID-at-a-time resolver is order-dependent: when process A's first
+ * message is delayed, it can claim process B's fresher JSONL before B is
+ * scanned. Resolve competing proposals as a batch instead. If two PIDs are
+ * within the same dominance window for one JSONL, leave it unbound rather
+ * than guessing an owner.
+ */
+export async function matchClaudeSessionsByMtime(
+  requests: ClaudeMtimeMatchRequest[],
+  config?: MarmonitorConfig,
+): Promise<Map<number, ClaudeMtimeMatch>> {
+  const matches = new Map<number, ClaudeMtimeMatch>();
+  const byCwd = new Map<string, ClaudeMtimeMatchRequest[]>();
+
+  for (const request of requests) {
+    if (!request.cwd || request.cwd === "unknown" || request.processStartedAt === undefined)
+      continue;
+    const group = byCwd.get(request.cwd) ?? [];
+    group.push(request);
+    byCwd.set(request.cwd, group);
+  }
+
+  for (const [cwd, group] of byCwd) {
+    const candidates = await listClaudeMtimeCandidates(cwd, config);
+    const proposals: Array<{
+      pid: number;
+      candidate: ClaudeMtimeCandidate;
+      deltaSec: number;
+    }> = [];
+
+    for (const request of group) {
+      const processStartedAt = request.processStartedAt;
+      if (processStartedAt === undefined) continue;
+      const scored = scoreClaudeMtimeCandidates(candidates, processStartedAt);
+      if (isConfidentClaudeMtimeMatch(scored)) {
+        proposals.push({ pid: request.pid, candidate: scored[0], deltaSec: scored[0].deltaSec });
+      }
+    }
+
+    const proposalsBySession = new Map<string, typeof proposals>();
+    for (const proposal of proposals) {
+      const contenders = proposalsBySession.get(proposal.candidate.sessionId) ?? [];
+      contenders.push(proposal);
+      proposalsBySession.set(proposal.candidate.sessionId, contenders);
+    }
+
+    for (const contenders of proposalsBySession.values()) {
+      contenders.sort((a, b) => a.deltaSec - b.deltaSec);
+      const winner = contenders[0];
+      const runnerUp = contenders[1];
+      // The owner must be clearly closer too. A one-second lstart difference
+      // is normal process-start precision noise, not enough evidence to give
+      // either PID a shared JSONL.
+      if (runnerUp && runnerUp.deltaSec - winner.deltaSec < CLAUDE_MATCH_GAP_SEC) continue;
+      matches.set(winner.pid, toClaudeMtimeMatch(winner.candidate, cwd));
+    }
+  }
+
+  return matches;
 }
 
 /**
@@ -766,6 +958,8 @@ export async function parseClaudeSession(
   processStartedAt?: number,
   config?: MarmonitorConfig,
   cycleClaimedSessionIds?: Set<string>,
+  preselectedMtimeMatch?: ClaudeMtimeMatch | null,
+  reservedSessionIds?: ReadonlySet<string>,
 ): Promise<Partial<AgentSession>> {
   // 1st: try legacy sessions/{pid}.json
   const sessionFile = getClaudeSessionRoots(config)
@@ -788,6 +982,8 @@ export async function parseClaudeSession(
           data.sessionId,
           processStartedAt,
           config,
+          cycleClaimedSessionIds,
+          reservedSessionIds,
         );
         if (override) {
           resolvedSessionId = override.sessionId;
@@ -815,6 +1011,13 @@ export async function parseClaudeSession(
         sessionMatched: true,
       };
 
+      // Legacy PID records can be stale or duplicated. Returning a sessionId
+      // that is already owned in this scan cycle would recreate the collapse
+      // the mtime path prevents.
+      if (resolvedSessionId && cycleClaimedSessionIds?.has(resolvedSessionId)) {
+        return { cwd: resolvedCwd ?? processCwd, startedAt: resolvedStartedAt };
+      }
+
       if (resolvedSessionId && resolvedCwd) {
         const tokenData = await parseClaudeTokens(
           resolvedSessionId,
@@ -833,6 +1036,13 @@ export async function parseClaudeSession(
   }
 
   // 2nd: match by JSONL mtime in project directory
+  if (preselectedMtimeMatch !== undefined) {
+    if (!preselectedMtimeMatch || cycleClaimedSessionIds?.has(preselectedMtimeMatch.sessionId)) {
+      return {};
+    }
+    return hydrateClaudeMtimeMatch(preselectedMtimeMatch, config);
+  }
+
   if (cwd && cwd !== "unknown") {
     const matched = await matchClaudeSessionByMtime(
       cwd,

--- a/src/scanner/claude.ts
+++ b/src/scanner/claude.ts
@@ -625,6 +625,18 @@ export interface ClaudeMtimeMatch {
   lastActivityAt: number;
 }
 
+export interface ClaudeMtimeBatchOptions {
+  /**
+   * Live Claude PID count per cwd, counting every process that could own a
+   * jsonl there — including PIDs this batch cannot score (unreadable lstart)
+   * and PIDs already resolved through legacy pid.json. Sole ownership judged
+   * from the batch's own group would miss those and wrongly relax.
+   */
+  liveClaudePidCountByCwd?: ReadonlyMap<string, number>;
+  /** sessionIds already owned via legacy pid.json — never propose them. */
+  reservedSessionIds?: ReadonlySet<string>;
+}
+
 type ClaudeMtimeCandidate = {
   path: string;
   mtimeMs: number;
@@ -781,20 +793,26 @@ async function hydrateClaudeMtimeMatch(
 export async function matchClaudeSessionsByMtime(
   requests: ClaudeMtimeMatchRequest[],
   config?: MarmonitorConfig,
+  options?: ClaudeMtimeBatchOptions,
 ): Promise<Map<number, ClaudeMtimeMatch>> {
   const matches = new Map<number, ClaudeMtimeMatch>();
   const byCwd = new Map<string, ClaudeMtimeMatchRequest[]>();
 
   for (const request of requests) {
-    if (!request.cwd || request.cwd === "unknown" || request.processStartedAt === undefined)
-      continue;
+    if (!request.cwd || request.cwd === "unknown") continue;
+    if (!Number.isFinite(request.processStartedAt)) continue;
     const group = byCwd.get(request.cwd) ?? [];
     group.push(request);
     byCwd.set(request.cwd, group);
   }
 
   for (const [cwd, group] of byCwd) {
-    const candidates = await listClaudeMtimeCandidates(cwd, config);
+    // A jsonl already owned through pid.json is not up for grabs; proposing it
+    // here would let a heuristic match outrank an authoritative one.
+    const candidates = (await listClaudeMtimeCandidates(cwd, config)).filter(
+      (candidate) => !options?.reservedSessionIds?.has(candidate.sessionId),
+    );
+    const liveClaudePidCount = options?.liveClaudePidCountByCwd?.get(cwd) ?? group.length;
     const proposals: Array<{
       pid: number;
       candidate: ClaudeMtimeCandidate;
@@ -807,7 +825,7 @@ export async function matchClaudeSessionsByMtime(
       const score = scoreClaudeMtimeCandidates(candidates, processStartedAt);
       // Knowing how many live PIDs share this cwd is what the batch pass buys
       // us; a per-PID resolver could never tell "sole owner" from "one of two".
-      const soleOwner = group.length === 1 && score.activeCount === 1;
+      const soleOwner = liveClaudePidCount === 1 && score.activeCount === 1;
       if (isConfidentClaudeMtimeMatch(score, soleOwner)) {
         const top = score.scored[0];
         proposals.push({ pid: request.pid, candidate: top, deltaSec: top.deltaSec });

--- a/src/scanner/claude.ts
+++ b/src/scanner/claude.ts
@@ -630,7 +630,17 @@ type ClaudeMtimeCandidate = {
   mtimeMs: number;
   sessionId: string;
   cwd?: string;
-  timestamp: string;
+  /** Absent when the first 8 lines carry no usable timestamp. */
+  timestamp?: string;
+};
+
+/** How far one jsonl must lead the runner-up by mtime to win without timestamps. */
+const CLAUDE_MTIME_FALLBACK_LEAD_MS = 5 * 60 * 1000;
+
+type ClaudeMtimeScore = {
+  scored: Array<ClaudeMtimeCandidate & { deltaSec: number }>;
+  /** Candidates modified around or after the process start — the causal pool. */
+  activeCount: number;
 };
 
 async function listClaudeMtimeCandidates(
@@ -648,14 +658,16 @@ async function listClaudeMtimeCandidates(
 
   for (const candidate of candidates) {
     const meta = await readJsonlSessionMeta(candidate.path);
-    if (!meta?.sessionId || !meta.timestamp) continue;
-    const timestampMs = new Date(meta.timestamp).getTime();
-    if (!Number.isFinite(timestampMs)) continue;
+    if (!meta?.sessionId) continue;
+    // A jsonl whose meta window carries no timestamp is still a real session —
+    // dropping it here would hide the only candidate in a cwd and leave a live
+    // PID permanently unbound. Keep it and let the mtime fallback score it.
+    const timestampMs = meta.timestamp ? new Date(meta.timestamp).getTime() : Number.NaN;
     result.push({
       ...candidate,
       sessionId: meta.sessionId,
       cwd: meta.cwd,
-      timestamp: meta.timestamp,
+      timestamp: Number.isFinite(timestampMs) ? meta.timestamp : undefined,
     });
   }
 
@@ -665,27 +677,56 @@ async function listClaudeMtimeCandidates(
 function scoreClaudeMtimeCandidates(
   candidates: ClaudeMtimeCandidate[],
   processStartedAt: number,
-): Array<ClaudeMtimeCandidate & { deltaSec: number }> {
+): ClaudeMtimeScore {
   const startMs = processStartedAt * 1000;
   const active = candidates.filter(
     (candidate) => candidate.mtimeMs >= startMs - CLAUDE_SESSION_MTIME_MATCH_SEC * 1000,
   );
   const pool = active.length > 0 ? active : candidates;
+  const activeCount = active.length;
 
-  return pool
+  const scored = pool
+    .filter((candidate) => candidate.timestamp !== undefined)
     .map((candidate) => ({
       ...candidate,
-      deltaSec: Math.abs(new Date(candidate.timestamp).getTime() / 1000 - processStartedAt),
+      deltaSec: Math.abs(
+        new Date(candidate.timestamp as string).getTime() / 1000 - processStartedAt,
+      ),
     }))
     .sort((a, b) => a.deltaSec - b.deltaSec);
+  if (scored.length > 0) return { scored, activeCount };
+
+  // No candidate carries a first-line timestamp, so proximity scoring is
+  // impossible. Mirror matchClaudeSessionByMtime's fallback: commit only when
+  // one jsonl clearly leads the rest by mtime. deltaSec 0 marks it as the sole
+  // proposal — two PIDs reaching this path for the same jsonl still tie and
+  // therefore still cancel each other out in the contention pass.
+  const byMtime = [...pool].sort((a, b) => b.mtimeMs - a.mtimeMs);
+  const latest = byMtime[0];
+  const runnerUp = byMtime[1];
+  if (!latest) return { scored: [], activeCount };
+  if (runnerUp && latest.mtimeMs - runnerUp.mtimeMs < CLAUDE_MTIME_FALLBACK_LEAD_MS)
+    return { scored: [], activeCount };
+  return { scored: [{ ...latest, deltaSec: 0 }], activeCount };
 }
 
-function isConfidentClaudeMtimeMatch(
-  scored: Array<ClaudeMtimeCandidate & { deltaSec: number }>,
-): boolean {
-  const top = scored[0];
-  if (!top || top.deltaSec > CLAUDE_MATCH_TOP_DELTA_SEC) return false;
-  const second = scored[1];
+/**
+ * Whether a scored candidate list is safe to bind.
+ *
+ * `soleOwner` means this cwd holds exactly one live Claude PID and exactly one
+ * actively-written jsonl. Collapse needs two of something, so neither failure
+ * mode this guard exists for is reachable there — and the absolute proximity
+ * cap would otherwise reject a resumed session whose jsonl predates its lstart
+ * by hours or days, which is the common shape of a long-running session.
+ * Dominance still applies in every other case; it is what actually prevents
+ * two PIDs from landing on one sessionId.
+ */
+function isConfidentClaudeMtimeMatch(score: ClaudeMtimeScore, soleOwner = false): boolean {
+  const top = score.scored[0];
+  if (!top) return false;
+  const second = score.scored[1];
+  if (soleOwner) return !second;
+  if (top.deltaSec > CLAUDE_MATCH_TOP_DELTA_SEC) return false;
   return !second || second.deltaSec - top.deltaSec >= CLAUDE_MATCH_GAP_SEC;
 }
 
@@ -697,7 +738,7 @@ function toClaudeMtimeMatch(
     filePath: candidate.path,
     sessionId: candidate.sessionId,
     cwd: candidate.cwd ?? fallbackCwd,
-    startedAt: new Date(candidate.timestamp).getTime() / 1000,
+    startedAt: candidate.timestamp ? new Date(candidate.timestamp).getTime() / 1000 : undefined,
     lastActivityAt: candidate.mtimeMs / 1000,
   };
 }
@@ -763,9 +804,13 @@ export async function matchClaudeSessionsByMtime(
     for (const request of group) {
       const processStartedAt = request.processStartedAt;
       if (processStartedAt === undefined) continue;
-      const scored = scoreClaudeMtimeCandidates(candidates, processStartedAt);
-      if (isConfidentClaudeMtimeMatch(scored)) {
-        proposals.push({ pid: request.pid, candidate: scored[0], deltaSec: scored[0].deltaSec });
+      const score = scoreClaudeMtimeCandidates(candidates, processStartedAt);
+      // Knowing how many live PIDs share this cwd is what the batch pass buys
+      // us; a per-PID resolver could never tell "sole owner" from "one of two".
+      const soleOwner = group.length === 1 && score.activeCount === 1;
+      if (isConfidentClaudeMtimeMatch(score, soleOwner)) {
+        const top = score.scored[0];
+        proposals.push({ pid: request.pid, candidate: top, deltaSec: top.deltaSec });
       }
     }
 

--- a/src/scanner/claude.ts
+++ b/src/scanner/claude.ts
@@ -19,6 +19,8 @@ import {
 } from "../output/utils.js";
 import type { AgentSession, SessionPhase, TokenUsage } from "../types.js";
 import {
+  CLAUDE_MATCH_GAP_SEC,
+  CLAUDE_MATCH_TOP_DELTA_SEC,
   CLAUDE_PHASE_RECENT_LINES,
   CLAUDE_SESSION_AMBIGUITY_GAP_SEC,
   CLAUDE_SESSION_MTIME_MATCH_SEC,
@@ -602,17 +604,26 @@ async function chooseStaleSessionOverride(
  * When processStartedAt is available, matches by JSONL creation timestamp
  * (first-line timestamp) proximity to process start time.
  * Falls back to the most recently modified JSONL when no start time is available.
+ *
+ * Fail-closed dual threshold (local issue #108): a candidate is accepted only
+ * when (a) its proximity to processStartedAt is within CLAUDE_MATCH_TOP_DELTA_SEC
+ * AND (b) it dominates the runner-up by at least CLAUDE_MATCH_GAP_SEC. When
+ * cycleClaimedSessionIds is supplied, any session already bound to another PID
+ * in this scan cycle is excluded from the candidate pool — without this, two
+ * same-cwd Claude PIDs whose lstart falls in the same second tiebreak onto the
+ * same jsonl and the daemon snapshot collapses both PIDs onto one sessionId.
  */
 export async function matchClaudeSessionByMtime(
   cwd: string,
   processStartedAt: number | undefined,
   config?: MarmonitorConfig,
+  cycleClaimedSessionIds?: Set<string>,
 ): Promise<Partial<AgentSession> | undefined> {
   const projectDirName = await findClaudeProjectDir(cwd, undefined, config);
   if (!projectDirName) return undefined;
 
   const projectRoots = getClaudeProjectRoots(config);
-  const candidates: Array<{ path: string; mtimeMs: number }> = [];
+  const candidates: Array<{ path: string; mtimeMs: number; sessionId: string }> = [];
 
   for (const projectsDir of projectRoots) {
     const projectDir = join(projectsDir, projectDirName);
@@ -621,10 +632,14 @@ export async function matchClaudeSessionByMtime(
       const files = await readdir(projectDir);
       for (const file of files) {
         if (!file.endsWith(".jsonl")) continue;
+        // Basename without ".jsonl" is the sessionId on disk; we use it to
+        // skip files already claimed by another PID in this scan cycle.
+        const sessionId = basename(file, ".jsonl");
+        if (cycleClaimedSessionIds?.has(sessionId)) continue;
         try {
           const filePath = join(projectDir, file);
           const fileStat = await stat(filePath);
-          candidates.push({ path: filePath, mtimeMs: fileStat.mtimeMs });
+          candidates.push({ path: filePath, mtimeMs: fileStat.mtimeMs, sessionId });
         } catch {
           // skip
         }
@@ -660,17 +675,25 @@ export async function matchClaudeSessionByMtime(
     }
 
     if (scored.length > 0) {
-      // Pick the JSONL whose creation time is closest to process start
       scored.sort((a, b) => a.deltaSec - b.deltaSec);
-      // Only accept if within reasonable tolerance (5 minutes)
-      if (scored[0].deltaSec <= 300) {
-        bestPath = scored[0].path;
+      const top = scored[0];
+      const second = scored[1];
+      // Require (a) top close enough AND (b) dominant over the runner-up.
+      // Without (b), two near-simultaneous Claude starts in the same cwd
+      // both land on whichever jsonl wins the tiebreak — same-sessionId
+      // collapse in the daemon snapshot. With (a)+(b), ambiguous matches
+      // are deferred to a later scan cycle (snapshot sessionId stays
+      // unset; CLI surfaces "session not ready") instead of misrouting.
+      const dominates = !second || second.deltaSec - top.deltaSec >= CLAUDE_MATCH_GAP_SEC;
+      if (top.deltaSec <= CLAUDE_MATCH_TOP_DELTA_SEC && dominates) {
+        bestPath = top.path;
       }
-    }
-
-    // Fallback: no timestamp-scored match — only commit if one file clearly leads
-    // to avoid mismatching when multiple sessions share the same cwd.
-    if (!bestPath) {
+      // Intentional fail-closed: if scored produced a result that does not
+      // pass the dual threshold, do NOT fall back to mtime — fallback is
+      // reserved for the case where no jsonl carries a timestamp at all.
+    } else {
+      // Fallback: no timestamp-scored match — only commit if one file clearly
+      // leads by mtime to avoid mismatching when multiple sessions share cwd.
       pool.sort((a, b) => b.mtimeMs - a.mtimeMs);
       const latest = pool[0];
       const second = pool[1];
@@ -733,12 +756,16 @@ export async function matchClaudeSessionByMtime(
   }
 }
 
-/** Parse Claude Code session file for enriched data */
+/** Parse Claude Code session file for enriched data.
+ *  cycleClaimedSessionIds (#108): per-scan-cycle Set of sessionIds already
+ *  bound to another PID. Threaded to matchClaudeSessionByMtime so same-cwd
+ *  multi-PID environments cannot collapse onto a single sessionId. */
 export async function parseClaudeSession(
   pid: number,
   cwd?: string,
   processStartedAt?: number,
   config?: MarmonitorConfig,
+  cycleClaimedSessionIds?: Set<string>,
 ): Promise<Partial<AgentSession>> {
   // 1st: try legacy sessions/{pid}.json
   const sessionFile = getClaudeSessionRoots(config)
@@ -807,7 +834,12 @@ export async function parseClaudeSession(
 
   // 2nd: match by JSONL mtime in project directory
   if (cwd && cwd !== "unknown") {
-    const matched = await matchClaudeSessionByMtime(cwd, processStartedAt, config);
+    const matched = await matchClaudeSessionByMtime(
+      cwd,
+      processStartedAt,
+      config,
+      cycleClaimedSessionIds,
+    );
     if (matched) return matched;
   }
 

--- a/src/scanner/index.ts
+++ b/src/scanner/index.ts
@@ -70,6 +70,23 @@ export async function scanAgents(
   const sessionRegistry = options.sessionRegistry;
   const seenPids = new Set<number>();
 
+  // #108: cycle-local guard against same-cwd Claude PID collisions. A
+  // sessionId bound to one PID is excluded from later parseClaudeSession
+  // candidate pools in the same scan cycle, so two PIDs whose lstart
+  // collides in the same second cannot collapse onto the same sessionId.
+  // The mutex serializes the matching step itself — without it, parallel
+  // promises would each race the claim Set before either could update it.
+  const cycleClaimedClaudeSessionIds = new Set<string>();
+  let claudeMatchTail: Promise<void> = Promise.resolve();
+  const withClaudeMatchLock = <T>(fn: () => Promise<T>): Promise<T> => {
+    const prev = claudeMatchTail;
+    let releaseLock: () => void = () => {};
+    claudeMatchTail = new Promise<void>((resolve) => {
+      releaseLock = resolve;
+    });
+    return prev.then(fn).finally(releaseLock);
+  };
+
   perfStart("scanAgents");
 
   // 1. Find running processes
@@ -197,7 +214,22 @@ export async function scanAgents(
       // Get cwd and start time early so mtime-based matching can use them
       const processCwd = (await getProcessCwd(proc.pid)) ?? undefined;
       const processStartTime = await getProcessStartTime(proc.pid);
-      const claudeData = await parseClaudeSession(proc.pid, processCwd, processStartTime, config);
+      // #108: serialize Claude matches and pass the cycle-claim Set in so
+      // each PID's match step sees previously bound sessionIds and skips
+      // them. parseClaudeSession adds to the Set itself is not enough —
+      // a race window between read & add would still let two PIDs win the
+      // same sessionId; the mutex closes that window.
+      const claudeData = await withClaudeMatchLock(async () => {
+        const result = await parseClaudeSession(
+          proc.pid,
+          processCwd,
+          processStartTime,
+          config,
+          cycleClaimedClaudeSessionIds,
+        );
+        if (result.sessionId) cycleClaimedClaudeSessionIds.add(result.sessionId);
+        return result;
+      });
       if (claudeData.cwd) cwd = claudeData.cwd;
       if (cwd === "unknown") cwd = processCwd ?? "unknown";
       sessionId = claudeData.sessionId;

--- a/src/scanner/index.ts
+++ b/src/scanner/index.ts
@@ -60,6 +60,24 @@ import type { ScanOptions } from "./types.js";
 
 // ─── Main Scanner ──────────────────────────────────────────────────
 
+/**
+ * Whether a Claude PID belongs in the batch mtime resolution pass (#108).
+ *
+ * The batch scores candidates against `processStartedAt` inside a known cwd,
+ * so a PID missing either is unscorable there. Such a PID must fall through to
+ * the per-PID matcher, which still has an mtime-dominance fallback — keeping it
+ * in the batch would mark it "resolved to nothing" instead. `ps -o lstart=`
+ * failures are cached for PROCESS_START_TTL_MS, so one transient failure would
+ * otherwise leave the session unbound for that entire window.
+ */
+export function isBatchableClaudeMtimeRequest<
+  T extends { cwd?: string; processStartedAt?: number },
+>(request: T | null | undefined): request is T {
+  if (!request) return false;
+  if (!request.cwd || request.cwd === "unknown") return false;
+  return request.processStartedAt !== undefined;
+}
+
 /** Scan for all running AI agent sessions */
 export async function scanAgents(
   config: MarmonitorConfig,
@@ -189,7 +207,7 @@ export async function scanAgents(
             })),
           4,
         )
-      ).flatMap((request) => (request ? [request] : []))
+      ).flatMap((request) => (isBatchableClaudeMtimeRequest(request) ? [request] : []))
     : [];
   const claudeMtimeMatches = await matchClaudeSessionsByMtime(claudeMtimeRequests, config);
   const claudeMtimePidSet = new Set(claudeMtimeRequests.map((request) => request.pid));

--- a/src/scanner/index.ts
+++ b/src/scanner/index.ts
@@ -27,6 +27,7 @@ import { claudeSessionRegistry, sessionEnrichmentCache } from "./cache.js";
 import {
   detectClaudePhase,
   getClaudeSessionRoots,
+  matchClaudeSessionsByMtime,
   parseClaudeSession,
   parseClaudeTokens,
 } from "./claude.js";
@@ -142,6 +143,61 @@ export async function scanAgents(
     : [];
   perfEnd("codex-index");
 
+  const claudeSessionRoots = getClaudeSessionRoots(config);
+  const claudeLegacySessionIds = new Set<string>();
+  if (isFullEnrichment) {
+    const legacySessionIds = await promiseAllLimited(
+      agentProcesses
+        .filter((item) => item.agentName === "Claude Code")
+        .map(({ proc }) => async () => {
+          const sessionFile = claudeSessionRoots
+            .map((root) => join(root, `${proc.pid}.json`))
+            .find((candidate) => existsSync(candidate));
+          if (!sessionFile) return undefined;
+          try {
+            const data = JSON.parse(await readFile(sessionFile, "utf-8"));
+            return typeof data.sessionId === "string" ? data.sessionId : undefined;
+          } catch {
+            return undefined;
+          }
+        }),
+      4,
+    );
+    for (const sessionId of legacySessionIds) {
+      if (sessionId) claudeLegacySessionIds.add(sessionId);
+    }
+  }
+
+  // Resolve mtime-only Claude sessions as one batch before enrichment. A
+  // per-PID resolver is order-dependent: a process whose first message is
+  // delayed can claim its sibling's fresher JSONL if it happens to lock first.
+  // Legacy PID session files keep their direct path and are not part of this
+  // heuristic batch.
+  const claudeMtimeRequests = isFullEnrichment
+    ? (
+        await promiseAllLimited(
+          agentProcesses
+            .filter(
+              ({ proc, agentName }) =>
+                agentName === "Claude Code" &&
+                !claudeSessionRoots.some((root) => existsSync(join(root, `${proc.pid}.json`))),
+            )
+            .map(({ proc }) => async () => ({
+              pid: proc.pid,
+              cwd: await getProcessCwd(proc.pid),
+              processStartedAt: await getProcessStartTime(proc.pid),
+            })),
+          4,
+        )
+      ).flatMap((request) => (request ? [request] : []))
+    : [];
+  const claudeMtimeMatches = await matchClaudeSessionsByMtime(claudeMtimeRequests, config);
+  const claudeMtimePidSet = new Set(claudeMtimeRequests.map((request) => request.pid));
+  const reservedClaudeSessionIds = new Set([
+    ...claudeLegacySessionIds,
+    ...[...claudeMtimeMatches.values()].map((match) => match.sessionId),
+  ]);
+
   // 4. Build sessions with enrichment (concurrency limited)
   const sessionPromises = agentProcesses.map(({ proc, agentName }) => async () => {
     const usage = usageMap[proc.pid];
@@ -214,6 +270,9 @@ export async function scanAgents(
       // Get cwd and start time early so mtime-based matching can use them
       const processCwd = (await getProcessCwd(proc.pid)) ?? undefined;
       const processStartTime = await getProcessStartTime(proc.pid);
+      const preselectedMtimeMatch = claudeMtimePidSet.has(proc.pid)
+        ? (claudeMtimeMatches.get(proc.pid) ?? null)
+        : undefined;
       // #108: serialize Claude matches and pass the cycle-claim Set in so
       // each PID's match step sees previously bound sessionIds and skips
       // them. parseClaudeSession adds to the Set itself is not enough —
@@ -226,6 +285,8 @@ export async function scanAgents(
           processStartTime,
           config,
           cycleClaimedClaudeSessionIds,
+          preselectedMtimeMatch,
+          reservedClaudeSessionIds,
         );
         if (result.sessionId) cycleClaimedClaudeSessionIds.add(result.sessionId);
         return result;

--- a/src/scanner/index.ts
+++ b/src/scanner/index.ts
@@ -69,13 +69,17 @@ import type { ScanOptions } from "./types.js";
  * in the batch would mark it "resolved to nothing" instead. `ps -o lstart=`
  * failures are cached for PROCESS_START_TTL_MS, so one transient failure would
  * otherwise leave the session unbound for that entire window.
+ *
+ * NaN must be rejected as firmly as undefined: getProcessStartTime derives the
+ * value with `new Date(...).getTime()`, so an unparseable `ps` line yields NaN,
+ * and a NaN deltaSec silently passes every `>` threshold comparison.
  */
 export function isBatchableClaudeMtimeRequest<
   T extends { cwd?: string; processStartedAt?: number },
 >(request: T | null | undefined): request is T {
   if (!request) return false;
   if (!request.cwd || request.cwd === "unknown") return false;
-  return request.processStartedAt !== undefined;
+  return Number.isFinite(request.processStartedAt);
 }
 
 /** Scan for all running AI agent sessions */
@@ -191,26 +195,57 @@ export async function scanAgents(
   // delayed can claim its sibling's fresher JSONL if it happens to lock first.
   // Legacy PID session files keep their direct path and are not part of this
   // heuristic batch.
-  const claudeMtimeRequests = isFullEnrichment
+  const claudeProcessMeta = isFullEnrichment
     ? (
         await promiseAllLimited(
           agentProcesses
-            .filter(
-              ({ proc, agentName }) =>
-                agentName === "Claude Code" &&
-                !claudeSessionRoots.some((root) => existsSync(join(root, `${proc.pid}.json`))),
-            )
+            .filter((item) => item.agentName === "Claude Code")
             .map(({ proc }) => async () => ({
               pid: proc.pid,
               cwd: await getProcessCwd(proc.pid),
               processStartedAt: await getProcessStartTime(proc.pid),
+              hasLegacySessionFile: claudeSessionRoots.some((root) =>
+                existsSync(join(root, `${proc.pid}.json`)),
+              ),
             })),
           4,
         )
-      ).flatMap((request) => (isBatchableClaudeMtimeRequest(request) ? [request] : []))
+      ).flatMap((meta) => (meta ? [meta] : []))
     : [];
-  const claudeMtimeMatches = await matchClaudeSessionsByMtime(claudeMtimeRequests, config);
+
+  // Ownership context covers every live Claude PID in the cwd, not just the
+  // ones this batch can score. A sibling with an unreadable lstart, or one
+  // already resolved through pid.json, still owns one of the jsonls there.
+  const liveClaudePidCountByCwd = new Map<string, number>();
+  for (const meta of claudeProcessMeta) {
+    if (!meta.cwd || meta.cwd === "unknown") continue;
+    liveClaudePidCountByCwd.set(meta.cwd, (liveClaudePidCountByCwd.get(meta.cwd) ?? 0) + 1);
+  }
+
+  const claudeMtimeRequests = claudeProcessMeta
+    .filter((meta) => !meta.hasLegacySessionFile)
+    .flatMap((meta) => (isBatchableClaudeMtimeRequest(meta) ? [meta] : []));
+  const claudeMtimeMatches = await matchClaudeSessionsByMtime(claudeMtimeRequests, config, {
+    liveClaudePidCountByCwd,
+    reservedSessionIds: claudeLegacySessionIds,
+  });
   const claudeMtimePidSet = new Set(claudeMtimeRequests.map((request) => request.pid));
+
+  // The per-PID matcher's no-start-time fallback picks the most recent jsonl,
+  // which is only defensible when nothing else in the cwd could own it. With a
+  // sibling present it would hand one pane's session to the other, so those
+  // PIDs are refused outright instead.
+  const claudeSiblingBlockedPids = new Set(
+    claudeProcessMeta
+      .filter(
+        (meta) =>
+          !meta.hasLegacySessionFile &&
+          !claudeMtimePidSet.has(meta.pid) &&
+          meta.cwd !== undefined &&
+          (liveClaudePidCountByCwd.get(meta.cwd) ?? 0) > 1,
+      )
+      .map((meta) => meta.pid),
+  );
   const reservedClaudeSessionIds = new Set([
     ...claudeLegacySessionIds,
     ...[...claudeMtimeMatches.values()].map((match) => match.sessionId),
@@ -290,7 +325,9 @@ export async function scanAgents(
       const processStartTime = await getProcessStartTime(proc.pid);
       const preselectedMtimeMatch = claudeMtimePidSet.has(proc.pid)
         ? (claudeMtimeMatches.get(proc.pid) ?? null)
-        : undefined;
+        : claudeSiblingBlockedPids.has(proc.pid)
+          ? null
+          : undefined;
       // #108: serialize Claude matches and pass the cycle-claim Set in so
       // each PID's match step sees previously bound sessionIds and skips
       // them. parseClaudeSession adds to the Set itself is not enough —

--- a/tests/claude-session-collision.test.mjs
+++ b/tests/claude-session-collision.test.mjs
@@ -367,15 +367,42 @@ describe("matchClaudeSessionByMtime — same-cwd collision (#108)", () => {
  * The daemon does not control ps-list ordering, so any assertion made here has
  * to hold for every input order — that is the whole point of the batch pass.
  */
-async function runScanCycle(requests, config) {
-  const batch = await matchClaudeSessionsByMtime(requests, config);
+async function runScanCycle(requests, config, legacySessionIds = new Set()) {
+  // Ownership census covers every live Claude PID in the cwd, including the
+  // ones the batch cannot score — sole ownership judged from the batch's own
+  // group would miss an unscorable sibling and wrongly relax.
+  const liveClaudePidCountByCwd = new Map();
+  for (const request of requests) {
+    if (!request.cwd || request.cwd === "unknown") continue;
+    liveClaudePidCountByCwd.set(request.cwd, (liveClaudePidCountByCwd.get(request.cwd) ?? 0) + 1);
+  }
+
   const batched = new Set(requests.filter(isBatchableClaudeMtimeRequest).map((r) => r.pid));
-  const reserved = new Set([...batch.values()].map((match) => match.sessionId));
+  const batch = await matchClaudeSessionsByMtime(
+    requests.filter((r) => batched.has(r.pid)),
+    config,
+    { liveClaudePidCountByCwd, reservedSessionIds: legacySessionIds },
+  );
+  // An unscorable PID may only use the per-PID fallback when nothing else in
+  // the cwd could own the jsonl it would pick.
+  const siblingBlocked = new Set(
+    requests
+      .filter((r) => !batched.has(r.pid) && r.cwd && (liveClaudePidCountByCwd.get(r.cwd) ?? 0) > 1)
+      .map((r) => r.pid),
+  );
+  const reserved = new Set([
+    ...legacySessionIds,
+    ...[...batch.values()].map((match) => match.sessionId),
+  ]);
   const claimed = new Set();
   const bindings = new Map();
 
   for (const request of requests) {
-    const preselected = batched.has(request.pid) ? (batch.get(request.pid) ?? null) : undefined;
+    const preselected = batched.has(request.pid)
+      ? (batch.get(request.pid) ?? null)
+      : siblingBlocked.has(request.pid)
+        ? null
+        : undefined;
     const result = await parseClaudeSession(
       request.pid,
       request.cwd,
@@ -506,6 +533,76 @@ describe("scan cycle orchestration — order independence (#108)", () => {
       false,
     );
     assert.equal(isBatchableClaudeMtimeRequest(undefined), false);
+  });
+
+  it("isBatchableClaudeMtimeRequest rejects a NaN start time", () => {
+    // getProcessStartTime derives the value with `new Date(...).getTime()`, so
+    // an unparseable `ps` line yields NaN. A NaN deltaSec passes every `>`
+    // threshold comparison, which would let a lone candidate be accepted.
+    assert.equal(
+      isBatchableClaudeMtimeRequest({ cwd: "/tmp/x", processStartedAt: Number.NaN }),
+      false,
+    );
+  });
+
+  it("an unscorable PID does not steal a sibling's jsonl in either order", async () => {
+    // Review #69 point 1: the batch only groups scorable PIDs, so a sibling
+    // whose lstart cannot be read used to fall outside the ownership context.
+    // The readable PID was then treated as sole owner and handed the jsonl,
+    // while the unscorable one reached the per-PID no-start-time fallback and
+    // bound the very same file — whoever took the lock first won.
+    clearAllCaches();
+    const root = join(tmpdir(), `marm-unscorable-sibling-${Date.now()}`);
+    const cwd = join(root, "shared");
+    const sid = "51d0aaaa-bbbb-cccc-dddd-51d0aaaabbbb";
+    const projectsRoot = await setupTwoSessions(root, cwd, [
+      // Resume-style: the first entry long predates both processes' lstart.
+      { sessionId: sid, isoTs: "2026-04-01T09:00:00.000Z" },
+    ]);
+    const config = makeConfig(projectsRoot);
+    const readable = { pid: 101, cwd, processStartedAt: Math.floor(Date.now() / 1000) - 3600 };
+    const unscorable = { pid: 102, cwd, processStartedAt: undefined };
+
+    try {
+      clearAllCaches();
+      const readableFirst = await runScanCycle([readable, unscorable], config);
+      clearAllCaches();
+      const unscorableFirst = await runScanCycle([unscorable, readable], config);
+
+      assert.deepEqual(
+        [readableFirst.get(101), readableFirst.get(102)],
+        [unscorableFirst.get(101), unscorableFirst.get(102)],
+        "owner must not flip with ps-list order",
+      );
+      assert.equal(readableFirst.get(101), undefined, "sole-owner relaxation must not apply");
+      assert.equal(readableFirst.get(102), undefined, "unscorable sibling must not claim it");
+    } finally {
+      clearAllCaches();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("the batch never proposes a sessionId already owned via legacy pid.json", async () => {
+    clearAllCaches();
+    const root = join(tmpdir(), `marm-legacy-reserved-batch-${Date.now()}`);
+    const cwd = join(root, "shared");
+    const owned = "6e6c1111-2222-3333-4444-6e6c11112222";
+    const projectsRoot = await setupTwoSessions(root, cwd, [
+      { sessionId: owned, isoTs: "2026-04-01T09:00:00.000Z" },
+    ]);
+    const config = makeConfig(projectsRoot);
+
+    try {
+      const batch = await matchClaudeSessionsByMtime(
+        [{ pid: 101, cwd, processStartedAt: Math.floor(Date.now() / 1000) - 3600 }],
+        config,
+        { reservedSessionIds: new Set([owned]) },
+      );
+      assert.equal(batch.size, 0, "a pid.json-owned session must stay out of the candidate pool");
+    } finally {
+      clearAllCaches();
+      await rm(root, { recursive: true, force: true });
+    }
   });
 });
 

--- a/tests/claude-session-collision.test.mjs
+++ b/tests/claude-session-collision.test.mjs
@@ -1,0 +1,224 @@
+/**
+ * Regression tests for local issue #108 — same-cwd Claude collision.
+ *
+ * Reproduces the 4 collision patterns we verified by direct repro:
+ *   1. Two processes with clearly separated lstart values → each binds to its
+ *      own jsonl (happy path; must keep working).
+ *   2. Two processes with the same lstart (1-sec ps precision) → neither
+ *      should bind, because a tiebreaker would land both on the same sessionId
+ *      in the daemon snapshot.
+ *   3. Process A's first jsonl message lags ≥30s behind its lstart while a
+ *      sibling jsonl is fresh → match must refuse rather than misroute to the
+ *      sibling. This is the exact mechanism behind the user-reported
+ *      "prefix+y copied the other pane's turn".
+ *   4. Two jsonls authored <1s apart → match must refuse (gap below the
+ *      dominance threshold).
+ *
+ * Also covers the orchestration-level invariant: a sessionId already claimed
+ * by another PID in the same scan cycle is excluded from the candidate pool.
+ */
+import assert from "node:assert/strict";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { getDefaults } from "../dist/config/index.js";
+import { claudeProjectDirCache, claudeSessionRegistry } from "../dist/scanner/cache.js";
+import { matchClaudeSessionByMtime } from "../dist/scanner/claude.js";
+
+function encodeClaudeProjectDir(cwd) {
+  return cwd.replace(/[/.]/g, "-");
+}
+
+function buildJsonl(sessionId, cwd, isoTs) {
+  return `${JSON.stringify({
+    parentUuid: null,
+    sessionId,
+    cwd,
+    timestamp: isoTs,
+    type: "user",
+    message: { content: "hi" },
+  })}\n`;
+}
+
+function makeConfig(projectsRoot) {
+  const defaults = getDefaults();
+  return {
+    ...defaults,
+    paths: { ...defaults.paths, claudeProjects: [projectsRoot] },
+  };
+}
+
+async function setupTwoSessions(root, cwd, sessions) {
+  const projectsRoot = join(root, "projects");
+  const projectDir = join(projectsRoot, encodeClaudeProjectDir(cwd));
+  await mkdir(projectDir, { recursive: true });
+  for (const { sessionId, isoTs } of sessions) {
+    await writeFile(
+      join(projectDir, `${sessionId}.jsonl`),
+      buildJsonl(sessionId, cwd, isoTs),
+      "utf-8",
+    );
+  }
+  return projectsRoot;
+}
+
+function clearAllCaches() {
+  claudeSessionRegistry.clear();
+  claudeProjectDirCache.clear();
+}
+
+describe("matchClaudeSessionByMtime — same-cwd collision (#108)", () => {
+  it("scenario 1: clearly separated lstart values → each PID binds to its own jsonl", async () => {
+    clearAllCaches();
+    const root = join(tmpdir(), `marm-collision-s1-${Date.now()}`);
+    const cwd = join(root, "shared");
+    const sidA = "11111111-aaaa-aaaa-aaaa-111111111111";
+    const sidB = "22222222-bbbb-bbbb-bbbb-222222222222";
+    const tsA = "2026-05-27T10:00:00.000Z";
+    const tsB = "2026-05-27T10:05:00.000Z"; // 5 minutes apart — clearly separated
+    const projectsRoot = await setupTwoSessions(root, cwd, [
+      { sessionId: sidA, isoTs: tsA },
+      { sessionId: sidB, isoTs: tsB },
+    ]);
+    const config = makeConfig(projectsRoot);
+    const epochA = new Date(tsA).getTime() / 1000;
+    const epochB = new Date(tsB).getTime() / 1000;
+    try {
+      const r1 = await matchClaudeSessionByMtime(cwd, epochA, config);
+      const r2 = await matchClaudeSessionByMtime(cwd, epochB, config);
+      assert.equal(r1?.sessionId, sidA, "proc_A lstart=tsA → sidA");
+      assert.equal(r2?.sessionId, sidB, "proc_B lstart=tsB → sidB");
+    } finally {
+      clearAllCaches();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("scenario 2: same-second lstart (ps precision) → no PID gets a binding", async () => {
+    clearAllCaches();
+    const root = join(tmpdir(), `marm-collision-s2-${Date.now()}`);
+    const cwd = join(root, "shared");
+    const sidA = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    const sidB = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+    const tsA = "2026-05-27T10:00:00.000Z";
+    const tsB = "2026-05-27T10:00:01.000Z"; // <1s apart → gap below threshold
+    const projectsRoot = await setupTwoSessions(root, cwd, [
+      { sessionId: sidA, isoTs: tsA },
+      { sessionId: sidB, isoTs: tsB },
+    ]);
+    const config = makeConfig(projectsRoot);
+    const sameEpoch = new Date(tsA).getTime() / 1000;
+    try {
+      const r1 = await matchClaudeSessionByMtime(cwd, sameEpoch, config);
+      const r2 = await matchClaudeSessionByMtime(cwd, sameEpoch, config);
+      assert.equal(r1, undefined, "call #1 must refuse when gap is too small");
+      assert.equal(r2, undefined, "call #2 must refuse when gap is too small");
+    } finally {
+      clearAllCaches();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("scenario 3: proc_A first message delayed 30s → orchestration cycle-claim refuses misroute", async () => {
+    // Scenario 3 (the user-reported bug) is *not* solvable by single-call
+    // dual threshold alone — proc_A sees sidB at 1s and sidA at 30s, so the
+    // closest+dominant winner is the sibling jsonl. The match returns sidB
+    // from proc_A's perspective in isolation, which is exactly the
+    // misrouting. The fix is the cycle-local claim Set the orchestration
+    // builds: once proc_B is bound to sidB in the same scan cycle, sidB is
+    // excluded from proc_A's candidate pool — leaving only sidA whose
+    // deltaSec=30s exceeds the top threshold → proc_A stays unbound (safer
+    // than misrouting). This test models the cycle as the daemon would.
+    clearAllCaches();
+    const root = join(tmpdir(), `marm-collision-s3-${Date.now()}`);
+    const cwd = join(root, "shared");
+    const sidA = "33333333-aaaa-aaaa-aaaa-333333333333";
+    const sidB = "44444444-bbbb-bbbb-bbbb-444444444444";
+    const tsAlate = "2026-05-27T10:00:30.000Z"; // proc_A first msg lags 30s
+    const tsBfresh = "2026-05-27T10:00:01.000Z"; // proc_B msg at T+1s
+    const projectsRoot = await setupTwoSessions(root, cwd, [
+      { sessionId: sidA, isoTs: tsAlate },
+      { sessionId: sidB, isoTs: tsBfresh },
+    ]);
+    const config = makeConfig(projectsRoot);
+    const procAEpoch = new Date("2026-05-27T10:00:00.000Z").getTime() / 1000;
+    const procBEpoch = new Date("2026-05-27T10:00:00.000Z").getTime() / 1000 + 1;
+    try {
+      const claimed = new Set();
+      // Cycle step 1: proc_B matches first (closest to its lstart) → sidB.
+      const rB = await matchClaudeSessionByMtime(cwd, procBEpoch, config, claimed);
+      assert.equal(rB?.sessionId, sidB, "proc_B should bind sidB");
+      if (rB?.sessionId) claimed.add(rB.sessionId);
+      // Cycle step 2: proc_A — sidB excluded by claim, only sidA left with
+      // deltaSec=30s which exceeds CLAUDE_MATCH_TOP_DELTA_SEC → unbound.
+      const rA = await matchClaudeSessionByMtime(cwd, procAEpoch, config, claimed);
+      assert.equal(rA, undefined, "proc_A must stay unbound rather than misroute to sidB");
+    } finally {
+      clearAllCaches();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("scenario 4: two jsonls <1s apart → refuse (gap below dominance threshold)", async () => {
+    clearAllCaches();
+    const root = join(tmpdir(), `marm-collision-s4-${Date.now()}`);
+    const cwd = join(root, "shared");
+    const sidA = "55555555-aaaa-aaaa-aaaa-555555555555";
+    const sidB = "66666666-bbbb-bbbb-bbbb-666666666666";
+    const tsA = "2026-05-27T10:00:00.500Z";
+    const tsB = "2026-05-27T10:00:00.700Z"; // 200ms apart
+    const projectsRoot = await setupTwoSessions(root, cwd, [
+      { sessionId: sidA, isoTs: tsA },
+      { sessionId: sidB, isoTs: tsB },
+    ]);
+    const config = makeConfig(projectsRoot);
+    const procEpoch = new Date(tsA).getTime() / 1000;
+    try {
+      const r = await matchClaudeSessionByMtime(cwd, procEpoch, config);
+      // top.deltaSec≈0, second.deltaSec≈0.2 → gap=0.2s < CLAUDE_MATCH_GAP_SEC (5s).
+      assert.equal(r, undefined, "must refuse when runner-up gap < CLAUDE_MATCH_GAP_SEC");
+    } finally {
+      clearAllCaches();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("cycle-claim: a sessionId claimed by an earlier PID in the same scan cycle is excluded", async () => {
+    clearAllCaches();
+    const root = join(tmpdir(), `marm-collision-claim-${Date.now()}`);
+    const cwd = join(root, "shared");
+    const sidA = "77777777-aaaa-aaaa-aaaa-777777777777";
+    const sidB = "88888888-bbbb-bbbb-bbbb-888888888888";
+    // Two clearly-separated sessions. proc_A naturally binds to sidA.
+    // proc_B's lstart happens to also be close to sidA's timestamp (e.g. ps
+    // precision swallowed the gap). Without the cycle-claim guard, both
+    // would race for sidA. With the guard, proc_B sees sidA already taken
+    // and binds to sidB instead.
+    const tsA = "2026-05-27T10:00:00.000Z";
+    const tsB = "2026-05-27T10:10:00.000Z"; // 10 minutes apart
+    const projectsRoot = await setupTwoSessions(root, cwd, [
+      { sessionId: sidA, isoTs: tsA },
+      { sessionId: sidB, isoTs: tsB },
+    ]);
+    const config = makeConfig(projectsRoot);
+    const epochA = new Date(tsA).getTime() / 1000;
+    try {
+      const claimed = new Set();
+      const r1 = await matchClaudeSessionByMtime(cwd, epochA, config, claimed);
+      assert.equal(r1?.sessionId, sidA, "proc_A binds to sidA");
+      if (r1?.sessionId) claimed.add(r1.sessionId);
+      // proc_B's lstart is tsA-ish too — without the claim guard it would
+      // also bind to sidA. With the guard sidA is excluded, leaving only
+      // sidB (deltaSec=600s — too far to bind even by itself).
+      const r2 = await matchClaudeSessionByMtime(cwd, epochA, config, claimed);
+      assert.notEqual(r2?.sessionId, sidA, "proc_B must not collapse onto sidA");
+      // proc_B winds up unbound here (sidB is 10min away from epochA, beyond
+      // the top threshold) — that is the correct conservative outcome.
+      assert.equal(r2, undefined, "proc_B unbound is preferred over misrouting");
+    } finally {
+      clearAllCaches();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/claude-session-collision.test.mjs
+++ b/tests/claude-session-collision.test.mjs
@@ -29,6 +29,7 @@ import {
   matchClaudeSessionsByMtime,
   parseClaudeSession,
 } from "../dist/scanner/claude.js";
+import { isBatchableClaudeMtimeRequest } from "../dist/scanner/index.js";
 
 function encodeClaudeProjectDir(cwd) {
   return cwd.replace(/[/.]/g, "-");
@@ -143,7 +144,9 @@ describe("matchClaudeSessionByMtime — same-cwd collision (#108)", () => {
     // builds: once proc_B is bound to sidB in the same scan cycle, sidB is
     // excluded from proc_A's candidate pool — leaving only sidA whose
     // deltaSec=30s exceeds the top threshold → proc_A stays unbound (safer
-    // than misrouting). This test models the cycle as the daemon would.
+    // than misrouting). This test pins the *lucky* ordering only — proc_B is
+    // scanned first here. The unlucky ordering is not safe without the batch
+    // pass; see "scan cycle orchestration — order independence" below.
     clearAllCaches();
     const root = join(tmpdir(), `marm-collision-s3-${Date.now()}`);
     const cwd = join(root, "shared");
@@ -349,6 +352,273 @@ describe("matchClaudeSessionByMtime — same-cwd collision (#108)", () => {
         new Set(["active"]),
       );
       assert.equal(parsed.sessionId, "dormant", "must not override to sibling's reserved session");
+    } finally {
+      clearAllCaches();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+/**
+ * Replays one daemon scan cycle over a set of same-cwd Claude PIDs exactly the
+ * way scanAgents() does: batch mtime resolution first, then per-PID enrichment
+ * carrying the preselected match, the cycle-claim Set and the reserved Set.
+ *
+ * The daemon does not control ps-list ordering, so any assertion made here has
+ * to hold for every input order — that is the whole point of the batch pass.
+ */
+async function runScanCycle(requests, config) {
+  const batch = await matchClaudeSessionsByMtime(requests, config);
+  const batched = new Set(requests.filter(isBatchableClaudeMtimeRequest).map((r) => r.pid));
+  const reserved = new Set([...batch.values()].map((match) => match.sessionId));
+  const claimed = new Set();
+  const bindings = new Map();
+
+  for (const request of requests) {
+    const preselected = batched.has(request.pid) ? (batch.get(request.pid) ?? null) : undefined;
+    const result = await parseClaudeSession(
+      request.pid,
+      request.cwd,
+      request.processStartedAt,
+      config,
+      claimed,
+      preselected,
+      reserved,
+    );
+    if (result.sessionId) claimed.add(result.sessionId);
+    bindings.set(request.pid, result.sessionId);
+  }
+
+  return bindings;
+}
+
+describe("scan cycle orchestration — order independence (#108)", () => {
+  it("scenario 3 holds in the unlucky PID order too", async () => {
+    // The single-call dual threshold does not save proc_A here: its own jsonl
+    // is 30s away while the sibling's is 1s away, so the sibling both passes
+    // the top threshold and dominates the runner-up. The cycle-claim Set only
+    // helps when proc_B happens to be scanned first — with ps-list handing us
+    // proc_A first, proc_A binds sidB and `prefix+y` copies the other pane's
+    // turn. Only the batch pass makes the outcome order-independent.
+    clearAllCaches();
+    const root = join(tmpdir(), `marm-collision-s3-order-${Date.now()}`);
+    const cwd = join(root, "shared");
+    const sidA = "33333333-aaaa-aaaa-aaaa-333333333333";
+    const sidB = "44444444-bbbb-bbbb-bbbb-444444444444";
+    const projectsRoot = await setupTwoSessions(root, cwd, [
+      { sessionId: sidA, isoTs: "2026-05-27T10:00:30.000Z" }, // proc_A's jsonl lags 30s
+      { sessionId: sidB, isoTs: "2026-05-27T10:00:01.000Z" }, // proc_B messaged at T+1s
+    ]);
+    const config = makeConfig(projectsRoot);
+    const baseEpoch = new Date("2026-05-27T10:00:00.000Z").getTime() / 1000;
+    const procA = { pid: 101, cwd, processStartedAt: baseEpoch };
+    const procB = { pid: 102, cwd, processStartedAt: baseEpoch + 1 };
+
+    try {
+      clearAllCaches();
+      const aFirst = await runScanCycle([procA, procB], config);
+      clearAllCaches();
+      const bFirst = await runScanCycle([procB, procA], config);
+
+      assert.notEqual(aFirst.get(101), sidB, "proc_A must never bind proc_B's jsonl");
+      assert.notEqual(bFirst.get(101), sidB, "proc_A must never bind proc_B's jsonl");
+      assert.deepEqual(
+        [aFirst.get(101), aFirst.get(102)],
+        [bFirst.get(101), bFirst.get(102)],
+        "cycle result must not depend on ps-list ordering",
+      );
+    } finally {
+      clearAllCaches();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("never collapses two PIDs onto one sessionId in any order", async () => {
+    clearAllCaches();
+    const root = join(tmpdir(), `marm-collision-collapse-${Date.now()}`);
+    const cwd = join(root, "shared");
+    const sidA = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    const sidB = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+    const projectsRoot = await setupTwoSessions(root, cwd, [
+      { sessionId: sidA, isoTs: "2026-05-27T10:00:00.000Z" },
+      { sessionId: sidB, isoTs: "2026-05-27T10:00:01.000Z" },
+    ]);
+    const config = makeConfig(projectsRoot);
+    // Same-second lstart — `ps -o lstart=` has one-second precision.
+    const sameEpoch = new Date("2026-05-27T10:00:00.000Z").getTime() / 1000;
+    const requests = [
+      { pid: 101, cwd, processStartedAt: sameEpoch },
+      { pid: 102, cwd, processStartedAt: sameEpoch },
+    ];
+
+    try {
+      for (const order of [requests, [...requests].reverse()]) {
+        clearAllCaches();
+        const bindings = await runScanCycle(order, config);
+        const bound = [...bindings.values()].filter(Boolean);
+        assert.equal(new Set(bound).size, bound.length, "two PIDs must not share a sessionId");
+      }
+    } finally {
+      clearAllCaches();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("a PID with no readable start time falls back to the per-PID matcher", async () => {
+    // `ps -o lstart=` failures are cached for PROCESS_START_TTL_MS. Routing
+    // such a PID into the batch would resolve it to "no match" and leave the
+    // session unbound for that whole window even when its cwd holds exactly
+    // one unambiguous jsonl.
+    clearAllCaches();
+    const root = join(tmpdir(), `marm-collision-nostart-${Date.now()}`);
+    const cwd = join(root, "solo");
+    const sid = "abcdabcd-aaaa-aaaa-aaaa-abcdabcdabcd";
+    const projectsRoot = await setupTwoSessions(root, cwd, [
+      { sessionId: sid, isoTs: new Date().toISOString() },
+    ]);
+    const config = makeConfig(projectsRoot);
+
+    try {
+      const bindings = await runScanCycle([{ pid: 201, cwd, processStartedAt: undefined }], config);
+      assert.equal(bindings.get(201), sid, "unscorable PID must still resolve its lone session");
+    } finally {
+      clearAllCaches();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("isBatchableClaudeMtimeRequest keeps unscorable requests out of the batch", () => {
+    const startedAt = 1_700_000_000;
+    assert.equal(
+      isBatchableClaudeMtimeRequest({ cwd: "/tmp/x", processStartedAt: startedAt }),
+      true,
+    );
+    assert.equal(
+      isBatchableClaudeMtimeRequest({ cwd: "/tmp/x", processStartedAt: undefined }),
+      false,
+    );
+    assert.equal(
+      isBatchableClaudeMtimeRequest({ cwd: undefined, processStartedAt: startedAt }),
+      false,
+    );
+    assert.equal(
+      isBatchableClaudeMtimeRequest({ cwd: "unknown", processStartedAt: startedAt }),
+      false,
+    );
+    assert.equal(isBatchableClaudeMtimeRequest(undefined), false);
+  });
+});
+
+/**
+ * Binding-miss minimisation (#108 follow-up).
+ *
+ * The dual threshold exists to stop two PIDs collapsing onto one sessionId.
+ * Collapse needs two of something, so when a cwd holds exactly one live Claude
+ * PID and exactly one actively-written jsonl, the absolute proximity cap only
+ * costs bindings — a resumed session's jsonl legitimately predates its lstart
+ * by hours or days. Measured on real sessions, that cap alone refused 2 of 7
+ * live PIDs whose single candidate was the correct one.
+ */
+describe("sole-owner relaxation (#108)", () => {
+  const RESUMED_TS = "2026-04-01T09:00:00.000Z"; // months before the process start
+
+  it("binds a resumed session when it is the only PID and the only jsonl", async () => {
+    clearAllCaches();
+    const root = join(tmpdir(), `marm-sole-owner-${Date.now()}`);
+    const cwd = join(root, "solo");
+    const sid = "aaaa1111-aaaa-aaaa-aaaa-aaaa11112222";
+    const projectsRoot = await setupTwoSessions(root, cwd, [{ sessionId: sid, isoTs: RESUMED_TS }]);
+    const config = makeConfig(projectsRoot);
+    const startedAt = Math.floor(Date.now() / 1000) - 3600;
+
+    try {
+      const batch = await matchClaudeSessionsByMtime(
+        [{ pid: 301, cwd, processStartedAt: startedAt }],
+        config,
+      );
+      assert.equal(batch.get(301)?.sessionId, sid, "sole owner must bind despite a huge delta");
+    } finally {
+      clearAllCaches();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not relax when a second PID shares the cwd", async () => {
+    clearAllCaches();
+    const root = join(tmpdir(), `marm-sole-owner-2pid-${Date.now()}`);
+    const cwd = join(root, "shared");
+    const sid = "bbbb1111-bbbb-bbbb-bbbb-bbbb11112222";
+    const projectsRoot = await setupTwoSessions(root, cwd, [{ sessionId: sid, isoTs: RESUMED_TS }]);
+    const config = makeConfig(projectsRoot);
+    const startedAt = Math.floor(Date.now() / 1000) - 3600;
+
+    try {
+      const batch = await matchClaudeSessionsByMtime(
+        [
+          { pid: 301, cwd, processStartedAt: startedAt },
+          { pid: 302, cwd, processStartedAt: startedAt + 1 },
+        ],
+        config,
+      );
+      assert.equal(batch.size, 0, "two PIDs over one jsonl must stay ambiguous");
+    } finally {
+      clearAllCaches();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not relax when the cwd holds a second active jsonl", async () => {
+    clearAllCaches();
+    const root = join(tmpdir(), `marm-sole-owner-2jsonl-${Date.now()}`);
+    const cwd = join(root, "solo");
+    const projectsRoot = await setupTwoSessions(root, cwd, [
+      { sessionId: "cccc1111-cccc-cccc-cccc-cccc11112222", isoTs: RESUMED_TS },
+      { sessionId: "dddd1111-dddd-dddd-dddd-dddd11112222", isoTs: "2026-04-02T09:00:00.000Z" },
+    ]);
+    const config = makeConfig(projectsRoot);
+    const startedAt = Math.floor(Date.now() / 1000) - 3600;
+
+    try {
+      const batch = await matchClaudeSessionsByMtime(
+        [{ pid: 301, cwd, processStartedAt: startedAt }],
+        config,
+      );
+      assert.equal(batch.size, 0, "an alternative jsonl means the cap must still apply");
+    } finally {
+      clearAllCaches();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("binds the sole active jsonl even when its meta window has no timestamp", async () => {
+    // Real data: 2 of 44 jsonls on this machine carry no timestamp in the meta
+    // window, and one of them belonged to a live session. Dropping such a
+    // candidate left that PID permanently unbound.
+    clearAllCaches();
+    const root = join(tmpdir(), `marm-sole-owner-nots-${Date.now()}`);
+    const cwd = join(root, "solo");
+    const sid = "eeee1111-eeee-eeee-eeee-eeee11112222";
+    const projectsRoot = join(root, "projects");
+    const projectDir = join(projectsRoot, encodeClaudeProjectDir(cwd));
+    await mkdir(projectDir, { recursive: true });
+    await writeFile(
+      join(projectDir, `${sid}.jsonl`),
+      `${JSON.stringify({ sessionId: sid, cwd, type: "user" })}\n`,
+      "utf-8",
+    );
+    const config = makeConfig(projectsRoot);
+
+    try {
+      const batch = await matchClaudeSessionsByMtime(
+        [{ pid: 301, cwd, processStartedAt: Math.floor(Date.now() / 1000) - 3600 }],
+        config,
+      );
+      assert.equal(
+        batch.get(301)?.sessionId,
+        sid,
+        "timestamp-less jsonl must still be a candidate",
+      );
+      assert.equal(batch.get(301)?.startedAt, undefined, "no timestamp means no startedAt");
     } finally {
       clearAllCaches();
       await rm(root, { recursive: true, force: true });

--- a/tests/claude-session-collision.test.mjs
+++ b/tests/claude-session-collision.test.mjs
@@ -24,7 +24,11 @@ import { join } from "node:path";
 import { describe, it } from "node:test";
 import { getDefaults } from "../dist/config/index.js";
 import { claudeProjectDirCache, claudeSessionRegistry } from "../dist/scanner/cache.js";
-import { matchClaudeSessionByMtime } from "../dist/scanner/claude.js";
+import {
+  matchClaudeSessionByMtime,
+  matchClaudeSessionsByMtime,
+  parseClaudeSession,
+} from "../dist/scanner/claude.js";
 
 function encodeClaudeProjectDir(cwd) {
   return cwd.replace(/[/.]/g, "-");
@@ -89,6 +93,16 @@ describe("matchClaudeSessionByMtime — same-cwd collision (#108)", () => {
       const r2 = await matchClaudeSessionByMtime(cwd, epochB, config);
       assert.equal(r1?.sessionId, sidA, "proc_A lstart=tsA → sidA");
       assert.equal(r2?.sessionId, sidB, "proc_B lstart=tsB → sidB");
+
+      const batch = await matchClaudeSessionsByMtime(
+        [
+          { pid: 101, cwd, processStartedAt: epochA },
+          { pid: 102, cwd, processStartedAt: epochB },
+        ],
+        config,
+      );
+      assert.equal(batch.get(101)?.sessionId, sidA);
+      assert.equal(batch.get(102)?.sessionId, sidB);
     } finally {
       clearAllCaches();
       await rm(root, { recursive: true, force: true });
@@ -160,6 +174,36 @@ describe("matchClaudeSessionByMtime — same-cwd collision (#108)", () => {
     }
   });
 
+  it("scenario 3: batch matching is input-order independent and refuses both ambiguous owners", async () => {
+    clearAllCaches();
+    const root = join(tmpdir(), `marm-collision-s3-batch-${Date.now()}`);
+    const cwd = join(root, "shared");
+    const sidA = "33333333-aaaa-aaaa-aaaa-333333333333";
+    const sidB = "44444444-bbbb-bbbb-bbbb-444444444444";
+    const projectsRoot = await setupTwoSessions(root, cwd, [
+      { sessionId: sidA, isoTs: "2026-05-27T10:00:30.000Z" },
+      { sessionId: sidB, isoTs: "2026-05-27T10:00:01.000Z" },
+    ]);
+    const config = makeConfig(projectsRoot);
+    const requests = [
+      { pid: 101, cwd, processStartedAt: new Date("2026-05-27T10:00:00.000Z").getTime() / 1000 },
+      { pid: 102, cwd, processStartedAt: new Date("2026-05-27T10:00:01.000Z").getTime() / 1000 },
+    ];
+
+    try {
+      const forward = await matchClaudeSessionsByMtime(requests, config);
+      const reverse = await matchClaudeSessionsByMtime([...requests].reverse(), config);
+      // sidB is only one second closer to PID 102 than PID 101. With
+      // lstart's one-second precision that is insufficient evidence to assign
+      // either owner, so the result must be safely identical in either order.
+      assert.equal(forward.size, 0);
+      assert.equal(reverse.size, 0);
+    } finally {
+      clearAllCaches();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("scenario 4: two jsonls <1s apart → refuse (gap below dominance threshold)", async () => {
     clearAllCaches();
     const root = join(tmpdir(), `marm-collision-s4-${Date.now()}`);
@@ -216,6 +260,95 @@ describe("matchClaudeSessionByMtime — same-cwd collision (#108)", () => {
       // proc_B winds up unbound here (sidB is 10min away from epochA, beyond
       // the top threshold) — that is the correct conservative outcome.
       assert.equal(r2, undefined, "proc_B unbound is preferred over misrouting");
+    } finally {
+      clearAllCaches();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("legacy PID metadata refuses a sessionId already claimed by another PID", async () => {
+    clearAllCaches();
+    const root = join(tmpdir(), `marm-collision-legacy-claim-${Date.now()}`);
+    const cwd = join(root, "shared");
+    const sessionsRoot = join(root, "sessions");
+    const sessionId = "99999999-aaaa-aaaa-aaaa-999999999999";
+    const startedAt = Math.floor(Date.now() / 1000);
+    await mkdir(sessionsRoot, { recursive: true });
+    await Promise.all(
+      [101, 102].map((pid) =>
+        writeFile(
+          join(sessionsRoot, `${pid}.json`),
+          JSON.stringify({ pid, cwd, sessionId, startedAt: startedAt * 1000 }),
+          "utf-8",
+        ),
+      ),
+    );
+    const defaults = getDefaults();
+    const config = {
+      ...defaults,
+      paths: { ...defaults.paths, claudeProjects: [], claudeSessions: [sessionsRoot] },
+    };
+
+    try {
+      const claimed = new Set();
+      const first = await parseClaudeSession(101, cwd, startedAt, config, claimed);
+      assert.equal(first.sessionId, sessionId);
+      claimed.add(sessionId);
+      const second = await parseClaudeSession(102, cwd, startedAt, config, claimed);
+      assert.equal(second.sessionId, undefined, "duplicate legacy PID must stay unbound");
+    } finally {
+      clearAllCaches();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("legacy stale override does not steal a sibling's reserved mtime match", async () => {
+    clearAllCaches();
+    const root = join(tmpdir(), `marm-collision-legacy-reserved-${Date.now()}`);
+    const cwd = join(root, "shared");
+    const projectsRoot = join(root, "projects");
+    const sessionsRoot = join(root, "sessions");
+    const projectDir = join(projectsRoot, encodeClaudeProjectDir(cwd));
+    const dormantPid = 101;
+    const nowSec = Math.floor(Date.now() / 1000);
+    await mkdir(projectDir, { recursive: true });
+    await mkdir(sessionsRoot, { recursive: true });
+    await writeFile(
+      join(projectDir, "active.jsonl"),
+      buildJsonl("active", cwd, new Date((nowSec - 10) * 1000).toISOString()),
+      "utf-8",
+    );
+    await writeFile(
+      join(sessionsRoot, `${dormantPid}.json`),
+      JSON.stringify({
+        pid: dormantPid,
+        cwd,
+        sessionId: "dormant",
+        startedAt: (nowSec - 3600) * 1000,
+      }),
+      "utf-8",
+    );
+    const defaults = getDefaults();
+    const config = {
+      ...defaults,
+      paths: {
+        ...defaults.paths,
+        claudeProjects: [projectsRoot],
+        claudeSessions: [sessionsRoot],
+      },
+    };
+
+    try {
+      const parsed = await parseClaudeSession(
+        dormantPid,
+        cwd,
+        nowSec - 3600,
+        config,
+        new Set(),
+        undefined,
+        new Set(["active"]),
+      );
+      assert.equal(parsed.sessionId, "dormant", "must not override to sibling's reserved session");
     } finally {
       clearAllCaches();
       await rm(root, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- Same-cwd 다중 Claude PID 가 daemon snapshot 의 `PID → sessionId` 바인딩에서 collapse 되어 `marmonitor copy-latest-turn` (tmux `prefix+y`) 가 다른 세션의 turn 을 복사하던 회귀 차단.
- 접근이 두 단계로 진행됐다. **1차**: `matchClaudeSessionByMtime` 에 dual threshold (`top.deltaSec ≤ 10s` AND `gap ≥ 5s`) + `cycleClaimedSessionIds` Set 가드. **1.5차**: 순차 매칭을 **cwd 단위 배치 매칭**으로 전환하고, 그 과정에서 생긴 바인딩 미스를 실측 기반으로 최소화.
- 최종적으로 수정 전과 동일한 매칭 정확도(live 세션 7/7)를 유지하면서 충돌 시나리오 5개를 전부 차단한다.

## Root cause
같은 cwd 세션은 전부 `~/.claude/projects/<encoded-cwd>/` 한 디렉터리에 들어가고, PID↔jsonl 을 잇는 결정적 신호가 없다.
- jsonl 메타에 PID 필드 없음
- Claude 가 jsonl fd 를 계속 잡고 있지 않음 (`lsof -p <pid> | grep -c .jsonl` → `0`) → lsof 로 못 묶음
- 남는 신호는 `ps -o lstart=` 와 jsonl 첫 엔트리 타임스탬프의 근접도뿐인데, `lstart` 는 **1초 정밀도**다

| # | 시나리오 | 수정 전 |
|---|---|---|
| 1 | lstart 1초+ 분리 | OK |
| 2 | 같은 초 lstart (ps 정밀도) | 두 PID 가 같은 sessionId 로 collapse |
| 3 | proc_A 첫 메시지 30초 지연 (`/resume`/모델 선택) | proc_A 가 proc_B 의 jsonl 로 misroute ← 사용자 보고 메커니즘 |
| 4 | 두 jsonl `firstTs` <1초 차이 | tiebreak collapse |

### 1차만으로는 시나리오 3 이 안 막힌다 (배치 도입 근거)
proc_A 관점의 후보는 sidB(delta 1s)·sidA(delta 30s) 라 **dual threshold 를 그대로 통과**한다(top 1s ≤ 10s, gap 29s ≥ 5s). `cycleClaimedSessionIds` 는 proc_B 가 먼저 스캔될 때만 구제하는데, 데몬은 ps-list 순서를 제어할 수 없다.

```
1차 PR:  fwd: 101→sidB  102→unbound     ← proc_A 가 proc_B 의 jsonl 을 가져감
         rev: 101→unbound 102→sidB      ← 순서 바꾸면 정상
```

기존 시나리오 3 테스트가 이걸 못 잡은 이유는 `matchClaudeSessionByMtime(procBEpoch)` 를 먼저 호출하도록 **운 좋은 순서를 하드코딩**해뒀기 때문이다. 배치 매칭은 sidB 에 대한 두 제안을 경합시켜 격차가 `gap` 미만이면 양쪽 다 거부하므로 순서와 무관해진다.

## Changes

### 매칭 코어
- `src/scanner/cache.ts`: `CLAUDE_MATCH_TOP_DELTA_SEC=10`, `CLAUDE_MATCH_GAP_SEC=5`
- `src/scanner/claude.ts:matchClaudeSessionByMtime`: dual threshold, `cycleClaimedSessionIds`, scored 실패 시 mtime fallback 차단
- `src/scanner/claude.ts:matchClaudeSessionsByMtime` **(신설)**: cwd 단위 배치 해석. 각 PID 가 최선 후보를 제안 → sessionId 별 경합 → 1·2위 delta 격차가 `gap` 미만이면 아무에게도 주지 않음
- `src/scanner/claude.ts:chooseStaleSessionOverride`: `cycleClaimedSessionIds` + `reservedSessionIds` 가드. legacy stale 레코드가 형제의 예약된 세션을 뺏지 못하게 함 (gemini 리뷰 반영)
- `src/scanner/index.ts:scanAgents`: 배치 선해석 → PID 별 `preselectedMtimeMatch`/`reservedSessionIds` 전파

### 바인딩 미스 최소화 (7ce2df7, 4fe53fa)
- `isBatchableClaudeMtimeRequest` **(신설)**: cwd 나 `processStartedAt` 을 못 읽은 PID 를 배치에서 제외해 개별 매처로 폴백. 배치에 남기면 "매칭 실패"로 확정되는데, `getProcessStartTime` 은 `ps` 실패를 `PROCESS_START_TTL_MS`(5분) 캐시하므로 일시적 실패 한 번이 살아있는 세션을 5분간 unbound 로 만든다
- `listClaudeMtimeCandidates`: meta 타임스탬프 없는 jsonl 을 후보에서 버리지 않고, 개별 매처와 동일한 **mtime dominance 폴백**(5분 리드)으로 채점. 실제 44개 jsonl 중 2개가 해당하고 그중 하나가 live 세션이었다
- `isConfidentClaudeMtimeMatch`: **sole-owner 완화**. cwd 의 live Claude PID 가 1개이고 active 후보도 1개면 절대 임계치를 면제하고 dominance 만 적용. collapse 는 "둘 이상"이 있어야 성립하므로 이 조건에서 안전 규칙은 미스만 만든다. resume 세션은 jsonl 첫 엔트리가 lstart 보다 수 시간~수십 일 앞서 구조적으로 전부 탈락하고 있었다
  - cwd 의 형제 수를 아는 건 **배치 패스라서 가능**하다. PID 단위 리졸버는 알 수 없었다

### 리뷰 반영 (7e99aef)
- **소유권 census** (`liveClaudePidCountByCwd`): sole-owner 판정이 배치 그룹이 아니라 **cwd 의 모든 live Claude PID** 를 기준으로 이뤄진다. `lstart` 를 못 읽어 배치에서 빠진 형제, pid.json 으로 이미 해석된 형제도 센다. 이게 없으면 `ps` 일시 실패 시 읽히는 쪽이 sole owner 로 판정돼 jsonl 을 선점하고, 형제는 개별 폴백으로 같은 파일에 도달해 **먼저 락을 잡는 쪽이 이긴다**(순서 의존 cross-pane 라우팅)
- 배치에 못 들어간 PID 는 cwd 에 형제가 있으면 `preselectedMtimeMatch = null` 로 개별 폴백까지 차단. "가장 최근 jsonl 하나 집기" 는 다른 소유자가 없을 때만 정당하다
- 배치 후보 풀에서 **legacy pid.json 이 소유한 sessionId 제외**. 휴리스틱 매칭이 authoritative 매칭을 앞지르지 못하게 함
- `isBatchableClaudeMtimeRequest` 가 `Number.isFinite` 로 NaN 도 거부. `getProcessStartTime` 은 `new Date(...).getTime()` 으로 값을 만들어 `ps` 출력이 파싱 불가하면 NaN 이 되고, NaN `deltaSec` 은 모든 `>` 임계치 비교를 통과한다

## 정확도 실측
live Claude 세션 7개에 대해 ground truth 를 Claude Code 자신이 쓰는 `~/.claude/sessions/<pid>.json` 에서 읽고, mtime 휴리스틱만 격리 호출해 대조했다.

| | correct | wrong | refused |
|---|---|---|---|
| 수정 전 | 7 | 0 | 0 |
| 1차 PR | 5 | 0 | 2 |
| 배치 커밋만 | 4 | 0 | 3 |
| **현재 (미스 최소화 후)** | **7** | **0** | **0** |

fail-closed 가 fallback 경로에서 정상 바인딩 43% 를 잃고 있었다. 원인은 (a) 경합자가 없는데도 절대 임계치를 적용해 resume 세션 2건 탈락, (b) timestamp 없는 jsonl 후보 제거로 1건 탈락. 둘 다 이 PR 에서 해소.

**미매칭이 재시도로 안 풀린다는 점 주의**: `processStartedAt` 과 jsonl 첫 타임스탬프는 둘 다 고정값이라 delta 도 고정이다. 후보 집합이 바뀌지 않는 한 매 사이클 같은 결과다.

## Test plan
- [x] `npm test` — **350/350** (신규 11건: 순서 무관성 4 + sole-owner 4 + 리뷰 반영 3)
- [x] `npm run lint` — clean
- [x] 커밋 2개 각각 독립 빌드·테스트 green (bisect 안전)
- [x] **돌연변이 테스트** — `isBatchableClaudeMtimeRequest` 를 항상 false 로 만들어 1차 PR 의 오케스트레이션을 재현하면, 기존 8개 케이스는 전부 통과하고 신규 "scenario 3 holds in the unlucky PID order too" 만 실패한다. 기존 스위트가 버그를 못 잡았음을 입증
- [x] live 세션 7개 ground truth 대조 (위 표) — 리뷰 반영 후에도 `7/0/0` 유지
- [x] 리뷰 1번 재현 → 수정 확인 (읽히는 PID + `lstart` 없는 PID, 정방향/역방향 동일 결과)
- [ ] dev 머지 후 다른 노트북에서 같은 cwd 두 Claude 띄우고 `prefix+y` 교차 검증

### 라이브 재현 관련 참고
Claude Code 2.1.233 은 `~/.claude/sessions/<pid>.json` 에 sessionId 를 직접 기록하고, 이 파일이 있으면 `parseClaudeSession` 이 legacy direct 경로에서 끝나 mtime 휴리스틱을 타지 않는다. 그래서 최신 버전 환경에서는 수정 전 코드조차 collapse 하지 않는다. **본 이슈는 pid.json 이 없거나 stale 할 때**(구버전, `/clear` 리맵, 로컬 이슈 #107) 터진다. 이 PR 이 고치는 것은 그 fallback 휴리스틱 경로다.

## Follow-up (별도 PR)
신호를 강도순으로 보면 지금은 가장 약한 신호를 주력으로 쓰고 있다.

| 신호 | 강도 | 현재 취급 |
|---|---|---|
| `sessions/<pid>.json` — PID↔sessionId 직접 기재 | 결정적 | "legacy" 취급 |
| 어느 jsonl 이 지금 쓰이고 있는가 (mtime 전진) | 인과적 | 단순 prefilter |
| lstart ↔ 첫 타임스탬프 근접도 | 약함 | **유일한 주 신호** |

- **P3 — pid.json 1급 승격**: `procStart` 필드가 `ps -o lstart=` 와 초 단위까지 일치함을 확인(UTC 표기 차이만). 교차검증하면 PID 재사용/stale 판정이 결정론이 되고 `chooseStaleSessionOverride` 추측 로직을 크게 걷어낼 수 있다
- **P2 — mtime 전진 관찰**: "같은 초 시작" 쌍의 영구 거부를 깰 수 있는 유일한 수단
- **P4 — `claude-binding-registry.json`**: 기존 2차 PR 안 (`codex-binding-registry` 패턴 복제)
- 권장 순서 P3 → P2 → P4

별건으로, `determineStatus` 가 `!sessionMatched → "Unmatched"` 이고 `marmonitor clean --kill` 이 Unmatched 를 확인 없이 SIGTERM 한다. fail-closed 미매칭이 살아있는 세션을 kill 후보로 만들 수 있어 후속 검토가 필요하다.

## Tracking
- Local: `issues/108-claude-session-collision-same-cwd.md`
- GH: closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)
