### PR TITLE
[FIX] bind Codex processes by their declared session id instead of guessing (local #114)

### DIFF
--- a/src/scanner/codex.ts
+++ b/src/scanner/codex.ts
@@ -360,6 +360,71 @@ export async function indexCodexSessions(
   return sessions;
 }
 
+/** `codex resume <uuid>` — the thread the process explicitly reopened. */
+const CODEX_RESUME_ID_RE =
+  /\bresume\s+([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\b/i;
+
+/** `--session-id <id>` — used by the ChatGPT desktop app's helper. */
+const CODEX_SESSION_ID_FLAG_RE = /--session[-_]id[=\s]+([0-9a-f][0-9a-f-]{7,})/i;
+
+/**
+ * Session id a Codex process names in its own command line.
+ *
+ * This is an identity, not a guess, and it outranks every heuristic. Matching
+ * by cwd and nearest start time gets this wrong in the ordinary case of a
+ * resumed thread: the process starts today while its session file is dated
+ * whenever the thread began, so a newer unrelated session in the same cwd wins
+ * the proximity sort and two processes end up on one session (#114).
+ */
+export function parseCodexSessionIdFromCmd(cmd: string | undefined): string | undefined {
+  if (!cmd) return undefined;
+  const match = CODEX_RESUME_ID_RE.exec(cmd) ?? CODEX_SESSION_ID_FLAG_RE.exec(cmd);
+  return match?.[1]?.toLowerCase();
+}
+
+export interface CodexSessionPick {
+  declaredSessionId: string | undefined;
+  sessions: CodexSessionMeta[];
+  claimedSessionIds: ReadonlySet<string>;
+  argvReservedSessionIds: ReadonlySet<string>;
+  cwd: string;
+  processStartedAt: number | undefined;
+  resolveBinding?: (available: CodexSessionMeta[]) => CodexSessionMeta | undefined;
+}
+
+/**
+ * Which session a Codex process owns, in order of how much the answer is
+ * actually known (#114).
+ *
+ * Binding to the wrong session is worse than not binding at all: a misbound
+ * process reports another session's tokens and jumps to its pane. So each step
+ * refuses instead of falling through to a weaker guess once the strong answer
+ * is unavailable.
+ *
+ *   declared   the id in the process's own command line — an identity
+ *   binding    what this exact PID resolved to before, from the registry
+ *   heuristic  cwd + nearest start time, the only option left
+ *
+ * Sessions already claimed this cycle, and sessions another process declared,
+ * are removed from the pool before the two weaker steps run — otherwise a guess
+ * can steal a session that someone else names outright.
+ */
+export function selectCodexSessionForProcess(pick: CodexSessionPick): CodexSessionMeta | undefined {
+  const { declaredSessionId, sessions, claimedSessionIds } = pick;
+  if (declaredSessionId) {
+    if (claimedSessionIds.has(declaredSessionId)) return undefined;
+    return sessions.find((session) => session.id === declaredSessionId);
+  }
+
+  const available = sessions.filter(
+    (session) => !claimedSessionIds.has(session.id) && !pick.argvReservedSessionIds.has(session.id),
+  );
+  return (
+    pick.resolveBinding?.(available) ??
+    matchCodexSession(pick.cwd, pick.processStartedAt, available)
+  );
+}
+
 /** Match a Codex process to a session by cwd + closest timestamp */
 export function matchCodexSession(
   processCwd: string,

--- a/src/scanner/index.ts
+++ b/src/scanner/index.ts
@@ -37,7 +37,13 @@ import {
   selectCodexBindingSession,
   upsertCodexBindingRecord,
 } from "./codex-binding-registry.js";
-import { detectCodexPhase, indexCodexSessions, matchCodexSession } from "./codex.js";
+import type { CodexSessionMeta } from "./codex.js";
+import {
+  detectCodexPhase,
+  indexCodexSessions,
+  parseCodexSessionIdFromCmd,
+  selectCodexSessionForProcess,
+} from "./codex.js";
 import { promiseAllLimited } from "./concurrency.js";
 import { parseGeminiSession } from "./gemini.js";
 import { groupByParent } from "./group.js";
@@ -167,6 +173,25 @@ export async function scanAgents(
     ? await indexCodexSessions(config, { activeCwds: activeCodexCwds })
     : [];
   perfEnd("codex-index");
+
+  // #114: resolve every Codex process's self-declared session before the
+  // enrichment loop, so an explicit binding always outranks another process's
+  // heuristic guess regardless of the order the loop happens to run in. This
+  // mirrors what matchClaudeSessionsByMtime does for Claude.
+  const codexArgvSessionIdByPid = new Map<number, string>();
+  for (const { proc, agentName } of agentProcesses) {
+    if (agentName !== "Codex") continue;
+    const declaredId = parseCodexSessionIdFromCmd(proc.cmd);
+    if (declaredId) codexArgvSessionIdByPid.set(proc.pid, declaredId);
+  }
+  const codexArgvReservedSessionIds = new Set(codexArgvSessionIdByPid.values());
+  const cycleClaimedCodexSessionIds = new Set<string>();
+  let codexMatchChain: Promise<unknown> = Promise.resolve();
+  const withCodexMatchLock = <T>(fn: () => Promise<T>): Promise<T> => {
+    const next = codexMatchChain.then(fn, fn);
+    codexMatchChain = next.catch(() => undefined);
+    return next;
+  };
 
   const claudeSessionRoots = getClaudeSessionRoots(config);
   const claudeLegacySessionIds = new Set<string>();
@@ -385,16 +410,32 @@ export async function scanAgents(
         "unknown";
       processStartedAt = await getProcessStartTime(proc.pid);
 
-      const matched =
-        (codexBindingRegistry
-          ? selectCodexBindingSession(
-              codexBindingRegistry,
-              proc.pid,
-              processStartedAt,
-              cwd,
-              codexSessions,
-            )
-          : undefined) ?? matchCodexSession(cwd, processStartedAt, codexSessions);
+      // #114: serialize so each PID sees what earlier ones claimed. Binding to
+      // the wrong session is worse than not binding — a misbound process shows
+      // another session's tokens and jumps to its pane — so every step refuses
+      // rather than falling through to a guess once a claim exists.
+      const matched = await withCodexMatchLock(async () => {
+        const picked = selectCodexSessionForProcess({
+          declaredSessionId: codexArgvSessionIdByPid.get(proc.pid),
+          sessions: codexSessions,
+          claimedSessionIds: cycleClaimedCodexSessionIds,
+          argvReservedSessionIds: codexArgvReservedSessionIds,
+          cwd,
+          processStartedAt,
+          resolveBinding: codexBindingRegistry
+            ? (available) =>
+                selectCodexBindingSession(
+                  codexBindingRegistry,
+                  proc.pid,
+                  processStartedAt,
+                  cwd,
+                  available,
+                )
+            : undefined,
+        });
+        if (picked) cycleClaimedCodexSessionIds.add(picked.id);
+        return picked;
+      });
       if (matched) {
         sessionMatched = true;
         sessionId = matched.id;

--- a/src/scanner/process.ts
+++ b/src/scanner/process.ts
@@ -123,6 +123,13 @@ const CODEX_VSCODE_APP_SERVER_RE = /[/\\]codex\s+app-server(?:\s|$)/i;
 /** Codex `app-server` mode is an IDE/Desktop embedded RPC backend, not an interactive CLI session. */
 const CODEX_APP_SERVER_RE = /\bcodex\b[\s\S]*\bapp-server\b/i;
 
+/**
+ * `codex sandbox` runs one command inside the sandbox — the shape the ChatGPT
+ * desktop app spawns. It owns no rollout of its own, so leaving it in the pool
+ * only gave the cwd heuristic another process to misbind (#114).
+ */
+const CODEX_SANDBOX_RE = /[/\\]codex\s+sandbox(?:\s|$)/i;
+
 /** Match a process against agent signatures using process name first, then cmd fallback. */
 export function detectAgentFromProcessSignature(
   proc: { name: string; cmd?: string },
@@ -134,6 +141,7 @@ export function detectAgentFromProcessSignature(
   // Skip `codex app-server` backends spawned by Codex Desktop or the VS Code
   // Codex extension — these are RPC backends, not interactive CLI sessions.
   if (proc.cmd && CODEX_APP_SERVER_RE.test(proc.cmd)) return null;
+  if (proc.cmd && CODEX_SANDBOX_RE.test(proc.cmd)) return null;
 
   const name = proc.name.toLowerCase();
   const command = (proc.cmd ?? "").toLowerCase();

--- a/tests/codex-session-misbinding.test.mjs
+++ b/tests/codex-session-misbinding.test.mjs
@@ -1,0 +1,147 @@
+/**
+ * Regression tests for local issue #114 — two Codex processes on one session.
+ *
+ * Measured on the live machine before the fix: the tmux statusline showed
+ * `vos-aws-infrastructure` twice and both pills jumped to the same session.
+ * Three distinct things were involved, and marmonitor picked none of them:
+ *
+ *   PID 72208  ChatGPT.app codex sandbox, --session-id 77be15a2…
+ *   PID 94171  codex resume 019fee78-4612-77f2-b745-f71f87c5f49d
+ *   bound to   019ffff3-bd10-…  (a stale 08-14 rollout, neither process's)
+ *
+ * 94171's real session was not merely different, it was active that day. The
+ * proximity sort lost because a resumed thread's file is dated when the thread
+ * began (08-11) while the process started when it was resumed (08-20), so an
+ * unrelated newer session in the same cwd won.
+ */
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { getDefaults } from "../dist/config/index.js";
+import { parseCodexSessionIdFromCmd, selectCodexSessionForProcess } from "../dist/scanner/codex.js";
+import { detectAgentFromProcessSignature } from "../dist/scanner/process.js";
+
+const RESUMED = "019fee78-4612-77f2-b745-f71f87c5f49d";
+const STALE = "019ffff3-bd10-7873-bb6e-4f1886292434";
+const CWD = "/Users/macrent/Documents/valueofspace/vos-aws-infrastructure";
+const RESUME_CMD = `node /opt/homebrew/bin/codex resume ${RESUMED}`;
+const SANDBOX_CMD =
+  '/Applications/ChatGPT.app/Contents/Resources/codex sandbox -c shell_environment_policy.inherit="all" -- /Applications/ChatGPT.app/Contents/Resources/cua_node/bin/node --session-id 77be15a298294e26b50673b51ad85286';
+
+const session = (id, timestamp) => ({ id, cwd: CWD, timestamp, filePath: `/r/${id}.jsonl` });
+const RESUMED_SESSION = session(RESUMED, 1786000000); // 08-11, when the thread began
+const STALE_SESSION = session(STALE, 1786700000); // 08-14, nearer the process start
+
+const pick = (overrides) =>
+  selectCodexSessionForProcess({
+    declaredSessionId: undefined,
+    sessions: [RESUMED_SESSION, STALE_SESSION],
+    claimedSessionIds: new Set(),
+    argvReservedSessionIds: new Set(),
+    cwd: CWD,
+    processStartedAt: 1787200000, // 08-20, the resume
+    ...overrides,
+  });
+
+describe("parseCodexSessionIdFromCmd (#114)", () => {
+  it("reads the thread a process resumed", () => {
+    assert.equal(parseCodexSessionIdFromCmd(RESUME_CMD), RESUMED);
+  });
+
+  it("reads a --session-id flag", () => {
+    assert.equal(parseCodexSessionIdFromCmd(SANDBOX_CMD), "77be15a298294e26b50673b51ad85286");
+  });
+
+  it("normalises case", () => {
+    assert.equal(parseCodexSessionIdFromCmd(RESUME_CMD.toUpperCase()), RESUMED);
+  });
+
+  it("finds nothing in a plain invocation", () => {
+    assert.equal(parseCodexSessionIdFromCmd("node /opt/homebrew/bin/codex"), undefined);
+    assert.equal(parseCodexSessionIdFromCmd(undefined), undefined);
+  });
+
+  it("does not mistake a bare word for an id", () => {
+    assert.equal(parseCodexSessionIdFromCmd("codex resume latest"), undefined);
+  });
+});
+
+describe("selectCodexSessionForProcess (#114)", () => {
+  it("reproduces the misbinding when nothing is declared", () => {
+    // The pre-fix behaviour, kept explicit: proximity picks the stale session.
+    assert.equal(pick({}).id, STALE);
+  });
+
+  it("prefers the declared thread over the nearer one", () => {
+    assert.equal(pick({ declaredSessionId: RESUMED }).id, RESUMED);
+  });
+
+  it("refuses when the declared thread is already taken", () => {
+    // A second process resuming the same thread must not get a consolation
+    // guess — that is precisely how two pills ended up on one session.
+    assert.equal(
+      pick({ declaredSessionId: RESUMED, claimedSessionIds: new Set([RESUMED]) }),
+      undefined,
+    );
+  });
+
+  it("refuses when the declared thread is not indexed", () => {
+    assert.equal(pick({ declaredSessionId: "019fffff-0000-7000-8000-000000000000" }), undefined);
+  });
+
+  it("does not hand a guesser a session another process declared", () => {
+    assert.equal(pick({ argvReservedSessionIds: new Set([STALE]) }).id, RESUMED);
+    assert.equal(
+      pick({ argvReservedSessionIds: new Set([STALE, RESUMED]) }),
+      undefined,
+      "with every session spoken for, refuse rather than misbind",
+    );
+  });
+
+  it("skips a session already claimed this cycle", () => {
+    assert.equal(pick({ claimedSessionIds: new Set([STALE]) }).id, RESUMED);
+  });
+
+  it("lets the persisted binding win over proximity", () => {
+    assert.equal(pick({ resolveBinding: () => RESUMED_SESSION }).id, RESUMED);
+  });
+
+  it("only offers the binding sessions that are still free", () => {
+    const offered = [];
+    pick({
+      claimedSessionIds: new Set([STALE]),
+      resolveBinding: (available) => {
+        offered.push(...available.map((s) => s.id));
+        return undefined;
+      },
+    });
+    assert.deepEqual(offered, [RESUMED]);
+  });
+});
+
+describe("ChatGPT app sandbox helpers are not sessions (#114)", () => {
+  const config = getDefaults();
+
+  it("excludes codex sandbox", () => {
+    assert.equal(
+      detectAgentFromProcessSignature({ name: "codex", cmd: SANDBOX_CMD }, config),
+      null,
+    );
+  });
+
+  it("still detects a real codex CLI", () => {
+    assert.equal(
+      detectAgentFromProcessSignature({ name: "codex", cmd: RESUME_CMD }, config),
+      "Codex",
+    );
+  });
+
+  it("does not exclude a process merely mentioning sandbox settings", () => {
+    assert.equal(
+      detectAgentFromProcessSignature(
+        { name: "codex", cmd: "node /opt/homebrew/bin/codex -c sandbox_mode=danger-full-access" },
+        config,
+      ),
+      "Codex",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

tmux statusline 에 `vos-aws-infrastructure` 가 두 개 뜨고 어느 쪽을 눌러도 같은 세션으로 점프한다는 사용자 보고. UI 중복이 아니라 실제로 **두 PID 가 같은 sessionId 에 바인딩**돼 있었고, 그 sessionId 는 **둘 중 어느 쪽의 것도 아니었다.**

```
PID 72208   ChatGPT.app codex sandbox   --session-id 77be15a2…              시작 08-24 10:49
PID 94171   homebrew codex              codex resume 019fee78-4612-77f2-…   시작 08-20 15:30
바인딩된 것 019ffff3-bd10-…             (08-14 rollout, 아무의 것도 아님)
```

두 프로세스 모두 **argv 에 자기 세션 ID 를 들고 있는데** 매칭이 그걸 안 읽었다.

## Root cause

Codex 매칭은 사실상 함수 하나였다 — cwd 가 같고 시작시각이 제일 가까운 것. **claim 추적도 형제 배제도 우세도 임계값도 없다.**

`#108` 이 Claude 에 넣은 collision 방지 장치(`cycleClaimedClaudeSessionIds`, `withClaudeMatchLock`, `reservedClaudeSessionIds`, `matchClaudeSessionsByMtime`)는 전부 Claude 전용 이름으로 박혀 있어 Codex 에 전파되지 않았다. `scanAgents` 가 agentName 으로 갈라지는 if/else 구조라 같은 계열 버그를 두 번 고쳐야 한다(별도 이슈 `#117` 로 기록).

**근접 정렬은 resume 된 스레드에서 구조적으로 진다.** 세션 파일은 스레드가 처음 열린 날짜(08-11)인데 프로세스 시작은 resume 시점(08-20)이라, 같은 cwd 의 무관한 08-14 가 이긴다. 실측에서 정답 rollout 은 **그날도 살아 있었는데**(mtime 08-24 17:02) 죽은 세션에 묶여 `Stalled` 로 표시됐다.

`codex-binding-registry.json` 은 이 오답을 4건 영속화해 두고 있었다.

## Type

- [x] `[BUG]` Bug fix

## Changes

- `src/scanner/codex.ts`
  - `parseCodexSessionIdFromCmd` — `codex resume <uuid>` / `--session-id <id>` 파싱
  - `selectCodexSessionForProcess` — `declared` > `binding` > `heuristic` 우선순위. **각 단계는 실패해도 다음으로 흘러내리지 않고 거절한다.** 틀린 세션에 묶이는 건 안 묶이는 것보다 나쁘다 — 남의 토큰을 표시하고 남의 pane 으로 점프한다. 이번 cycle 에 claim 된 세션과 다른 프로세스가 argv 로 선언한 세션은 약한 두 단계 전에 후보에서 제외
- `src/scanner/index.ts` — argv 선처리(루프 실행 순서와 무관하게 명시적 바인딩이 우선), cycle claim Set, 직렬화 뮤텍스. `#108` 의 Claude 구조를 Codex 에 대응시킨 것
- `src/scanner/process.ts` — `codex sandbox` 서브커맨드 제외. rollout 을 소유하지 않아 어떤 세션도 정당하게 가질 수 없는데 후보 풀에 남아 남의 세션을 가져갔다. `#100`(app-server 제외)과 같은 판단. `-c sandbox_mode=…` 설정 플래그는 안 걸리도록 서브커맨드 위치로만 매칭
- `tests/codex-session-misbinding.test.mjs` — 16 케이스

`#113` 의 교훈대로 선택 정책을 순수 함수로 분리해 배선과 무관하게 테스트 가능하게 뒀다.

## Checklist

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (411/411)
- [x] New features have tests
- [ ] README updated
- [x] No hardcoded paths or environment-specific values

## Testing

```
npm test              411/411
npm run lint          clean
npx tsc --noEmit      clean
커밋 4개 각각 독립 tsc + lint 통과 (별도 worktree 체크아웃 검증)
```

실측 — **sessionId 를 공유하는 PID 그룹 0건.**

```
94171  Codex  Active  019fee78-4612-77f2-b745-f71f87c5f49d  08-24T08:04:24  vos-aws-infrastructure
       (이전:  Stalled  019ffff3-bd10-…  08-14)
```

statusline 중복이 사라지고, 덤으로 활성 세션이 죽은 것으로 표시되던 문제도 함께 해결된다.

## Risk

**Medium — 사용자 노출 동작 변경 1건 포함.**

- **ChatGPT 데스크톱 앱의 `codex sandbox` 프로세스가 이제 표시되지 않는다.** 이전에는 (틀린 데이터로) 표시됐다. rollout 을 소유하지 않아 정확한 정보를 낼 수 없고, `Unmatched` 로 남기면 `#111`(clean --kill 이 Unmatched 를 SIGTERM) 위험이 있어 `#100` 과 같이 완전 제외를 택했다. 앱 작업 가시성 요구가 나오면 별도 이슈
- argv 를 못 읽는 Codex 기동 방식이 있으면 기존 휴리스틱으로 폴백하므로 회귀는 없다. 다만 그 경로는 여전히 추측이다
- 기존 `codex-binding-registry.json` 의 오답은 argv 가 있는 프로세스에서 자연히 덮어써진다
