### PR TITLE
[FIX] verify pid.json ownership via procStart instead of guessing staleness (local #107)

### DIFF
--- a/src/scanner/claude.ts
+++ b/src/scanner/claude.ts
@@ -507,6 +507,48 @@ async function readJsonlSessionMeta(
 }
 
 /**
+ * Claude Code writes `procStart` into ~/.claude/sessions/<pid>.json as a UTC
+ * calendar string ("Mon Aug 17 05:43:19 2026"). Measured against `ps -o
+ * lstart=` on every live session, it names the same instant to the second —
+ * so it identifies which *incarnation* of a PID authored the file.
+ *
+ * `new Date()` would read the string as local time, which is off by the UTC
+ * offset, hence the explicit suffix.
+ */
+export function parseClaudePidJsonProcStart(procStart: unknown): number | undefined {
+  if (typeof procStart !== "string" || !procStart.trim()) return undefined;
+  const parsed = new Date(`${procStart.trim()} UTC`).getTime();
+  return Number.isFinite(parsed) ? parsed / 1000 : undefined;
+}
+
+/** Slack for the one-second rendering precision on both sides of the compare. */
+const CLAUDE_PROC_START_TOLERANCE_SEC = 2;
+
+/**
+ * Whether a pid.json was written by the process currently holding that PID.
+ *
+ * PIDs are recycled, and the legacy lookup trusts `sessions/<pid>.json` on
+ * filename alone — a new process inheriting a dead one's PID would adopt its
+ * sessionId. Comparing `procStart` against the live start time settles that
+ * deterministically instead of inferring it from mtime staleness.
+ *
+ * Returns "unknown" when either side is missing (older Claude Code builds have
+ * no `procStart`, and `ps` can fail), so callers keep their previous behaviour
+ * rather than discarding a record they cannot judge.
+ */
+export function classifyClaudePidJsonOwnership(
+  procStart: unknown,
+  processStartedAt: number | undefined,
+): "owned" | "recycled" | "unknown" {
+  const recorded = parseClaudePidJsonProcStart(procStart);
+  if (recorded === undefined) return "unknown";
+  if (processStartedAt === undefined || !Number.isFinite(processStartedAt)) return "unknown";
+  return Math.abs(recorded - processStartedAt) <= CLAUDE_PROC_START_TOLERANCE_SEC
+    ? "owned"
+    : "recycled";
+}
+
+/**
  * Stale-session override resolver.
  *
  * Picks a non-current jsonl when the current sessionId's metadata is stale
@@ -1033,13 +1075,32 @@ export async function parseClaudeSession(
       const fileStat = await stat(sessionFile);
       const raw = await readFile(sessionFile, "utf-8");
       const data = JSON.parse(raw);
+      const ownership = classifyClaudePidJsonOwnership(data.procStart, processStartedAt);
+      // #107 A: a recycled PID inherits the dead process's file. Nothing in it
+      // describes the process we are looking at, so drop it wholesale rather
+      // than trying to repair it, and let the mtime heuristic decide.
+      if (ownership === "recycled") {
+        return resolveClaudeSessionByMtime(
+          cwd,
+          processStartedAt,
+          config,
+          cycleClaimedSessionIds,
+          preselectedMtimeMatch,
+        );
+      }
+
       const processCwd = cwd ?? data.cwd;
       const sessionStartedAt = data.startedAt ? data.startedAt / 1000 : undefined;
       let resolvedSessionId: string | undefined = data.sessionId;
       let resolvedCwd: string | undefined = data.cwd;
       let resolvedStartedAt = sessionStartedAt;
 
-      if (processCwd && processCwd !== "unknown") {
+      // #107 B: Claude Code keeps this file current — verified live by running
+      // /clear, which rewrote sessionId while leaving procStart untouched. A
+      // maintained record beats the override's "most recent jsonl in the cwd"
+      // guess, which in that same experiment picked the session /clear had just
+      // abandoned (its first entry sits 1s from lstart, the live one 34m away).
+      if (ownership !== "owned" && processCwd && processCwd !== "unknown") {
         const override = await chooseStaleSessionOverride(
           processCwd,
           data.sessionId,
@@ -1063,6 +1124,27 @@ export async function parseClaudeSession(
             source: "claude",
             binding: "provisional",
           });
+        }
+      }
+
+      // #107 C: pid.json's `startedAt` is when the CLI process came up, not
+      // when the current conversation began. /clear starts a new sessionId in
+      // the same process, so after one the two differ by however long the
+      // process had been running (34 minutes in the live experiment). Take the
+      // session's own first entry when the record is authoritative.
+      if (ownership === "owned" && resolvedSessionId && resolvedCwd) {
+        const directPath = await resolveClaudeSessionFile(
+          resolvedSessionId,
+          resolvedCwd,
+          resolvedStartedAt,
+          config,
+        );
+        const directMeta = directPath ? await readJsonlSessionMeta(directPath) : undefined;
+        const sessionBeganAt = directMeta?.timestamp
+          ? new Date(directMeta.timestamp).getTime() / 1000
+          : undefined;
+        if (sessionBeganAt !== undefined && Number.isFinite(sessionBeganAt)) {
+          resolvedStartedAt = sessionBeganAt;
         }
       }
 
@@ -1099,6 +1181,26 @@ export async function parseClaudeSession(
   }
 
   // 2nd: match by JSONL mtime in project directory
+  return resolveClaudeSessionByMtime(
+    cwd,
+    processStartedAt,
+    config,
+    cycleClaimedSessionIds,
+    preselectedMtimeMatch,
+  );
+}
+
+/**
+ * The mtime-heuristic half of parseClaudeSession, reachable both as the normal
+ * fallback and when a pid.json turns out to belong to a recycled PID (#107).
+ */
+async function resolveClaudeSessionByMtime(
+  cwd: string | undefined,
+  processStartedAt: number | undefined,
+  config?: MarmonitorConfig,
+  cycleClaimedSessionIds?: Set<string>,
+  preselectedMtimeMatch?: ClaudeMtimeMatch | null,
+): Promise<Partial<AgentSession>> {
   if (preselectedMtimeMatch !== undefined) {
     if (!preselectedMtimeMatch || cycleClaimedSessionIds?.has(preselectedMtimeMatch.sessionId)) {
       return {};

--- a/tests/claude-pid-json-ownership.test.mjs
+++ b/tests/claude-pid-json-ownership.test.mjs
@@ -1,0 +1,261 @@
+/**
+ * Regression tests for local issue #107 — pid.json ownership via `procStart`.
+ *
+ * Claude Code records `procStart` in ~/.claude/sessions/<pid>.json as a UTC
+ * calendar string. Measured against `ps -o lstart=` on every live session it
+ * names the same instant to the second, which makes it a decisive answer to
+ * "was this file written by the process currently holding this PID?".
+ *
+ * Verified live before writing these: running /clear in a session left the PID
+ * and `procStart` untouched while rewriting `sessionId` to the new session and
+ * creating its jsonl 34 minutes after process start. The mtime heuristic
+ * picked the *abandoned* pre-clear session for that PID (its first entry sits
+ * 1s from lstart), while pid.json named the live one. That is the shape these
+ * fixtures reproduce.
+ */
+import assert from "node:assert/strict";
+import { mkdir, rm, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { getDefaults } from "../dist/config/index.js";
+import { claudeProjectDirCache, claudeSessionRegistry } from "../dist/scanner/cache.js";
+import {
+  classifyClaudePidJsonOwnership,
+  parseClaudePidJsonProcStart,
+  parseClaudeSession,
+} from "../dist/scanner/claude.js";
+
+const encodeProjectDir = (cwd) => cwd.replace(/[/.]/g, "-");
+const clearCaches = () => {
+  claudeSessionRegistry.clear();
+  claudeProjectDirCache.clear();
+};
+
+/** Render an epoch as the UTC calendar string Claude Code writes. */
+function toProcStart(epochSec) {
+  return new Date(epochSec * 1000)
+    .toUTCString()
+    .replace(/^(\w+), (\d+) (\w+) (\d+) (.+) GMT$/, "$1 $3 $2 $4 $5");
+}
+
+function jsonlLine(sessionId, cwd, isoTs) {
+  return `${JSON.stringify({ parentUuid: null, sessionId, cwd, timestamp: isoTs, type: "user", message: { content: "hi" } })}\n`;
+}
+
+/**
+ * cwd with a "current" session whose jsonl predates the process (a resumed
+ * conversation, so guard F1 cannot vouch for it) and a fresher sibling that
+ * the stale override would rather pick.
+ */
+async function setupStaleShapedFixture({ pid, procStart, currentSessionId, siblingSessionId }) {
+  const root = join(tmpdir(), `marm-107-${pid}-${Date.now()}-${Math.floor(Math.random() * 1e6)}`);
+  const cwd = join(root, "work");
+  const projectsRoot = join(root, "projects");
+  const sessionsRoot = join(root, "sessions");
+  const projectDir = join(projectsRoot, encodeProjectDir(cwd));
+  await mkdir(projectDir, { recursive: true });
+  await mkdir(sessionsRoot, { recursive: true });
+
+  const nowSec = Math.floor(Date.now() / 1000);
+  const processStartedAt = nowSec - 4 * 3600;
+
+  const currentPath = join(projectDir, `${currentSessionId}.jsonl`);
+  await writeFile(
+    currentPath,
+    jsonlLine(currentSessionId, cwd, new Date((processStartedAt - 3 * 3600) * 1000).toISOString()),
+    "utf-8",
+  );
+  // Untouched for over an hour, so the override's staleGap/minLead both pass.
+  await utimes(currentPath, nowSec - 3600, nowSec - 3600);
+
+  const siblingPath = join(projectDir, `${siblingSessionId}.jsonl`);
+  await writeFile(
+    siblingPath,
+    jsonlLine(siblingSessionId, cwd, new Date((nowSec - 600) * 1000).toISOString()),
+    "utf-8",
+  );
+  await utimes(siblingPath, nowSec - 60, nowSec - 60);
+
+  await writeFile(
+    join(sessionsRoot, `${pid}.json`),
+    JSON.stringify({
+      pid,
+      sessionId: currentSessionId,
+      cwd,
+      startedAt: processStartedAt * 1000,
+      ...(procStart === null ? {} : { procStart: procStart ?? toProcStart(processStartedAt) }),
+    }),
+    "utf-8",
+  );
+
+  const defaults = getDefaults();
+  return {
+    root,
+    cwd,
+    processStartedAt,
+    config: {
+      ...defaults,
+      paths: { ...defaults.paths, claudeProjects: [projectsRoot], claudeSessions: [sessionsRoot] },
+    },
+  };
+}
+
+describe("parseClaudePidJsonProcStart (#107)", () => {
+  it("reads the recorded string as UTC, not local time", () => {
+    const parsed = parseClaudePidJsonProcStart("Mon Aug 17 05:43:19 2026");
+    assert.equal(parsed, Date.UTC(2026, 7, 17, 5, 43, 19) / 1000);
+  });
+
+  it("round-trips a real process start", () => {
+    const epoch = Math.floor(Date.UTC(2026, 7, 17, 5, 12, 18) / 1000);
+    assert.equal(parseClaudePidJsonProcStart(toProcStart(epoch)), epoch);
+  });
+
+  it("returns undefined for missing or unparseable values", () => {
+    for (const bad of [undefined, null, "", "   ", 12345, "not a date"]) {
+      assert.equal(parseClaudePidJsonProcStart(bad), undefined, String(bad));
+    }
+  });
+});
+
+describe("classifyClaudePidJsonOwnership (#107)", () => {
+  const epoch = Math.floor(Date.UTC(2026, 7, 17, 5, 43, 19) / 1000);
+  const procStart = toProcStart(epoch);
+
+  it("calls it owned when procStart matches the live start time", () => {
+    assert.equal(classifyClaudePidJsonOwnership(procStart, epoch), "owned");
+  });
+
+  it("absorbs the one-second rendering precision on both sides", () => {
+    assert.equal(classifyClaudePidJsonOwnership(procStart, epoch + 1), "owned");
+    assert.equal(classifyClaudePidJsonOwnership(procStart, epoch - 1), "owned");
+  });
+
+  it("calls it recycled when the live process started at a different time", () => {
+    assert.equal(classifyClaudePidJsonOwnership(procStart, epoch + 600), "recycled");
+  });
+
+  it("stays unknown when either side is missing", () => {
+    // Older Claude Code builds write no procStart; `ps` can also fail.
+    assert.equal(classifyClaudePidJsonOwnership(undefined, epoch), "unknown");
+    assert.equal(classifyClaudePidJsonOwnership(procStart, undefined), "unknown");
+    assert.equal(classifyClaudePidJsonOwnership(procStart, Number.NaN), "unknown");
+  });
+});
+
+describe("parseClaudeSession honours pid.json ownership (#107)", () => {
+  it("keeps the recorded session when procStart proves the file is ours", async () => {
+    // Without the ownership check the stale override fires here: the current
+    // jsonl predates the process (resumed conversation) so F1 cannot vouch for
+    // it, it has been idle long enough to look stale, and the sibling leads it
+    // by mtime. The override would hand this PID the sibling's session.
+    clearCaches();
+    const current = "c0000000-1111-2222-3333-c00000001111";
+    const sibling = "5b100000-1111-2222-3333-5b1000001111";
+    const fx = await setupStaleShapedFixture({
+      pid: 4101,
+      currentSessionId: current,
+      siblingSessionId: sibling,
+    });
+    try {
+      const parsed = await parseClaudeSession(
+        4101,
+        fx.cwd,
+        fx.processStartedAt,
+        fx.config,
+        new Set(),
+      );
+      assert.equal(parsed.sessionId, current, "authoritative pid.json must win over the override");
+    } finally {
+      clearCaches();
+      await rm(fx.root, { recursive: true, force: true });
+    }
+  });
+
+  it("still consults the override when the build wrote no procStart", async () => {
+    clearCaches();
+    const current = "c0000000-1111-2222-3333-c00000002222";
+    const sibling = "5b100000-1111-2222-3333-5b1000002222";
+    const fx = await setupStaleShapedFixture({
+      pid: 4102,
+      procStart: null,
+      currentSessionId: current,
+      siblingSessionId: sibling,
+    });
+    try {
+      const parsed = await parseClaudeSession(
+        4102,
+        fx.cwd,
+        fx.processStartedAt,
+        fx.config,
+        new Set(),
+      );
+      assert.equal(parsed.sessionId, sibling, "unknown ownership must keep the previous behaviour");
+    } finally {
+      clearCaches();
+      await rm(fx.root, { recursive: true, force: true });
+    }
+  });
+
+  it("discards a pid.json left behind by a recycled PID", async () => {
+    clearCaches();
+    const current = "c0000000-1111-2222-3333-c00000003333";
+    const sibling = "5b100000-1111-2222-3333-5b1000003333";
+    const fx = await setupStaleShapedFixture({
+      pid: 4103,
+      currentSessionId: current,
+      siblingSessionId: sibling,
+    });
+    try {
+      // The live process started an hour after whatever wrote the file, so the
+      // record describes a dead process that happened to hold this PID.
+      const parsed = await parseClaudeSession(
+        4103,
+        fx.cwd,
+        fx.processStartedAt + 3600,
+        fx.config,
+        new Set(),
+      );
+      assert.notEqual(
+        parsed.sessionId,
+        current,
+        "a recycled PID must not inherit the dead process's sessionId",
+      );
+    } finally {
+      clearCaches();
+      await rm(fx.root, { recursive: true, force: true });
+    }
+  });
+
+  it("reports when the conversation began, not when the CLI process did", async () => {
+    // /clear starts a new sessionId inside a long-running process. pid.json's
+    // startedAt still points at process start, so it must not be used verbatim.
+    clearCaches();
+    const current = "c0000000-1111-2222-3333-c00000004444";
+    const sibling = "5b100000-1111-2222-3333-5b1000004444";
+    const fx = await setupStaleShapedFixture({
+      pid: 4104,
+      currentSessionId: current,
+      siblingSessionId: sibling,
+    });
+    try {
+      const parsed = await parseClaudeSession(
+        4104,
+        fx.cwd,
+        fx.processStartedAt,
+        fx.config,
+        new Set(),
+      );
+      assert.equal(parsed.sessionId, current);
+      // The fixture's current jsonl opens three hours before process start.
+      assert.ok(
+        parsed.startedAt !== undefined && parsed.startedAt < fx.processStartedAt,
+        `startedAt ${parsed.startedAt} should come from the jsonl, not pid.json (${fx.processStartedAt})`,
+      );
+    } finally {
+      clearCaches();
+      await rm(fx.root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
`chooseStaleSessionOverride` 는 "이 `sessions/<pid>.json` 이 정상인가 stale 인가" 를 mtime 나이와 시작시각 근접도로 **추정**해왔다. 그런데 그 판정 기준이 이미 파일 안에 있었다 — Claude Code 가 기록하는 `procStart` 다.

- `procStart` 는 프로세스 시작시각과 **초 단위까지 일치**한다 (live 세션 7개 실측, delta `0.0s`)
- 따라서 "이 파일을 지금 이 PID 를 쥔 프로세스가 썼는가" 를 결정론적으로 알 수 있다
- 추정에 의존하던 판단 하나를 확인으로 바꾼다

## Root cause / 근거

### 1. `procStart` 는 프로세스 시작시각과 정확히 일치한다

live PID 7개 실측. 기준은 `LC_ALL=C ps -o lstart=`.

| pid | version | ps lstart(epoch) | `procStart`(UTC) | Δ | `startedAt` | Δ |
|---|---|---|---|---|---|---|
| 15553 | 2.1.232 | 1786708750 | 1786708750 | **0.0s** | +2.8s | |
| 17369 | 2.1.233 | 1786945908 | 1786945908 | **0.0s** | +1.4s | |
| 71285 | 2.1.233 | 1786943538 | 1786943538 | **0.0s** | +4.1s | |
| 83497 | 2.1.232 | 1786705480 | 1786705480 | **0.0s** | +4.2s | |

`startedAt` 은 세션 초기화 시각이라 1.4~4.2초 변동 오차가 있고, `procStart` 가 정확하다. **resume 세션(83497, jsonl 이 37일 전)도 프로세스 기준**이라 신원 키로 쓸 수 있다.

`procStart` 는 UTC 표기이므로 파싱 시 UTC 로 읽어야 한다. 그냥 `new Date()` 하면 TZ 오프셋만큼 어긋난다.

### 2. `/clear` 동작을 live 로 확정했다

살아있는 세션에서 `/clear` 를 실행하고 관찰:

```
PID / lstart   72031 / Mon Aug 17 14:43:19    불변
procStart      Mon Aug 17 05:43:19 2026       불변 (ps 와 Δ 0s)
sessionId      a1c777ea → bb236eec            ★ 갱신됨
startedAt      14:43:20                       불변 (프로세스 기동 시각)
새 jsonl       bb236eec, 첫 엔트리 21:17:38    프로세스 시작 +34분
```

즉 `procStart` 는 rollover 를 가로질러 안정적이고, `sessionId` 는 Claude Code 가 최신으로 유지한다. 이 이슈가 우려하던 "같은 PID, 새 sessionId 인데 pid.json 이 옛 값" 은 2.1.232+ 에서는 발생하지 않는다.

### 3. 같은 상황에서 휴리스틱은 틀린다

```
정답 (pid.json)   bb236eec   첫 엔트리가 lstart +34분
버려진 이전 세션  a1c777ea   첫 엔트리가 lstart +1초
휴리스틱 선택     a1c777ea   ← 오답
```

시작시각 근접도로 고르면 `/clear` 로 버려진 자기 옛 세션을 집는다. 유지되는 기록이 "cwd 에서 가장 최근 jsonl" 추측보다 낫다는 직접 증거다.

## Changes

`src/scanner/claude.ts`

- **`parseClaudePidJsonProcStart`** (신규): `procStart` 를 UTC 로 파싱, 실패 시 `undefined`
- **`classifyClaudePidJsonOwnership`** (신규): `owned` / `recycled` / `unknown` 판정. 1초 렌더링 정밀도를 감안해 ±2s 허용
- **A. PID 재사용 방어** — `recycled` 면 pid.json 을 통째로 버리고 mtime 휴리스틱으로 폴백. 지금까지는 파일명만 보고 신뢰했으므로, 재활용된 PID 가 죽은 프로세스의 sessionId 를 물려받을 수 있었다
- **B. 권위 우선** — `owned` 면 `chooseStaleSessionOverride` 를 건너뛴다
- **C. `startedAt` 교정** — `owned` 일 때 세션 자신의 첫 엔트리에서 가져온다. pid.json 의 `startedAt` 은 CLI 기동 시각이라 `/clear` 이후 실제 대화 시작과 어긋난다 (실측 34분)
- mtime 폴백을 `resolveClaudeSessionByMtime` 로 분리해 `recycled` 경로가 재사용

### 하위 호환
`procStart` 가 없거나(구버전 Claude Code) `ps` 가 실패하면 `unknown` 을 반환해 **기존 동작을 그대로 유지**한다. 회귀 테스트로 고정했다.

## Test plan
- [x] `npm test` — **367/367** (신규 11건), `exit=0`
- [x] `npm run lint` / `tsc` — clean, `exit=0`
- [x] **신규 테스트가 dev 에서 실패함을 확인** — 권위 있는 pid.json 이 override 를 이겨야 하는 케이스에서 dev 는 sibling 으로 오라우팅된다

```
dev 2c5058c    sessionId=5b100000   *** MISROUTED to sibling ***
#107 branch    sessionId=c0000000   correct (pid.json)
```

- [x] `#108` 회귀 없음 — 충돌 시나리오 S1~S5, 순서 무관성, legacy 형제 케이스 전부 통과
- [x] live 세션 7개 바인딩 7/7 유지, collapse 없음
- [x] `/clear` 된 세션의 `startedAt` 이 `05:43:20` → `12:17:38` 로 교정됨

## 남은 한계 (후속 `#109`)
휴리스틱만 격리해 측정하면 `/clear` 된 PID 에서 여전히 버려진 세션을 고른다 (dev 와 동일, 이 PR 이 바꾸지 않는 부분). 제품 경로는 pid.json 덕에 정답을 내지만 **pid.json 이 없거나 구버전인 환경에서는 틀린다.** 시작시각 신호로는 원리적으로 풀 수 없고, `#109`(jsonl 쓰기 활동 관찰)의 몫이다.

## Tracking
- Local: `issues/107-stale-legacy-pid-json-precedence.md`
- 선행: `#112` (`ps` 로케일 고정) — `procStart` 비교가 `getProcessStartTime` 에 의존하므로 필수였다
- 후속: `#109`, `#110`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
