### PR TITLE
[FIX] pin LC_ALL=C for ps lstart so non-English locales do not yield NaN start times (local #112)

### DIFF
--- a/src/scanner/process.ts
+++ b/src/scanner/process.ts
@@ -16,6 +16,35 @@ import {
 
 export const execFileAsync = promisify(execFile);
 
+/**
+ * Environment for external commands whose output we parse.
+ *
+ * `ps -o lstart=` renders through LC_TIME, so a Korean or German locale emits
+ * "2026년 8월 17일 월요일 16시 27분 49초" / "Mo. 17 Aug. 16:27:49 2026" — neither
+ * of which `new Date()` can parse. Pinning the locale keeps the output in the
+ * one format our parsers were written against.
+ */
+function parseableOutputEnv(): NodeJS.ProcessEnv {
+  return { ...process.env, LC_ALL: "C" };
+}
+
+/**
+ * Parse a `ps -o lstart=` line into epoch seconds.
+ *
+ * Exported for tests: the locale that produced a given line cannot be recreated
+ * on an arbitrary CI runner, so the parser is exercised with captured output
+ * instead of a live `ps` call.
+ */
+export function parsePsLstart(raw: string): number | undefined {
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+  const parsed = new Date(trimmed).getTime();
+  // A non-C locale (or any unexpected format) yields NaN here. Returning it
+  // would poison every downstream comparison — NaN passes `>` thresholds and
+  // silently disables mtime prefilters — and the value is cached for minutes.
+  return Number.isFinite(parsed) ? parsed / 1000 : undefined;
+}
+
 /** Get process cwd via lsof (fallback for non-Claude agents) */
 export async function getProcessCwd(pid: number): Promise<string | undefined> {
   const cached = processCwdCache.get(pid);
@@ -54,9 +83,9 @@ export async function getProcessStartTime(pid: number): Promise<number | undefin
     const { stdout } = await execFileAsync("ps", ["-o", "lstart=", "-p", String(pid)], {
       encoding: "utf-8",
       timeout: 2000,
+      env: parseableOutputEnv(),
     });
-    const trimmed = stdout.trim();
-    const startedAt = trimmed ? new Date(trimmed).getTime() / 1000 : undefined;
+    const startedAt = parsePsLstart(stdout);
     processStartCache.set(pid, {
       checkedAt: Date.now(),
       startedAt,

--- a/tests/process-lstart.test.mjs
+++ b/tests/process-lstart.test.mjs
@@ -90,7 +90,10 @@ describe("getProcessStartTime pins the locale (#112)", () => {
         assert.equal(Number.isNaN(startedAt), false);
       }
     } finally {
-      if (previous === undefined) delete process.env.LC_ALL;
+      // Reflect.deleteProperty rather than `delete` — biome's noDelete would
+      // otherwise rewrite this to an assignment, and `process.env.LC_ALL =
+      // undefined` stores the string "undefined" instead of unsetting it.
+      if (previous === undefined) Reflect.deleteProperty(process.env, "LC_ALL");
       else process.env.LC_ALL = previous;
     }
   });

--- a/tests/process-lstart.test.mjs
+++ b/tests/process-lstart.test.mjs
@@ -1,0 +1,97 @@
+/**
+ * Regression tests for local issue #112 — `ps -o lstart=` locale dependence.
+ *
+ * `ps` renders lstart through LC_TIME, so a non-English locale emits a string
+ * `new Date()` cannot parse. The resulting NaN used to flow into
+ * processStartedAt, where it is cached for PROCESS_START_TTL_MS and silently
+ * corrupts every downstream comparison: `NaN > threshold` is false so bounds
+ * checks pass, and `mtimeMs >= NaN - window` is false so mtime prefilters
+ * select nothing.
+ *
+ * The live `ps` call is now pinned to LC_ALL=C. The parser is tested against
+ * captured output because a CI runner may not have any given locale installed.
+ */
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { describe, it } from "node:test";
+import { promisify } from "node:util";
+import { getProcessStartTime, parsePsLstart } from "../dist/scanner/process.js";
+
+const execFileAsync = promisify(execFile);
+
+describe("parsePsLstart (#112)", () => {
+  it("parses the C locale format ps is pinned to", () => {
+    const parsed = parsePsLstart("Mon Aug 17 16:27:49 2026");
+    assert.equal(typeof parsed, "number");
+    assert.ok(Number.isFinite(parsed));
+    assert.equal(new Date(parsed * 1000).getUTCFullYear(), 2026);
+  });
+
+  it("tolerates surrounding whitespace", () => {
+    assert.equal(
+      parsePsLstart("  Mon Aug 17 16:27:49 2026  "),
+      parsePsLstart("Mon Aug 17 16:27:49 2026"),
+    );
+  });
+
+  it("returns undefined for locale formats new Date() cannot parse", () => {
+    // Captured from `LC_TIME=<locale> ps -o lstart=` on macOS. Six of the eight
+    // locales sampled are unparseable; ja_JP and de_DE happen to survive V8's
+    // lenient parser, which is luck rather than a guarantee worth relying on.
+    for (const localized of [
+      "2026년 8월 17일 월요일 18시 51분 12초", // ko_KR
+      "lun. 17 août 18:51:12 2026", // fr_FR
+      "lun. 17 ago. 18:51:12 2026", // es_ES
+      "一 8月/17 18:51:12 2026", // zh_CN
+      "lun 17 ago 18:51:12 2026", // it_IT
+      "понедельник, 17 августа 2026 г. 18:51:12", // ru_RU
+    ]) {
+      assert.equal(parsePsLstart(localized), undefined, localized);
+    }
+  });
+
+  it("returns undefined rather than NaN for empty or junk output", () => {
+    assert.equal(parsePsLstart(""), undefined);
+    assert.equal(parsePsLstart("   "), undefined);
+    assert.equal(parsePsLstart("ps: process id too large: 999999"), undefined);
+  });
+
+  it("never returns NaN — NaN would pass every threshold comparison", () => {
+    for (const raw of ["", "not a date", "2026년 8월 17일 월요일 18시 51분 12초"]) {
+      const parsed = parsePsLstart(raw);
+      assert.notEqual(Number.isNaN(parsed), true, `parsePsLstart(${JSON.stringify(raw)})`);
+    }
+  });
+});
+
+describe("getProcessStartTime pins the locale (#112)", () => {
+  it("resolves a finite start time even when the caller's LC_TIME is not English", async () => {
+    // Sanity-check that the locale actually changes ps output on this host;
+    // if it does not, the assertion below would pass vacuously.
+    const { stdout: localized } = await execFileAsync(
+      "ps",
+      ["-o", "lstart=", "-p", String(process.pid)],
+      { encoding: "utf-8", env: { ...process.env, LC_ALL: "ko_KR.UTF-8" } },
+    ).catch(() => ({ stdout: "" }));
+
+    const previous = process.env.LC_ALL;
+    process.env.LC_ALL = "ko_KR.UTF-8";
+    try {
+      const startedAt = await getProcessStartTime(process.pid);
+      if (parsePsLstart(localized) === undefined && localized.trim()) {
+        // Host does localize ps output — this is the case #112 is about.
+        assert.ok(
+          Number.isFinite(startedAt),
+          "pinned LC_ALL=C must still yield a parseable start time",
+        );
+      } else {
+        // Host ignores LC_TIME (locale not installed); just assert we never
+        // hand back NaN.
+        assert.equal(Number.isNaN(startedAt), false);
+      }
+    } finally {
+      if (previous === undefined) delete process.env.LC_ALL;
+      else process.env.LC_ALL = previous;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
`getProcessStartTime` 이 `ps -o lstart=` 를 로케일 고정 없이 띄우고 출력을 `new Date()` 로 파싱한다. `ps` 는 `LC_TIME` 을 따르므로 **비영어 로케일 사용자는 모든 프로세스에서 `processStartedAt = NaN`** 이 되고, 그 NaN 이 5분간 캐시된다.

`#108` (PR #69) 에서 `isBatchableClaudeMtimeRequest` 가 NaN 을 거부하도록 막았지만 그건 fail-closed 방어이고, 근본 원인은 그대로였다. 이 PR 이 원인을 없앤다.

## Root cause
macOS 8개 로케일 실측. 기준값 `C` = `Mon Aug 17 18:51:12 2026`.

| LC_TIME | `ps -o lstart=` 출력 | `new Date()` |
|---|---|---|
| `C` | `Mon Aug 17 18:51:12 2026` | OK (기준) |
| `ja_JP` | `月 8/17 18:51:12 2026` | OK |
| `de_DE` | `Mo. 17 Aug. 18:51:12 2026` | OK |
| `ko_KR` | `2026년 8월 17일 월요일 18시 51분 12초` | **NaN** |
| `fr_FR` | `lun. 17 août 18:51:12 2026` | **NaN** |
| `es_ES` | `lun. 17 ago. 18:51:12 2026` | **NaN** |
| `zh_CN` | `一 8月/17 18:51:12 2026` | **NaN** |
| `it_IT` | `lun 17 ago 18:51:12 2026` | **NaN** |
| `ru_RU` | `понедельник, 17 августа 2026 г. 18:51:12` | **NaN** |

`ja_JP`/`de_DE` 가 통과하는 건 V8 파서가 모르는 토큰(`月`, `Mo.`, `Aug.`)을 무시하고 숫자를 주워 담기 때문이지 보장된 동작이 아니다. 일/월 순서가 다른 로케일이라면 NaN 대신 **조용히 틀린 시각**이 나올 수도 있다.

데몬은 사용자 셸 환경에서 fork 되므로 로케일을 그대로 상속받는다.

### NaN 의 파급
`processStartedAt` 은 세 곳에서 쓰인다.

1. **Claude mtime 매칭** (`#108`) — `deltaSec` 이 NaN 이면 `NaN > CLAUDE_MATCH_TOP_DELTA_SEC` 가 `false` 라 상한 검사를 **통과**한다. 더 나쁜 건 active prefilter 로, `mtimeMs >= NaN - window` 가 항상 false 라 활성 후보 풀이 비고 stale 파일까지 후보에 들어간다. 인과 신호가 조용히 사라진다
2. **Codex binding registry** — `PID × processStartedAt` 이 키라 PID 재사용 구분이 무너진다
3. **로컬 #107** 의 `procStart` 교차검증 계획 — 같은 파싱 경로를 물려받는다

## Changes
- `src/scanner/process.ts`
  - `ps` 호출에 `env: { ...process.env, LC_ALL: "C" }` 전달. 매 호출마다 생성해서 셸 환경이 바뀌어도 스냅샷이 낡지 않게 함
  - 파싱을 `parsePsLstart(raw)` 로 분리하고 `Number.isFinite` 검사 후 실패 시 `undefined` 반환. NaN 이 캐시에 들어가는 경로를 없앰
- `tests/process-lstart.test.mjs` (신규 6 케이스)

### 점검 결과
외부 명령 출력 중 **날짜를 파싱하는 곳은 `process.ts` 하나뿐**이다. `src/tmux/index.ts:133` 의 `ps -eo pid=,ppid=` 는 숫자만 읽고, `lsof -Fn` 호출들은 필드 코드라 로케일 무관.

## Test plan
- [x] `npm test` — **356/356** (신규 6건)
- [x] `npm run lint` / `tsc` — clean
- [x] `LC_ALL=ko_KR.UTF-8` 에서 `getProcessStartTime` → `NaN` 이던 것이 유한값(`1786960329`)으로 복구
- [x] `LC_ALL=ko_KR.UTF-8` 에서 live 스캔 7/7 bound, no collapse

로케일이 설치되지 않은 CI 러너를 고려해, 회귀 테스트는 캡처한 `ps` 출력으로 파서를 직접 검증한다. 라이브 `ps` 를 쓰는 케이스는 호스트가 로케일을 무시하면 "NaN 만 아니면 통과" 로 완화된다.

## Tracking
- Local: `issues/112-ps-lstart-locale-dependence.md`
- 후속: `#107` (`procStart` 교차검증) 이 이 수정을 전제로 한다

🤖 Generated with [Claude Code](https://claude.com/claude-code)
