### PR TITLE
[FIX] expire the Codex busy inference and keep it out of persisted activity (local #113)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,8 +35,8 @@ bin/daemon.js  ──▶  src/scanner/daemon-entry.ts ─▶ runDaemonLoop()
                        │ light scan (default 2s)  : ps-list + pidusage + 캐시 enrich
                        │ heavy scan (30s)         : Claude/Codex/Gemini jsonl·sqlite 풀 파싱
                        │
-                       ├─ /tmp/marmonitor/daemon-snapshot.json   (statusline 소비자)
-                       ├─ /tmp/marmonitor/alerts-snapshot.json
+                       ├─ $TMPDIR/marmonitor/daemon-snapshot.json (statusline 소비자)
+                       ├─ $TMPDIR/marmonitor/alerts-snapshot.json
                        ├─ ~/.config/marmonitor/session-registry.json
                        ├─ ~/.config/marmonitor/codex-binding-registry.json
                        ├─ ~/.config/marmonitor/activity-log/YYYY-MM-DD.jsonl
@@ -48,7 +48,7 @@ bin/marmonitor.js ─▶ src/cli.ts ─▶ readDaemonSnapshot() ─▶ src/outpu
 핵심 불변식:
 - **싱글 데이몬**: `start`는 ps-list로 중복 체크 후 fork. `stop`은 SIGTERM → 2s wait → SIGKILL.
 - **fail-safe**: `ps`/`lsof`/`tmux`/file IO 모든 외부 호출은 try/catch + 캐시 쓰기 실패 무시. guard는 fail-open(`{"decision":"allow"}`).
-- **statusline TTL 캐시**: `/tmp/marmonitor/statusline-<format>-<limit>-<width>.txt`. `tmux-badges`는 active panePid를 첫 줄에 박아 active 창이 바뀌면 즉시 invalidate.
+- **statusline TTL 캐시**: `$TMPDIR/marmonitor/statusline-<format>-<limit>-<width>.txt`. `tmux-badges`는 active panePid를 첫 줄에 박아 active 창이 바뀌면 즉시 invalidate.
 
 ## Code Layout
 
@@ -152,7 +152,10 @@ marmonitor setup tmux | update-integration | uninstall-integration
 ~/.config/marmonitor/settings.json     XDG 우선 (legacy: ~/.marmonitor.json)
 ~/.config/marmonitor/{session-registry,codex-binding-registry,alerts.log}
 ~/.config/marmonitor/activity-log/YYYY-MM-DD.jsonl
-/tmp/marmonitor/{daemon.pid,daemon-snapshot.json,alerts-snapshot.json,statusline-*.txt,jump-anchors.json}
+$TMPDIR/marmonitor/{daemon.pid,daemon-snapshot.json,alerts-snapshot.json,statusline-*.txt,jump-anchors.json}
+  ^ os.tmpdir() 기준. macOS는 /var/folders/.../T/marmonitor 이며 /tmp/marmonitor 가 아니다.
+  데몬 생존 확인은 daemon-snapshot.json mtime 으로 한다(light interval 2s). 데몬은
+  프로세스 타이틀을 marmonitor 로 바꾸므로 pgrep -f daemon.js 로는 잡히지 않는다.
 
 MARMONITOR_CLAUDE_HOME / MARMONITOR_CODEX_HOME    경로 루트 오버라이드
 MARMONITOR_CLAUDE_PROJECTS / _CLAUDE_SESSIONS / _CODEX_SESSIONS    PATH 형식 다중 경로

--- a/src/scanner/cache.ts
+++ b/src/scanner/cache.ts
@@ -24,6 +24,15 @@ export const CLAUDE_MATCH_GAP_SEC = 5;
 export const CLAUDE_PHASE_RECENT_LINES = 50;
 export const CODEX_PHASE_RECENT_LINES = 30;
 export const RECENT_ACTIVITY_ACTIVE_SEC = 180;
+
+/**
+ * How long a Codex "looks busy" inference (CPU burst / stdout phase) may stand
+ * in for observed activity. #090 added the inference so `last activity` would
+ * not snap back to the old rollout mtime the moment a tool finished; #113 is
+ * the same value never expiring, leaving a session that went quiet ten days
+ * ago looking recent forever. Real work keeps re-stamping within this window.
+ */
+export const CODEX_INFERRED_BUSY_TTL_SEC = RECENT_ACTIVITY_ACTIVE_SEC;
 export const STATUS_HYSTERESIS_SEC = 30;
 
 // ─── Cache Entry Types ─────────────────────────────────────────────

--- a/src/scanner/daemon-loop.ts
+++ b/src/scanner/daemon-loop.ts
@@ -202,6 +202,9 @@ export async function runDaemonLoop(
             startedAt: agent.startedAt,
             tokenUsage: agent.tokenUsage,
             lastActivityAt: agent.lastActivityAt,
+            // #113: without this, updateRegistry() falls back to the merged
+            // lastActivityAt and writes the busy inference to disk.
+            observedActivityAt: agent.observedActivityAt,
             model: agent.model,
             jsonlPath: sessionFile,
           });

--- a/src/scanner/group.ts
+++ b/src/scanner/group.ts
@@ -11,6 +11,7 @@ export function propagateWorkerStateToParent(
     | "status"
     | "phase"
     | "lastActivityAt"
+    | "observedActivityAt"
     | "lastResponseAt"
     | "startedAt"
     | "cpuPercent"
@@ -42,6 +43,18 @@ export function propagateWorkerStateToParent(
       child.lastResponseAt ?? 0,
       child.startedAt ?? 0,
     ),
+    // #113: raise the observed component alongside the merged one. Only
+    // observed times are persisted now, so leaving this behind would drop a
+    // worker's genuinely observed activity from the parent's registry record
+    // and break the `lastActivityAt = max(observed, fresh inference)`
+    // invariant. The child's own observed field is used, never its merged one.
+    observedActivityAt:
+      Math.max(
+        parent.observedActivityAt ?? 0,
+        child.observedActivityAt ?? 0,
+        child.lastResponseAt ?? 0,
+        child.startedAt ?? 0,
+      ) || undefined,
     lastResponseAt: Math.max(parent.lastResponseAt ?? 0, child.lastResponseAt ?? 0) || undefined,
   };
 }

--- a/src/scanner/index.ts
+++ b/src/scanner/index.ts
@@ -54,6 +54,7 @@ import {
   detectCliStdoutPhase,
   determineStatus,
   isInferredBusyFresh,
+  mergeObservedActivityAt,
   resolveCodexInferredBusyAt,
   resolveEffectiveActivityAt,
 } from "./status.js";
@@ -299,8 +300,9 @@ export async function scanAgents(
           const fileStat = await stat(regEntry.filePath);
           // #113: compared against a file mtime, so it must use the observed
           // time — a merged one would hide a real write behind an inference.
-          const cachedActivity =
-            (cachedEnrichment.observedActivityAt ?? cachedEnrichment.lastActivityAt ?? 0) * 1000;
+          // With no observation, 0 promotes the session, which is the safe way
+          // to be wrong for a check that only decides whether to look harder.
+          const cachedActivity = (cachedEnrichment.observedActivityAt ?? 0) * 1000;
           if (fileStat.mtimeMs > cachedActivity + 1000) {
             coldPromoted = true; // JSONL changed → force enrichment
           }
@@ -328,7 +330,7 @@ export async function scanAgents(
       // updateRegistry() call writes it to disk. The inference is carried
       // separately so its TTL keeps measuring age since the process last
       // looked busy.
-      lastActivityAt = cachedEnrichment.observedActivityAt ?? cachedEnrichment.lastActivityAt;
+      lastActivityAt = cachedEnrichment.observedActivityAt;
       inferredBusyAt = cachedEnrichment.inferredBusyAt;
     } else if (!isFullEnrichment && !cachedEnrichment) {
       // Light mode with no cache: skip expensive enrichment (lsof, JSONL, tmux)
@@ -397,8 +399,10 @@ export async function scanAgents(
         sessionMatched = true;
         sessionId = matched.id;
         startedAt = matched.timestamp;
-        lastActivityAt =
-          Math.max(cachedEnrichment?.lastActivityAt ?? 0, matched.lastActivityAt ?? 0) || undefined;
+        lastActivityAt = mergeObservedActivityAt(
+          cachedEnrichment?.observedActivityAt,
+          matched.lastActivityAt,
+        );
         model = matched.model;
         codexSessionFile = matched.filePath;
         if (matched.totalTokenUsage) {
@@ -436,8 +440,10 @@ export async function scanAgents(
           config.status.activeCpuThreshold,
           agentName,
         ) ?? cachedEnrichment?.inferredBusyAt;
-      lastActivityAt =
-        Math.max(cachedEnrichment?.observedActivityAt ?? 0, lastActivityAt ?? 0) || undefined;
+      lastActivityAt = mergeObservedActivityAt(
+        cachedEnrichment?.observedActivityAt,
+        lastActivityAt,
+      );
     } else if (agentName === "Gemini") {
       cwd = cachedEnrichment?.cwd ?? (await getProcessCwd(proc.pid)) ?? "unknown";
       const geminiData = await parseGeminiSession(cwd);
@@ -458,7 +464,7 @@ export async function scanAgents(
       // The registry only ever stores observed activity (#113), so merging it
       // monotonically is safe — rollout mtimes do not move backwards.
       const persistedLastActivityAt = sessionRegistry.get(sessionId)?.lastActivityAt;
-      lastActivityAt = Math.max(lastActivityAt ?? 0, persistedLastActivityAt ?? 0) || undefined;
+      lastActivityAt = mergeObservedActivityAt(lastActivityAt, persistedLastActivityAt);
     }
 
     // Everything above tracks observed activity; the inference is layered on

--- a/src/scanner/index.ts
+++ b/src/scanner/index.ts
@@ -53,7 +53,9 @@ import {
   applyStatusHysteresis,
   detectCliStdoutPhase,
   determineStatus,
-  refreshLastActivityAt,
+  isInferredBusyFresh,
+  resolveCodexInferredBusyAt,
+  resolveEffectiveActivityAt,
 } from "./status.js";
 
 import type { ScanOptions } from "./types.js";
@@ -270,12 +272,15 @@ export async function scanAgents(
     let phase: SessionPhase;
     let lastResponseAt: number | undefined;
     let lastActivityAt: number | undefined;
+    let inferredBusyAt: number | undefined;
     let codexSessionFile: string | undefined;
     const runtimeSource = detectRuntimeSource(agentName, proc.cmd);
     const cacheKey = `${agentName}:${proc.pid}`;
     const cachedEnrichment = sessionEnrichmentCache.get(cacheKey);
 
     // Determine session tier for differential enrichment
+    // #113: tiering intentionally uses the merged time — a process that looks
+    // busy should stay hot even while its session file lags behind.
     const tier = cachedEnrichment
       ? classifySessionTier(
           cachedEnrichment.lastActivityAt,
@@ -292,7 +297,10 @@ export async function scanAgents(
       if (regEntry?.filePath) {
         try {
           const fileStat = await stat(regEntry.filePath);
-          const cachedActivity = (cachedEnrichment.lastActivityAt ?? 0) * 1000;
+          // #113: compared against a file mtime, so it must use the observed
+          // time — a merged one would hide a real write behind an inference.
+          const cachedActivity =
+            (cachedEnrichment.observedActivityAt ?? cachedEnrichment.lastActivityAt ?? 0) * 1000;
           if (fileStat.mtimeMs > cachedActivity + 1000) {
             coldPromoted = true; // JSONL changed → force enrichment
           }
@@ -315,7 +323,13 @@ export async function scanAgents(
       sessionMatched = cachedEnrichment.sessionMatched ?? false;
       phase = cachedEnrichment.phase;
       lastResponseAt = cachedEnrichment.lastResponseAt;
-      lastActivityAt = cachedEnrichment.lastActivityAt;
+      // #113: restore the observed component, not the merged one — otherwise
+      // observedActivityAt below inherits the inference and the every-scan
+      // updateRegistry() call writes it to disk. The inference is carried
+      // separately so its TTL keeps measuring age since the process last
+      // looked busy.
+      lastActivityAt = cachedEnrichment.observedActivityAt ?? cachedEnrichment.lastActivityAt;
+      inferredBusyAt = cachedEnrichment.inferredBusyAt;
     } else if (!isFullEnrichment && !cachedEnrichment) {
       // Light mode with no cache: skip expensive enrichment (lsof, JSONL, tmux)
       sessionMatched = true;
@@ -413,15 +427,17 @@ export async function scanAgents(
         });
       }
 
-      lastActivityAt = refreshLastActivityAt(
-        lastActivityAt,
-        cpuPercent,
-        phase,
-        config.status.activeCpuThreshold,
-        agentName,
-      );
+      // #113: the CPU/phase inference is kept out of lastActivityAt so it can
+      // never be persisted or ratcheted into permanence.
+      inferredBusyAt =
+        resolveCodexInferredBusyAt(
+          cpuPercent,
+          phase,
+          config.status.activeCpuThreshold,
+          agentName,
+        ) ?? cachedEnrichment?.inferredBusyAt;
       lastActivityAt =
-        Math.max(cachedEnrichment?.lastActivityAt ?? 0, lastActivityAt ?? 0) || undefined;
+        Math.max(cachedEnrichment?.observedActivityAt ?? 0, lastActivityAt ?? 0) || undefined;
     } else if (agentName === "Gemini") {
       cwd = cachedEnrichment?.cwd ?? (await getProcessCwd(proc.pid)) ?? "unknown";
       const geminiData = await parseGeminiSession(cwd);
@@ -439,9 +455,17 @@ export async function scanAgents(
     }
 
     if (sessionId && sessionRegistry?.has(sessionId)) {
+      // The registry only ever stores observed activity (#113), so merging it
+      // monotonically is safe — rollout mtimes do not move backwards.
       const persistedLastActivityAt = sessionRegistry.get(sessionId)?.lastActivityAt;
       lastActivityAt = Math.max(lastActivityAt ?? 0, persistedLastActivityAt ?? 0) || undefined;
     }
+
+    // Everything above tracks observed activity; the inference is layered on
+    // only for reporting, and only while it is still fresh.
+    if (!isInferredBusyFresh(inferredBusyAt)) inferredBusyAt = undefined;
+    const observedActivityAt = lastActivityAt;
+    lastActivityAt = resolveEffectiveActivityAt(observedActivityAt, inferredBusyAt);
 
     if (cwd === "unknown" && isFullEnrichment) {
       cwd = cachedEnrichment?.cwd ?? (await getProcessCwd(proc.pid)) ?? "unknown";
@@ -494,6 +518,8 @@ export async function scanAgents(
       phase,
       lastResponseAt,
       lastActivityAt,
+      observedActivityAt,
+      inferredBusyAt,
       runtimeSource,
       branch,
     } as AgentSession;
@@ -511,6 +537,8 @@ export async function scanAgents(
         phase: session.phase,
         lastResponseAt: session.lastResponseAt,
         lastActivityAt: session.lastActivityAt,
+        observedActivityAt: session.observedActivityAt,
+        inferredBusyAt: session.inferredBusyAt,
         runtimeSource: session.runtimeSource,
         branch: session.branch,
       });

--- a/src/scanner/session-registry.ts
+++ b/src/scanner/session-registry.ts
@@ -30,6 +30,17 @@ export interface SessionRegistryUpdate extends Partial<AgentSession> {
   jsonlPath?: string;
 }
 
+/**
+ * The activity time safe to write to disk: the observed one when the caller
+ * tracks it at all, otherwise whatever it reported. Callers that split the two
+ * always set `observedActivityAt`, even when it is undefined, so its presence —
+ * not its value — is what says "this caller separates observation from
+ * inference" (#113).
+ */
+function resolveObservedForPersist(agent: SessionRegistryUpdate): number | undefined {
+  return "observedActivityAt" in agent ? agent.observedActivityAt : agent.lastActivityAt;
+}
+
 export function updateRegistry(
   registry: Map<string, SessionRegistryRecord>,
   agents: SessionRegistryUpdate[],
@@ -67,7 +78,10 @@ export function updateRegistry(
       // #113: persist observed activity only. lastActivityAt may carry a
       // fresh CPU/phase inference, and this Math.max is monotonic with no
       // expiry — one inferred stamp on disk would outlive the session forever.
-      const observedAt = agent.observedActivityAt ?? agent.lastActivityAt;
+      // The fallback keys on the field being absent, not on it being unset: a
+      // session with an inference but no observation reports the field as
+      // undefined, and `??` would have written the inference instead.
+      const observedAt = resolveObservedForPersist(agent);
       if (observedAt) {
         existing.lastActivityAt = Math.max(existing.lastActivityAt ?? 0, observedAt);
       }
@@ -91,7 +105,7 @@ export function updateRegistry(
           output: agent.tokenUsage?.outputTokens ?? 0,
           cache: agent.tokenUsage?.cacheReadTokens ?? 0,
         },
-        lastActivityAt: agent.observedActivityAt ?? agent.lastActivityAt,
+        lastActivityAt: resolveObservedForPersist(agent),
         model: agent.model,
       });
     }

--- a/src/scanner/session-registry.ts
+++ b/src/scanner/session-registry.ts
@@ -64,8 +64,12 @@ export function updateRegistry(
         existing.totalTokens.output = agent.tokenUsage.outputTokens ?? 0;
         existing.totalTokens.cache = agent.tokenUsage.cacheReadTokens ?? 0;
       }
-      if (agent.lastActivityAt) {
-        existing.lastActivityAt = Math.max(existing.lastActivityAt ?? 0, agent.lastActivityAt);
+      // #113: persist observed activity only. lastActivityAt may carry a
+      // fresh CPU/phase inference, and this Math.max is monotonic with no
+      // expiry — one inferred stamp on disk would outlive the session forever.
+      const observedAt = agent.observedActivityAt ?? agent.lastActivityAt;
+      if (observedAt) {
+        existing.lastActivityAt = Math.max(existing.lastActivityAt ?? 0, observedAt);
       }
       if (agent.model) existing.model = agent.model;
       if (agent.cwd) existing.cwd = agent.cwd;
@@ -87,7 +91,7 @@ export function updateRegistry(
           output: agent.tokenUsage?.outputTokens ?? 0,
           cache: agent.tokenUsage?.cacheReadTokens ?? 0,
         },
-        lastActivityAt: agent.lastActivityAt,
+        lastActivityAt: agent.observedActivityAt ?? agent.lastActivityAt,
         model: agent.model,
       });
     }

--- a/src/scanner/session-registry.ts
+++ b/src/scanner/session-registry.ts
@@ -6,6 +6,7 @@
 import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import type { AgentSession } from "../types.js";
+import { CODEX_INFERRED_BUSY_TTL_SEC } from "./cache.js";
 
 export interface SessionRegistryRecord {
   sessionId: string;
@@ -144,6 +145,9 @@ function findLatestJsonlPath(record: SessionRegistryRecord): string | undefined 
   return undefined;
 }
 
+/** Slack allowed before a record counts as drifted from its file. */
+const CLAMP_TOLERANCE_SEC = CODEX_INFERRED_BUSY_TTL_SEC;
+
 /**
  * Repair activity times that exceed what the session files can justify (#113).
  *
@@ -153,6 +157,14 @@ function findLatestJsonlPath(record: SessionRegistryRecord): string | undefined 
  * from an inference that used to be persisted without an expiry, which left
  * long-quiet sessions reporting "recent" indefinitely — for ten days in the
  * case that surfaced this.
+ *
+ * Two things keep this from firing on legitimate drift. Times are compared
+ * against the mtime rounded *up*, because stored stamps are fractional
+ * (`mtimeMs / 1000`) and a floor comparison would clamp nearly every record by
+ * under a second on every load. And a tolerance is allowed on top, because a
+ * Codex time can come from the SQLite `updated_at` that `mergeCodexIndexedSessions`
+ * maxes with the rollout mtime, so it may legitimately lead the file by a little.
+ * The drift this repairs is hours to days, so the tolerance costs nothing.
  *
  * Records whose file is gone are left alone; there is nothing to check against.
  */
@@ -170,8 +182,8 @@ export async function clampRegistryActivityToObserved(
     if (!jsonlPath) continue;
     try {
       const fileStat = await stat(jsonlPath);
-      const observedAt = Math.floor(fileStat.mtimeMs / 1000);
-      if (record.lastActivityAt > observedAt) {
+      const observedAt = Math.ceil(fileStat.mtimeMs / 1000);
+      if (record.lastActivityAt > observedAt + CLAMP_TOLERANCE_SEC) {
         record.lastActivityAt = observedAt;
         repaired++;
       }

--- a/src/scanner/session-registry.ts
+++ b/src/scanner/session-registry.ts
@@ -3,7 +3,7 @@
  * Maps sessionId → session history with PID changes and token accumulation.
  */
 
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import type { AgentSession } from "../types.js";
 
@@ -117,6 +117,57 @@ export function pruneRegistry(
   return pruned;
 }
 
+/**
+ * Newest `jsonlPath` recorded for a session, ignoring path-less history entries.
+ */
+function findLatestJsonlPath(record: SessionRegistryRecord): string | undefined {
+  const history = record.history;
+  if (!history) return undefined;
+  for (let i = history.length - 1; i >= 0; i--) {
+    const jsonlPath = history[i]?.jsonlPath;
+    if (jsonlPath) return jsonlPath;
+  }
+  return undefined;
+}
+
+/**
+ * Repair activity times that exceed what the session files can justify (#113).
+ *
+ * A record's `lastActivityAt` can never legitimately be newer than the mtime of
+ * the jsonl it was derived from: the file is written when the event happens, so
+ * the timestamp inside it is always at or before the write. Anything later came
+ * from an inference that used to be persisted without an expiry, which left
+ * long-quiet sessions reporting "recent" indefinitely — for ten days in the
+ * case that surfaced this.
+ *
+ * Records whose file is gone are left alone; there is nothing to check against.
+ */
+export async function clampRegistryActivityToObserved(
+  registry: Map<string, SessionRegistryRecord>,
+): Promise<number> {
+  let repaired = 0;
+  for (const record of registry.values()) {
+    if (record.lastActivityAt === undefined) continue;
+    // Walk back to the newest entry that actually carries a path. Only the
+    // heavy-scan writer records one, so the final entry is routinely a
+    // path-less light-scan append — anchoring on `at(-1)` alone skipped
+    // exactly the long-lived records that drift furthest from their files.
+    const jsonlPath = findLatestJsonlPath(record);
+    if (!jsonlPath) continue;
+    try {
+      const fileStat = await stat(jsonlPath);
+      const observedAt = Math.floor(fileStat.mtimeMs / 1000);
+      if (record.lastActivityAt > observedAt) {
+        record.lastActivityAt = observedAt;
+        repaired++;
+      }
+    } catch {
+      // file moved or removed — nothing to validate against
+    }
+  }
+  return repaired;
+}
+
 export async function saveRegistryToFile(
   filePath: string,
   registry: Map<string, SessionRegistryRecord>,
@@ -141,6 +192,7 @@ export async function loadRegistryFromFile(
       for (const [key, value] of Object.entries(data)) {
         registry.set(key, value as SessionRegistryRecord);
       }
+      await clampRegistryActivityToObserved(registry);
     }
   } catch {
     // missing or malformed file — start with empty registry

--- a/src/scanner/status.ts
+++ b/src/scanner/status.ts
@@ -7,29 +7,72 @@ import { detectApprovalPromptPhase } from "../output/utils.js";
 import { captureTmuxPaneOutput, resolveTmuxJumpTarget } from "../tmux/index.js";
 import type { AgentSession, SessionPhase, SessionStatus } from "../types.js";
 import {
+  CODEX_INFERRED_BUSY_TTL_SEC,
   RECENT_ACTIVITY_ACTIVE_SEC,
   STATUS_HYSTERESIS_SEC,
   stdoutHeuristicCache,
 } from "./cache.js";
 
-export function refreshLastActivityAt(
-  lastActivityAt: number | undefined,
+/**
+ * When a Codex process looks busy right now, independent of what its session
+ * files say.
+ *
+ * Codex drops to ~0% CPU the instant a burst ends and its rollout file lags,
+ * so #090 introduced this inference to stop `last activity` from snapping back
+ * to the old mtime mid-turn. It is an inference, not an observation: it must be
+ * kept apart from observed activity and given a lifetime, which is what #113
+ * was about — the stamp used to be merged into `lastActivityAt` and persisted,
+ * so one CPU blip made a long-dead session look recent forever.
+ */
+export function resolveCodexInferredBusyAt(
   cpuPercent: number,
   phase: SessionPhase | undefined,
   activeCpuThreshold: number,
   agentName: string | undefined,
   nowSec = Math.floor(Date.now() / 1000),
 ): number | undefined {
-  if (agentName !== "Codex") return lastActivityAt;
+  if (agentName !== "Codex") return undefined;
   if (
     cpuPercent > activeCpuThreshold ||
     phase === "permission" ||
     phase === "thinking" ||
     phase === "tool"
   ) {
-    return Math.max(lastActivityAt ?? 0, nowSec);
+    return nowSec;
   }
-  return lastActivityAt;
+  return undefined;
+}
+
+/**
+ * Whether a busy inference may still stand in for observed activity.
+ *
+ * A process doing real work keeps re-stamping well inside this window, so a
+ * stamp older than the TTL means it has been quiet since — and the reported
+ * time must fall back to what the session files actually show.
+ */
+export function isInferredBusyFresh(
+  inferredBusyAt: number | undefined,
+  nowSec = Math.floor(Date.now() / 1000),
+  ttlSec = CODEX_INFERRED_BUSY_TTL_SEC,
+): boolean {
+  return inferredBusyAt !== undefined && nowSec - inferredBusyAt <= ttlSec;
+}
+
+/**
+ * Activity time to report: observed activity, or a still-fresh inference when
+ * that is more recent. An expired inference is dropped so the reported time
+ * falls back to what the session files actually show.
+ */
+export function resolveEffectiveActivityAt(
+  observedActivityAt: number | undefined,
+  inferredBusyAt: number | undefined,
+  nowSec = Math.floor(Date.now() / 1000),
+  ttlSec = CODEX_INFERRED_BUSY_TTL_SEC,
+): number | undefined {
+  const usableInference = isInferredBusyFresh(inferredBusyAt, nowSec, ttlSec)
+    ? inferredBusyAt
+    : undefined;
+  return Math.max(observedActivityAt ?? 0, usableInference ?? 0) || undefined;
 }
 
 /** Determine agent activity status */

--- a/src/scanner/status.ts
+++ b/src/scanner/status.ts
@@ -44,6 +44,21 @@ export function resolveCodexInferredBusyAt(
 }
 
 /**
+ * Newest observed activity among the candidates.
+ *
+ * Every argument must be observation-only. Passing the merged `lastActivityAt`
+ * here is precisely how an inference got laundered into an observation: the
+ * merged value is stored in the enrichment cache for tiering, so reading that
+ * field back on the next scan re-promoted a CPU stamp to "observed", and from
+ * there the monotonic registry merge made it permanent.
+ */
+export function mergeObservedActivityAt(
+  ...candidates: Array<number | undefined>
+): number | undefined {
+  return Math.max(0, ...candidates.map((candidate) => candidate ?? 0)) || undefined;
+}
+
+/**
  * Whether a busy inference may still stand in for observed activity.
  *
  * A process doing real work keeps re-stamping well inside this window, so a

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,7 +45,11 @@ export interface AgentSession {
   sessionMatched?: boolean; // true if matched to a session file
   phase?: SessionPhase; // current activity phase
   lastResponseAt?: number; // epoch seconds — last AI response
-  lastActivityAt?: number; // epoch seconds — last any event
+  lastActivityAt?: number; // epoch seconds — last any event (observed, or a fresh inference)
+  /** Observed-only activity: session file / index timestamps, never an inference (#113). */
+  observedActivityAt?: number;
+  /** Epoch seconds when the process last looked busy by CPU/phase alone (#113). */
+  inferredBusyAt?: number;
   runtimeSource?: RuntimeSource;
   branch?: string; // git branch from .git/HEAD
 }

--- a/tests/codex-inferred-activity.test.mjs
+++ b/tests/codex-inferred-activity.test.mjs
@@ -1,0 +1,265 @@
+/**
+ * Regression tests for local issue #113 — the Codex busy inference used to
+ * never expire.
+ *
+ * Measured on a live session before the fix: every Codex-side source said the
+ * session last changed on 08-14 (rollout mtime, sqlite `updated_at`,
+ * `recency_at`, output tokens 0), while marmonitor reported 08-24 — ten days
+ * newer than any real signal. The value came from marmonitor itself: a CPU/
+ * phase inference stamped `now`, then four monotonic `Math.max` merges plus
+ * `session-registry.json` made it permanent.
+ *
+ * #090 introduced that inference deliberately, so `last activity` would not
+ * snap back to the old rollout mtime the moment a tool finished. The fix keeps
+ * that behaviour inside a TTL and drops the inference afterwards.
+ */
+import assert from "node:assert/strict";
+import { mkdir, rm, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { CODEX_INFERRED_BUSY_TTL_SEC } from "../dist/scanner/cache.js";
+import {
+  clampRegistryActivityToObserved,
+  updateRegistry,
+} from "../dist/scanner/session-registry.js";
+import {
+  isInferredBusyFresh,
+  resolveCodexInferredBusyAt,
+  resolveEffectiveActivityAt,
+} from "../dist/scanner/status.js";
+
+const OBSERVED = 1786717290; // 2026-08-14 23:21:30 — real rollout mtime
+const NOW = OBSERVED + 10 * 24 * 3600; // ten days later, as in the live report
+
+describe("resolveEffectiveActivityAt (#113)", () => {
+  it("prefers a fresh inference over an older observation", () => {
+    // #090's case: a tool just finished and the rollout mtime still lags.
+    const inferred = NOW - 5;
+    assert.equal(resolveEffectiveActivityAt(OBSERVED, inferred, NOW), inferred);
+  });
+
+  it("keeps the inference for the whole TTL", () => {
+    const inferred = NOW - CODEX_INFERRED_BUSY_TTL_SEC;
+    assert.equal(resolveEffectiveActivityAt(OBSERVED, inferred, NOW), inferred);
+  });
+
+  it("drops an expired inference and falls back to the observation", () => {
+    const inferred = NOW - CODEX_INFERRED_BUSY_TTL_SEC - 1;
+    assert.equal(resolveEffectiveActivityAt(OBSERVED, inferred, NOW), OBSERVED);
+  });
+
+  it("does not let a stale stamp survive for days", () => {
+    // The exact shape of the report: stamped once, quiet ever since.
+    const stampedOnce = NOW - 10 * 24 * 3600 + 60;
+    assert.equal(resolveEffectiveActivityAt(OBSERVED, stampedOnce, NOW), OBSERVED);
+  });
+
+  it("never reports an inference newer than now", () => {
+    const effective = resolveEffectiveActivityAt(OBSERVED, NOW, NOW);
+    assert.ok(effective !== undefined && effective <= NOW);
+  });
+
+  it("returns undefined when there is neither observation nor inference", () => {
+    assert.equal(resolveEffectiveActivityAt(undefined, undefined, NOW), undefined);
+  });
+
+  it("still reports an observation when nothing looks busy", () => {
+    assert.equal(resolveEffectiveActivityAt(OBSERVED, undefined, NOW), OBSERVED);
+  });
+});
+
+describe("session registry persists observed activity only (#113)", () => {
+  const base = {
+    pid: 87824,
+    agentName: "Codex",
+    cwd: "/Users/x/.ai/projects/tossbank",
+    sessionId: "019ffff2-5589-7ad2-b294-3a2024659287",
+    startedAt: OBSERVED - 12000,
+  };
+
+  it("does not write the busy inference to disk", () => {
+    const registry = new Map();
+    // What the scanner emits mid-burst: effective time is the inference.
+    updateRegistry(registry, [
+      { ...base, lastActivityAt: NOW, observedActivityAt: OBSERVED, inferredBusyAt: NOW },
+    ]);
+    assert.equal(registry.get(base.sessionId).lastActivityAt, OBSERVED);
+  });
+
+  it("does not ratchet an inference in on a later update", () => {
+    const registry = new Map();
+    updateRegistry(registry, [{ ...base, lastActivityAt: OBSERVED, observedActivityAt: OBSERVED }]);
+    updateRegistry(registry, [
+      { ...base, lastActivityAt: NOW, observedActivityAt: OBSERVED, inferredBusyAt: NOW },
+    ]);
+    assert.equal(
+      registry.get(base.sessionId).lastActivityAt,
+      OBSERVED,
+      "an inferred stamp must not become permanent on disk",
+    );
+  });
+
+  it("still advances when the observation itself moves forward", () => {
+    const registry = new Map();
+    updateRegistry(registry, [{ ...base, lastActivityAt: OBSERVED, observedActivityAt: OBSERVED }]);
+    const later = OBSERVED + 3600;
+    updateRegistry(registry, [{ ...base, lastActivityAt: later, observedActivityAt: later }]);
+    assert.equal(registry.get(base.sessionId).lastActivityAt, later);
+  });
+
+  it("falls back to lastActivityAt for agents that report no observed field", () => {
+    const registry = new Map();
+    updateRegistry(registry, [{ ...base, agentName: "Claude Code", lastActivityAt: OBSERVED }]);
+    assert.equal(registry.get(base.sessionId).lastActivityAt, OBSERVED);
+  });
+});
+
+describe("resolveCodexInferredBusyAt (#113)", () => {
+  it("is Codex-only", () => {
+    for (const agent of ["Claude Code", "Gemini", undefined]) {
+      assert.equal(
+        resolveCodexInferredBusyAt(9, "tool", 0.5, agent, NOW),
+        undefined,
+        String(agent),
+      );
+    }
+  });
+
+  it("stamps on a CPU burst or an active phase", () => {
+    assert.equal(resolveCodexInferredBusyAt(0.6, undefined, 0.5, "Codex", NOW), NOW);
+    for (const phase of ["permission", "thinking", "tool"]) {
+      assert.equal(resolveCodexInferredBusyAt(0, phase, 0.5, "Codex", NOW), NOW, phase);
+    }
+  });
+
+  it("stamps nothing for a quiet process", () => {
+    assert.equal(resolveCodexInferredBusyAt(0, "done", 0.5, "Codex", NOW), undefined);
+    assert.equal(resolveCodexInferredBusyAt(0.5, undefined, 0.5, "Codex", NOW), undefined);
+  });
+});
+
+describe("clampRegistryActivityToObserved (#113)", () => {
+  async function withJsonl(mtimeSec, run) {
+    const root = join(tmpdir(), `marm-113-${Date.now()}-${Math.floor(Math.random() * 1e6)}`);
+    await mkdir(root, { recursive: true });
+    const jsonlPath = join(root, "rollout.jsonl");
+    await writeFile(jsonlPath, "{}\n", "utf-8");
+    await utimes(jsonlPath, mtimeSec, mtimeSec);
+    try {
+      await run(jsonlPath);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  }
+
+  const record = (jsonlPath, lastActivityAt) => ({
+    sessionId: "s1",
+    agent: "Codex",
+    cwd: "/tmp/x",
+    history: [{ pid: 1, jsonlPath, startedAt: OBSERVED - 100 }],
+    totalTokens: { input: 0, output: 0, cache: 0 },
+    lastActivityAt,
+  });
+
+  it("pulls a stamp that outran the file back to the file's mtime", async () => {
+    // Exactly the state found on disk: stored ten days past the rollout mtime.
+    await withJsonl(OBSERVED, async (jsonlPath) => {
+      const registry = new Map([["s1", record(jsonlPath, NOW)]]);
+      assert.equal(await clampRegistryActivityToObserved(registry), 1);
+      assert.equal(registry.get("s1").lastActivityAt, OBSERVED);
+    });
+  });
+
+  it("leaves a value the file can justify alone", async () => {
+    await withJsonl(NOW, async (jsonlPath) => {
+      const registry = new Map([["s1", record(jsonlPath, OBSERVED)]]);
+      assert.equal(await clampRegistryActivityToObserved(registry), 0);
+      assert.equal(registry.get("s1").lastActivityAt, OBSERVED);
+    });
+  });
+
+  it("leaves records alone when the file is gone", async () => {
+    const registry = new Map([["s1", record("/nonexistent/rollout.jsonl", NOW)]]);
+    assert.equal(await clampRegistryActivityToObserved(registry), 0);
+    assert.equal(registry.get("s1").lastActivityAt, NOW);
+  });
+
+  it("skips records with no jsonl path or no activity time", async () => {
+    const noPath = record(undefined, NOW);
+    const noActivity = record("/nonexistent/x.jsonl", undefined);
+    const registry = new Map([
+      ["a", noPath],
+      ["b", noActivity],
+    ]);
+    assert.equal(await clampRegistryActivityToObserved(registry), 0);
+    assert.equal(registry.get("a").lastActivityAt, NOW);
+    assert.equal(registry.get("b").lastActivityAt, undefined);
+  });
+});
+
+describe("isInferredBusyFresh (#113)", () => {
+  it("is false without a stamp", () => {
+    assert.equal(isInferredBusyFresh(undefined, NOW), false);
+  });
+
+  it("holds through the last second of the TTL and not past it", () => {
+    assert.equal(isInferredBusyFresh(NOW - CODEX_INFERRED_BUSY_TTL_SEC, NOW), true);
+    assert.equal(isInferredBusyFresh(NOW - CODEX_INFERRED_BUSY_TTL_SEC - 1, NOW), false);
+  });
+});
+
+describe("the inference carried across scans (#113)", () => {
+  // The TTL is only reachable because scanAgents carries the stamp forward in
+  // the enrichment cache. Codex sits at ~0% CPU between bursts, so a stamp that
+  // only existed for the scan that made it would expire immediately and snap
+  // `last activity` back to the lagging rollout mtime — the #090 regression.
+  // This walks the sequence the daemon actually produces: one busy scan, then
+  // quiet ones that carry the same stamp.
+  const busyAt = NOW;
+
+  it("keeps reporting the burst while quiet scans carry the stamp", () => {
+    for (const elapsed of [2, 30, CODEX_INFERRED_BUSY_TTL_SEC]) {
+      assert.equal(
+        resolveEffectiveActivityAt(OBSERVED, busyAt, busyAt + elapsed),
+        busyAt,
+        `+${elapsed}s`,
+      );
+    }
+  });
+
+  it("falls back to the rollout mtime once the carried stamp ages out", () => {
+    assert.equal(
+      resolveEffectiveActivityAt(OBSERVED, busyAt, busyAt + CODEX_INFERRED_BUSY_TTL_SEC + 1),
+      OBSERVED,
+    );
+  });
+
+  it("advances to a real observation that lands during the burst", () => {
+    // The rollout file catches up mid-turn: observation wins once it is newer.
+    const written = busyAt + 20;
+    assert.equal(resolveEffectiveActivityAt(written, busyAt, busyAt + 30), written);
+  });
+});
+
+describe("daemon activity-collection updates (#113)", () => {
+  // daemon-loop's heavy scan pushes a second, differently shaped update into
+  // the same registry. It must carry observedActivityAt too, or updateRegistry
+  // falls back to the merged lastActivityAt and re-poisons the record.
+  const update = {
+    agentName: "Codex",
+    pid: 87824,
+    sessionId: "019ffff2-5589-7ad2-b294-3a2024659287",
+    cwd: "/Users/x/.ai/projects/tossbank",
+    startedAt: OBSERVED - 12000,
+    jsonlPath: "/Users/x/.codex/sessions/rollout.jsonl",
+  };
+
+  it("persists the observation, not the merged value", () => {
+    const registry = new Map();
+    updateRegistry(registry, [
+      { ...update, lastActivityAt: NOW, observedActivityAt: OBSERVED, inferredBusyAt: NOW },
+    ]);
+    assert.equal(registry.get(update.sessionId).lastActivityAt, OBSERVED);
+  });
+});

--- a/tests/codex-inferred-activity.test.mjs
+++ b/tests/codex-inferred-activity.test.mjs
@@ -14,17 +14,20 @@
  * that behaviour inside a TTL and drops the inference afterwards.
  */
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { mkdir, rm, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, it } from "node:test";
+import { after, before, describe, it } from "node:test";
 import { CODEX_INFERRED_BUSY_TTL_SEC } from "../dist/scanner/cache.js";
+import { propagateWorkerStateToParent } from "../dist/scanner/group.js";
 import {
   clampRegistryActivityToObserved,
   updateRegistry,
 } from "../dist/scanner/session-registry.js";
 import {
   isInferredBusyFresh,
+  mergeObservedActivityAt,
   resolveCodexInferredBusyAt,
   resolveEffectiveActivityAt,
 } from "../dist/scanner/status.js";
@@ -261,5 +264,199 @@ describe("daemon activity-collection updates (#113)", () => {
       { ...update, lastActivityAt: NOW, observedActivityAt: OBSERVED, inferredBusyAt: NOW },
     ]);
     assert.equal(registry.get(update.sessionId).lastActivityAt, OBSERVED);
+  });
+});
+
+describe("mergeObservedActivityAt (#113 review F1)", () => {
+  it("takes the newest candidate and ignores gaps", () => {
+    assert.equal(mergeObservedActivityAt(OBSERVED, undefined, OBSERVED + 5), OBSERVED + 5);
+    assert.equal(mergeObservedActivityAt(undefined, OBSERVED), OBSERVED);
+  });
+
+  it("is undefined when nothing was observed", () => {
+    assert.equal(mergeObservedActivityAt(undefined, undefined), undefined);
+    assert.equal(mergeObservedActivityAt(), undefined);
+  });
+});
+
+describe("enrichment cache round trip (#113 review F1)", () => {
+  // The leak this pins: sessionEnrichmentCache stores the *merged*
+  // lastActivityAt (tiering needs it), so a heavy scan that merged the cached
+  // merged value into its observed time promoted a CPU stamp to an observation
+  // one scan later, and the registry then made it permanent. This mirrors the
+  // Codex path's composition; the source guard below pins that scanAgents
+  // actually feeds it the observed field.
+  const scan = (cache, matchedActivityAt, busy, nowSec) => {
+    let lastActivityAt = mergeObservedActivityAt(cache?.observedActivityAt, matchedActivityAt);
+    let inferredBusyAt = (busy ? nowSec : undefined) ?? cache?.inferredBusyAt;
+    if (!isInferredBusyFresh(inferredBusyAt, nowSec)) inferredBusyAt = undefined;
+    const observedActivityAt = lastActivityAt;
+    lastActivityAt = resolveEffectiveActivityAt(observedActivityAt, inferredBusyAt, nowSec);
+    return { lastActivityAt, observedActivityAt, inferredBusyAt };
+  };
+
+  const T0 = NOW;
+  const busyScan = scan(undefined, OBSERVED, true, T0);
+
+  it("reports the burst but records the rollout mtime as observed", () => {
+    assert.equal(busyScan.lastActivityAt, T0);
+    assert.equal(busyScan.observedActivityAt, OBSERVED);
+  });
+
+  it("does not promote the stamp to an observation on the next scan", () => {
+    const quiet = scan(busyScan, OBSERVED, false, T0 + 30);
+    assert.equal(quiet.observedActivityAt, OBSERVED, "an inference must not become an observation");
+    assert.equal(quiet.lastActivityAt, T0, "the burst is still reported inside the TTL");
+  });
+
+  it("returns to the rollout mtime once the carried stamp expires", () => {
+    const later = scan(busyScan, OBSERVED, false, T0 + CODEX_INFERRED_BUSY_TTL_SEC + 1);
+    assert.equal(later.observedActivityAt, OBSERVED);
+    assert.equal(later.lastActivityAt, OBSERVED);
+  });
+
+  it("keeps observed <= reported at every step", () => {
+    for (const s of [busyScan, scan(busyScan, OBSERVED, false, T0 + 30)]) {
+      assert.ok(s.observedActivityAt <= s.lastActivityAt);
+    }
+  });
+});
+
+describe("scanAgents reads the observed field from the cache (#113 review F1)", () => {
+  // A composition test cannot see which field scanAgents passes in, and that
+  // choice is exactly what broke. The merged value is legitimate for tiering
+  // (a busy process should stay hot) and wrong everywhere else, so pin it to
+  // that one call site.
+  it("uses cachedEnrichment.lastActivityAt only for tier classification", () => {
+    const src = readFileSync(new URL("../src/scanner/index.ts", import.meta.url), "utf8");
+    const lines = src.split("\n");
+    const hits = lines.flatMap((line, i) =>
+      line.includes("cachedEnrichment.lastActivityAt") ||
+      line.includes("cachedEnrichment?.lastActivityAt")
+        ? [i]
+        : [],
+    );
+    assert.equal(hits.length, 1, `expected one read, found ${hits.length}`);
+    // Every other path must read observedActivityAt; an undefined value there
+    // means "nothing observed", never "fall back to the merged time".
+    const context = lines.slice(Math.max(0, hits[0] - 4), hits[0] + 1).join("\n");
+    assert.match(context, /classifySessionTier/);
+  });
+});
+
+describe("worker propagation raises both times (#113 review F3)", () => {
+  const parent = {
+    pid: 1,
+    agentName: "Claude Code",
+    status: "Idle",
+    cpuPercent: 0,
+    memoryMb: 100,
+    lastActivityAt: OBSERVED,
+    observedActivityAt: OBSERVED,
+  };
+
+  it("carries the child's observed activity onto the parent", () => {
+    const merged = propagateWorkerStateToParent(parent, {
+      status: "Active",
+      phase: "tool",
+      lastActivityAt: OBSERVED + 600,
+      observedActivityAt: OBSERVED + 600,
+      cpuPercent: 40,
+      memoryMb: 50,
+    });
+    assert.equal(merged.observedActivityAt, OBSERVED + 600);
+    assert.equal(merged.lastActivityAt, OBSERVED + 600);
+  });
+
+  it("does not let a child's inference reach the parent's observed time", () => {
+    // The child reports a burst it has no file evidence for.
+    const merged = propagateWorkerStateToParent(parent, {
+      status: "Active",
+      phase: "tool",
+      lastActivityAt: NOW,
+      observedActivityAt: OBSERVED,
+      cpuPercent: 40,
+      memoryMb: 50,
+    });
+    assert.equal(merged.observedActivityAt, OBSERVED);
+    assert.equal(merged.lastActivityAt, NOW);
+  });
+});
+
+describe("persisting when there is no observation at all (#113 review F2)", () => {
+  const base = {
+    pid: 87824,
+    agentName: "Codex",
+    cwd: "/Users/x/.ai/projects/tossbank",
+    sessionId: "019ffff2-5589-7ad2-b294-3a2024659287",
+    startedAt: OBSERVED - 12000,
+  };
+
+  it("writes nothing when the only time available is an inference", () => {
+    // A matched Codex session whose rollout mtime has not been read yet:
+    // observedActivityAt is reported, but undefined. `?? lastActivityAt` could
+    // not tell that apart from a caller that does not track it, and wrote the
+    // inference to disk — where the monotonic merge made it permanent.
+    const registry = new Map();
+    updateRegistry(registry, [
+      { ...base, lastActivityAt: NOW, observedActivityAt: undefined, inferredBusyAt: NOW },
+    ]);
+    assert.equal(registry.get(base.sessionId)?.lastActivityAt, undefined);
+  });
+
+  it("does not ratchet an inference in when the record already exists", () => {
+    const registry = new Map();
+    updateRegistry(registry, [{ ...base, lastActivityAt: OBSERVED, observedActivityAt: OBSERVED }]);
+    updateRegistry(registry, [
+      { ...base, lastActivityAt: NOW, observedActivityAt: undefined, inferredBusyAt: NOW },
+    ]);
+    assert.equal(registry.get(base.sessionId).lastActivityAt, OBSERVED);
+  });
+});
+
+describe("clampRegistryActivityToObserved tolerance (#113 review F4)", () => {
+  const dir = join(tmpdir(), "marmonitor-clamp-test");
+  const jsonlPath = join(dir, "rollout.jsonl");
+  const mtimeMs = OBSERVED * 1000 + 466; // fractional, as real mtimes are
+
+  const record = (lastActivityAt) => ({
+    sessionId: "s",
+    agent: "Codex",
+    cwd: "/x",
+    history: [{ pid: 1, jsonlPath, startedAt: OBSERVED }],
+    totalTokens: { input: 0, output: 0, cache: 0 },
+    lastActivityAt,
+  });
+
+  before(async () => {
+    await mkdir(dir, { recursive: true });
+    await writeFile(jsonlPath, "{}\n");
+    await utimes(jsonlPath, new Date(mtimeMs), new Date(mtimeMs));
+  });
+
+  after(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("leaves a fractional mtime-derived stamp alone", async () => {
+    // Stored as mtimeMs / 1000. A floor comparison clamped this by <1s on every
+    // single load, and inflated the repaired count with pure noise.
+    const stored = mtimeMs / 1000;
+    const registry = new Map([["s", record(stored)]]);
+    assert.equal(await clampRegistryActivityToObserved(registry), 0);
+    assert.equal(registry.get("s").lastActivityAt, stored);
+  });
+
+  it("allows a Codex time that legitimately leads the rollout file", async () => {
+    // mergeCodexIndexedSessions maxes the SQLite updated_at with the rollout
+    // mtime, so a small lead is observed, not inferred.
+    const registry = new Map([["s", record(OBSERVED + 60)]]);
+    assert.equal(await clampRegistryActivityToObserved(registry), 0);
+  });
+
+  it("still repairs the drift it exists for", async () => {
+    const registry = new Map([["s", record(OBSERVED + 10 * 24 * 3600)]]);
+    assert.equal(await clampRegistryActivityToObserved(registry), 1);
+    assert.ok(registry.get("s").lastActivityAt <= OBSERVED + 1);
   });
 });

--- a/tests/scanner-status.test.mjs
+++ b/tests/scanner-status.test.mjs
@@ -4,20 +4,25 @@ import { getDefaults } from "../dist/config/index.js";
 import {
   applyStatusHysteresis,
   determineStatus,
-  refreshLastActivityAt,
+  resolveCodexInferredBusyAt,
+  resolveEffectiveActivityAt,
 } from "../dist/scanner/status.js";
 
 describe("scanner status heuristics", () => {
-  it("refreshes Codex lastActivityAt when live signals exist", () => {
+  it("stamps a Codex busy inference when live signals exist", () => {
     const now = 1775223000;
-    assert.equal(refreshLastActivityAt(1775194317, 2.5, "tool", 0.5, "Codex", now), now);
-    assert.equal(refreshLastActivityAt(1775194317, 0.0, "thinking", 0.5, "Codex", now), now);
+    assert.equal(resolveCodexInferredBusyAt(2.5, "tool", 0.5, "Codex", now), now);
+    assert.equal(resolveCodexInferredBusyAt(0.0, "thinking", 0.5, "Codex", now), now);
   });
 
-  it("does not refresh lastActivityAt for non-Codex sessions", () => {
+  it("stamps nothing when a Codex process looks quiet", () => {
+    assert.equal(resolveCodexInferredBusyAt(0.0, "done", 0.5, "Codex", 1775223000), undefined);
+  });
+
+  it("does not infer busy for non-Codex sessions", () => {
     assert.equal(
-      refreshLastActivityAt(1775194317, 2.5, "tool", 0.5, "Claude Code", 1775223000),
-      1775194317,
+      resolveCodexInferredBusyAt(2.5, "tool", 0.5, "Claude Code", 1775223000),
+      undefined,
     );
   });
 


### PR DESCRIPTION
## Summary

같은 cwd 에서 Claude 만 응답 중인데 열흘 전 죽은 Codex 세션도 "최근" 으로 뜬다는 사용자 보고. Codex 쪽 원본은 전부 08-14 인데 marmonitor 는 08-24 를 보고했다.

```
rollout jsonl mtime         08-14 23:21:30
sqlite threads.updated_at   08-14 23:21:30
sqlite threads.recency_at   08-14 23:19:55
output tokens               0
marmonitor 보고값           08-24 13:15:23   ← 열흘 뒤
```

이 값은 Codex 에서 읽은 게 아니라 marmonitor 가 만들어낸 것이다.

## Root cause

`#090` 이 tool 종료 직후 스냅백을 막으려고 CPU/phase 기반 추론을 넣었는데, 그 추론이 관찰값과 **같은 필드에 머지**됐다. 추론은 `now` 를 찍으므로 한 번 찍히면 monotonic `Math.max` 를 타고 `session-registry.json` 에 영속돼 데몬 재시작으로도 복구되지 않는다.

`#090` 처리 이력에 이미 경고가 있었다.

> 실제 activity source 를 과도하게 낙관적으로 갱신하지 않도록 live signal 범위를 **제한**해야 한다

그 제한이 구현되지 않은 것이 이 이슈의 실체다. 래칫 자체는 필요하다 — 없애면 `#090` 이 고친 스냅백이 재발한다. 문제는 **무한 수명**이다.

`lastActivityAt` 은 `statusBaseAt` 으로도 쓰이므로 표시 시간뿐 아니라 상태 판정까지 오염된다.

| | lastActivityAt | status |
|---|---|---|
| 레지스트리 없이 스캔 | 08-14 23:21:30 ✓ | **Stalled** ✓ |
| 데몬 스냅샷 | 08-24 13:15:23 ✗ | **Idle** ✗ |

## Type

- [x] `[BUG]` Bug fix

## Changes

관찰(observation)과 추론(inference)을 분리하고, 추론에만 수명을 준다.

- `src/types.ts` — `AgentSession` 에 `observedActivityAt`(관찰 전용) / `inferredBusyAt`(추론 스탬프) 추가. `lastActivityAt` 은 둘을 합친 보고용 값으로 유지
- `src/scanner/status.ts` — `refreshLastActivityAt` 을 `resolveCodexInferredBusyAt`(추론 판정) / `resolveEffectiveActivityAt`(보고값) / `isInferredBusyFresh`(TTL) 로 분리. 관찰값 병합은 `mergeObservedActivityAt` 하나로 모으고, 인자는 관찰 전용이어야 한다는 계약을 주석에 명시
- `src/scanner/cache.ts` — `CODEX_INFERRED_BUSY_TTL_SEC` (= `RECENT_ACTIVITY_ACTIVE_SEC`, 180초)
- `src/scanner/index.ts` — heavy/light/cold 세 경로가 같은 의미를 갖도록 배선. 추론 스탬프를 enrichment 캐시로 스캔 간 전달(그래야 TTL 이 "마지막으로 바빠 보인 시점 이후" 를 의미한다). tiering 만 의도적으로 merged 값 유지
- `src/scanner/session-registry.ts` — 관찰값만 영속. 폴백은 값이 아니라 **필드 존재**로 판정(`resolveObservedForPersist`). `clampRegistryActivityToObserved` 로 기존 오염 레코드 치유
- `src/scanner/daemon-loop.ts` — heavy scan 의 두 번째 레지스트리 쓰기 경로에도 `observedActivityAt` 전달
- `src/scanner/group.ts` — worker 전파 시 두 필드를 함께 상승
- `CLAUDE.md` — 스냅샷 경로 오기(`/tmp/marmonitor` → `$TMPDIR/marmonitor`) + 데몬 생존 확인 방법

### 리뷰 반영

코덱스 리뷰에서 4건이 나왔고 전부 반영했다. 그중 F1(캐시의 merged 값을 관찰값으로 읽어 한 heavy scan 뒤 세탁이 재현)은 이슈가 안 닫히는 수준이었다.

배선 계층이 순수 함수 테스트로 안 덮인다는 게 이 PR 의 교훈이라, `src/scanner/index.ts` 를 직접 읽어 `cachedEnrichment.lastActivityAt` 읽기가 `classifySessionTier` 하나뿐임을 단언하는 **소스 불변식 가드**를 넣었다. 작성 즉시 리뷰가 못 본 누수 2곳(cold 승격 비교, light 복원)을 더 잡았다.

## Checklist

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (395/395)
- [x] New features have tests
- [ ] README updated (사용자 노출 변경 없음)
- [x] No hardcoded paths or environment-specific values

## Testing

```
npm test              395/395
npm run lint          clean
npx tsc --noEmit      clean
코드 커밋 10개 각각 독립 tsc + lint 통과 (별도 worktree 체크아웃 검증, 문서 커밋 1개 제외)
```

실측 재검증 — 보고된 세션이 정정되고, 버스트 중인 세션은 관찰값을 유지한 채 추론만 얹는다.

```
Codex 87824  Stalled  observed 08-14T14:21:30  inferred -               effective 08-14T14:21:30  9.7d
Codex 72208  Active   observed 08-14T11:06:58  inferred 08-24T07:05:24  effective 08-24T07:05:24  0.0d
```

`72208` 이 설계 의도다 — 영속화되는 값은 `observed` 이므로 TTL 이 지나면 08-14 로 정직하게 복귀한다. `observed <= effective` 불변식 위반 0건.

## Risk

**Medium.** activity/status 판정 경로 전반을 건드린다.

- `#090` 회귀 위험이 가장 크다. TTL 안에서는 추론값을 유지하도록 캐리오버를 넣어 막았고 회귀 테스트로 고정했다
- `clampRegistryActivityToObserved` 가 기존 `session-registry.json` 을 수정한다. 실측 데이터에서 `pruneRegistry(30)` 추가 삭제는 0건이었다
- Claude/Gemini 는 추론 자체가 없어 동작 변화가 없다
